### PR TITLE
fix: Update pre-commit dependency versions so isort works.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       - id: buildifier-lint
         args: *args
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)
@@ -34,6 +34,6 @@ repos:
           - --profile
           - black
   - repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 23.1.0
     hooks:
       - id: black


### PR DESCRIPTION
This resolve an issue where an older isort version don't work with a newer poetry version.

I think this problem occurs if you've upgraded isort (which upgrades poetry, I think), but then downgrade isort (which doesn't downgrade poetry, too). (I think this is what I ended up doing)