### PR TITLE
Add pre-commit hook for running addlicense

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,7 @@ repos:
     rev: 22.8.0
     hooks:
       - id: black
+  - repo: .
+    rev: HEAD
+    hooks:
+      - id: addlicense

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     rev: 6.0.0
     hooks:
       - id: buildifier
-        args: &args 
+        args: &args
           # Keep this argument in sync with .bazelci/presubmit.yaml
           - --warnings=all
       - id: buildifier-lint
@@ -30,14 +30,17 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
-        args: 
+        args:
           - --profile
           - black
   - repo: https://github.com/psf/black
     rev: 22.8.0
     hooks:
       - id: black
-  - repo: .
-    rev: HEAD
+  - repo: local
     hooks:
       - id: addlicense
+        name: Add copyright headers
+        entry: addlicense.sh
+        types: [text]
+        language: script

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,5 +1,0 @@
-- id: addlicense
-  name: Add copyright headers
-  entry: addlicense.sh
-  language: script
-  verbose: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,5 @@
+- id: addlicense
+  name: Add copyright headers
+  entry: addlicense.sh
+  language: script
+  verbose: true


### PR DESCRIPTION
Integrate the addlicense.sh script with the pre-commit config so that it automatically runs when git committing.