### PR TITLE
feat(rules): add main_module attribute to run a module name (python -m)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,8 @@ Unreleased changes template.
   ([#1647](https://github.com/bazelbuild/rules_python/issues/1647))
 * (rules) Added {obj}`interpreter_args` attribute to `py_binary` and `py_test`,
   which allows pass arguments to the interpreter before the regular args.
+* (rules) Added {obj}`main_module` attribute to `py_binary` and `py_test`,
+  which allows specifying a module name to run (i.e. `python -m <module>`).
 
 {#v0-0-0-removed}
 ### Removed

--- a/python/private/py_executable.bzl
+++ b/python/private/py_executable.bzl
@@ -126,6 +126,24 @@ Optional; the name of the source file that is the main entry point of the
 application. This file must also be listed in `srcs`. If left unspecified,
 `name`, with `.py` appended, is used instead. If `name` does not match any
 filename in `srcs`, `main` must be specified.
+
+This is mutually exclusive with {obj}`main_module`.
+""",
+        ),
+        "main_module": lambda: attrb.String(
+            doc = """
+Module name to execute as the main program.
+
+When set, `srcs` is not required, and it is assumed the module is
+provided by a dependency.
+
+See https://docs.python.org/3/using/cmdline.html#cmdoption-m for more
+information about running modules as the main program.
+
+This is mutually exclusive with {obj}`main`.
+
+:::{versionadded} VERSION_NEXT_FEATURE
+:::
 """,
         ),
         "pyc_collection": lambda: attrb.String(
@@ -638,6 +656,10 @@ def _create_stage2_bootstrap(
 
     template = runtime.stage2_bootstrap_template
 
+    if main_py:
+        main_py_path = "{}/{}".format(ctx.workspace_name, main_py.short_path)
+    else:
+        main_py_path = ""
     ctx.actions.expand_template(
         template = template,
         output = output,
@@ -645,7 +667,8 @@ def _create_stage2_bootstrap(
             "%coverage_tool%": _get_coverage_tool_runfiles_path(ctx, runtime),
             "%import_all%": "True" if ctx.fragments.bazel_py.python_import_all_repositories else "False",
             "%imports%": ":".join(imports.to_list()),
-            "%main%": "{}/{}".format(ctx.workspace_name, main_py.short_path),
+            "%main%": main_py_path,
+            "%main_module%": ctx.attr.main_module,
             "%target%": str(ctx.label),
             "%workspace_name%": ctx.workspace_name,
         },
@@ -929,7 +952,10 @@ def py_executable_base_impl(ctx, *, semantics, is_test, inherited_environment = 
     """
     _validate_executable(ctx)
 
-    main_py = determine_main(ctx)
+    if not ctx.attr.main_module:
+        main_py = determine_main(ctx)
+    else:
+        main_py = None
     direct_sources = filter_to_py_srcs(ctx.files.srcs)
     precompile_result = semantics.maybe_precompile(ctx, direct_sources)
 
@@ -1048,6 +1074,12 @@ def _get_build_info(ctx, cc_toolchain):
 def _validate_executable(ctx):
     if ctx.attr.python_version == "PY2":
         fail("It is not allowed to use Python 2")
+
+    if ctx.attr.main and ctx.attr.main_module:
+        fail((
+            "Only one of main and main_module can be set, got: " +
+            "main={}, main_module={}"
+        ).format(ctx.attr.main, ctx.attr.main_module))
 
 def _declare_executable_file(ctx):
     if target_platform_has_any_constraint(ctx, ctx.attr._windows_constraints):

--- a/tests/bootstrap_impls/BUILD.bazel
+++ b/tests/bootstrap_impls/BUILD.bazel
@@ -107,6 +107,15 @@ py_reconfig_test(
     main = "sys_path_order_test.py",
 )
 
+py_reconfig_test(
+    name = "main_module_test",
+    srcs = ["main_module.py"],
+    bootstrap_impl = "script",
+    imports = ["."],
+    main_module = "tests.bootstrap_impls.main_module",
+    target_compatible_with = SUPPORTS_BOOTSTRAP_SCRIPT,
+)
+
 sh_py_run_test(
     name = "inherit_pythonsafepath_env_test",
     bootstrap_impl = "script",

--- a/tests/bootstrap_impls/main_module.py
+++ b/tests/bootstrap_impls/main_module.py
@@ -1,0 +1,17 @@
+import sys
+import unittest
+
+
+class MainModuleTest(unittest.TestCase):
+    def test_run_as_module(self):
+        self.assertIsNotNone(__spec__, "__spec__ was none")
+        # If not run as a module, __spec__ is None
+        self.assertNotEqual(__name__, __spec__.name)
+        self.assertEqual(__spec__.name, "tests.bootstrap_impls.main_module")
+
+
+if __name__ == "__main__":
+    unittest.main()
+else:
+    # Guard against running it as a module in a non-main way.
+    sys.exit(f"__name__ should be __main__, got {__name__}")


### PR DESCRIPTION
This implements the ability to run a module name instead of a file path, aka
`python -m` style of invocation.

This allows a binary/test to specify what the main module is without having to
have a direct dependency on the entry point file.

As a side effect, the `srcs` attribute is no longer required.

Fixes https://github.com/bazelbuild/rules_python/issues/2539
