### PR TITLE
chore: update bcr metadata files to specify bazel-contrib

### DIFF
--- a/.bcr/gazelle/metadata.template.json
+++ b/.bcr/gazelle/metadata.template.json
@@ -1,9 +1,9 @@
 {
-    "homepage": "https://github.com/bazelbuild/rules_python",
+    "homepage": "https://github.com/bazel-contrib/rules_python",
     "maintainers": [
         {
             "name": "Richard Levasseur",
-            "email": "rlevasseur@google.com",
+            "email": "richardlev@gmail.com",
             "github": "rickeylev"
         },
         {
@@ -13,7 +13,8 @@
         }
     ],
     "repository": [
-        "github:bazelbuild/rules_python"
+        "github:bazelbuild/rules_python",
+        "github:bazel-contrib/rules_python"
     ],
     "versions": [],
     "yanked_versions": {}

--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,9 +1,9 @@
 {
-  "homepage": "https://github.com/bazelbuild/rules_python",
+  "homepage": "https://github.com/bazel-contrib/rules_python",
   "maintainers": [
     {
       "name": "Richard Levasseur",
-      "email": "rlevasseur@google.com",
+      "email": "richardlev@gmail.com",
       "github": "rickeylev"
     },
     {


### PR DESCRIPTION
BCR presubmits require that the list of repositories match where downloads come from

Along the way, also update the URL homepages to bazel-contrib and change the email
to my personal instead of work email.