### PR TITLE
chore: ignore releasing.md for version string check

### DIFF
--- a/.github/workflows/create_archive_and_notes.sh
+++ b/.github/workflows/create_archive_and_notes.sh
@@ -17,8 +17,8 @@ set -o errexit -o nounset -o pipefail
 
 # Exclude dot directories, specifically, this file so that we don't
 # find the substring we're looking for in our own file.
-# Exclude CONTRIBUTING.md because it documents how to use these strings.
-if grep --exclude=CONTRIBUTING.md --exclude-dir=.* VERSION_NEXT_ -r; then
+# Exclude CONTRIBUTING.md, RELEASING.md because they document how to use these strings.
+if grep --exclude=CONTRIBUTING.md --exclude=RELEASING.md --exclude-dir=.* VERSION_NEXT_ -r; then
   echo
   echo "Found VERSION_NEXT markers indicating version needs to be specified"
   exit 1


### PR DESCRIPTION
The RELEASING.md docs contain the VERSION_NEXT marker string in their docs, so also
have to be ignored by the release script.