### PR TITLE
chore: account for new GH org of standalone interpreter

### DIFF
--- a/python/private/pypi/whl_library.bzl
+++ b/python/private/pypi/whl_library.bzl
@@ -34,8 +34,8 @@ def _get_xcode_location_cflags(rctx):
     """Query the xcode sdk location to update cflags
 
     Figure out if this interpreter target comes from rules_python, and patch the xcode sdk location if so.
-    Pip won't be able to compile c extensions from sdists with the pre built python distributions from indygreg
-    otherwise. See https://github.com/indygreg/python-build-standalone/issues/103
+    Pip won't be able to compile c extensions from sdists with the pre built python distributions from astral-sh
+    otherwise. See https://github.com/astral-sh/python-build-standalone/issues/103
     """
 
     # Only run on MacOS hosts
@@ -63,8 +63,8 @@ def _get_xcode_location_cflags(rctx):
 def _get_toolchain_unix_cflags(rctx, python_interpreter, logger = None):
     """Gather cflags from a standalone toolchain for unix systems.
 
-    Pip won't be able to compile c extensions from sdists with the pre built python distributions from indygreg
-    otherwise. See https://github.com/indygreg/python-build-standalone/issues/103
+    Pip won't be able to compile c extensions from sdists with the pre built python distributions from astral-sh
+    otherwise. See https://github.com/astral-sh/python-build-standalone/issues/103
     """
 
     # Only run on Unix systems

--- a/python/private/python_repository.bzl
+++ b/python/private/python_repository.bzl
@@ -161,7 +161,7 @@ def _python_repository_impl(rctx):
     python_bin = "python.exe" if ("windows" in platform) else "bin/python3"
 
     if "linux" in platform:
-        # Workaround around https://github.com/indygreg/python-build-standalone/issues/231
+        # Workaround around https://github.com/astral-sh/python-build-standalone/issues/231
         for url in urls:
             head_and_release, _, _ = url.rpartition("/")
             _, _, release = head_and_release.rpartition("/")
@@ -177,7 +177,7 @@ def _python_repository_impl(rctx):
                 # building on.
                 #
                 # Link to the first affected release:
-                # https://github.com/indygreg/python-build-standalone/releases/tag/20240224
+                # https://github.com/astral-sh/python-build-standalone/releases/tag/20240224
                 rctx.delete("share/terminfo")
                 break
 

--- a/python/versions.bzl
+++ b/python/versions.bzl
@@ -22,7 +22,7 @@ WINDOWS_NAME = "windows"
 FREETHREADED = "freethreaded"
 INSTALL_ONLY = "install_only"
 
-DEFAULT_RELEASE_BASE_URL = "https://github.com/indygreg/python-build-standalone/releases/download"
+DEFAULT_RELEASE_BASE_URL = "https://github.com/astral-sh/python-build-standalone/releases/download"
 
 # When updating the versions and releases, run the following command to get
 # the hashes:


### PR DESCRIPTION
The repo was donated. It also trivially removes the need for a redirect on the URL that fetches artifacts.