### PR TITLE
fix(toolchain): no chmod on windows when downloading hermetic toolchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,9 @@ Unreleased changes template.
 
 {#v0-0-0-fixed}
 ### Fixed
-* Nothing fixed.
+* Do not try to run `chmod` when downloading non-windows hermetic toolchain
+  repositories on Windows. Fixes
+  [#2660](https://github.com/bazel-contrib/rules_python/issues/2660).
 
 {#v0-0-0-added}
 ### Added

--- a/python/private/python_repository.bzl
+++ b/python/private/python_repository.bzl
@@ -127,7 +127,9 @@ def _python_repository_impl(rctx):
     # pycs being generated at runtime:
     # * The pycs are not deterministic (they contain timestamps)
     # * Multiple processes trying to write the same pycs can result in errors.
-    if "windows" not in platform:
+    #
+    # Note, when on Windows the `chmod` may not work
+    if "windows" not in platform and "windows" != repo_utils.get_platforms_os_name(rctx):
         repo_utils.execute_checked(
             rctx,
             op = "python_repository.MakeReadOnly",


### PR DESCRIPTION
Previously the code would not chmod for the Windows hermetic toolchains
because there is usually no need - Windows does not have chmod and if
you are downloading the Windows repo on a UNIX system, you won't run it,
so it will stay as is.

However, that left a single case where somebody may want to download the
Linux toolchain on a Windows and the main cases are:
* `bazel sync`
* build a docker image on Windows using `rules_oci` or similar.

Fixes #2660
