### PR TITLE
docs: Simplify pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,44 +1,11 @@
-## PR Checklist
-
-Please check if your PR fulfills the following requirements:
-
-- [ ] Tests for the changes have been added (for bug fixes / features)
-- [ ] Docs have been added / updated (for bug fixes / features)
-
-
-## PR Type
-
-What kind of change does this PR introduce?
-
-<!-- Please check the one that applies to this PR using "x". -->
-
-- [ ] Bugfix
-- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
-- [ ] Code style update (formatting, local variables)
-- [ ] Refactoring (no functional changes, no api changes)
-- [ ] Build related changes
-- [ ] CI related changes
-- [ ] Documentation content changes
-- [ ] Other... Please describe:
-
-
-## What is the current behavior?
-<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
-
-Issue Number: N/A
-
-
-## What is the new behavior?
-
-
-## Does this PR introduce a breaking change?
-
-- [ ] Yes
-- [ ] No
-
-
-<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
-
-
-## Other information
-
+PR Instructions/requirements
+* Title uses `type: description` format. See CONTRIBUTING.md for types.
+* Common types are: build, docs, feat, fix, refactor, revert, test
+* Breaking changes include "!" after the type and a "BREAKING CHANGES:"
+  section at the bottom.
+* Body text describes:
+  * Why this change is being made, briefly.
+  * Before and after behavior, as applicable
+  * References issue number, as applicable
+* Update docs and tests, as applicable
+* Delete these instructions prior to sending the PR


### PR DESCRIPTION
The existing template is very verbose with many of the lines not being applicable to any given PR. This also makes the PR description poorly suitable for a commit description.

By having a cleaner PR description that is commit message friendly, whoever merges the PR can more easily create a meaningful commit message. It also allows other maintainer's to clean up the description prior to it being merged.
