### PR TITLE
chore(docs): fix forward-ref to 1.0

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ in this repository are simple aliases. On Bazel 7 and above `rules_python` uses
 a separate Starlark implementation,
 see {ref}`Migrating from the Bundled Rules` below.
 
-Once rules_python 1.0 is released, they will follow
+This repository follows
 [semantic versioning](https://semver.org) and the breaking change policy
 outlined in the [support](support) page.
 


### PR DESCRIPTION
It's been released so this was out-of-date.

