### PR TITLE
fix: Fix Python 3.4.x compatibilty with bootstrap (#2709)

### DIFF
--- a/python/private/python_bootstrap_template.txt
+++ b/python/private/python_bootstrap_template.txt
@@ -95,19 +95,17 @@ def print_verbose(*args, mapping=None, values=None):
             for key, value in sorted((mapping or {}).items()):
                 print(
                     "bootstrap:",
-                    *args,
-                    f"{key}={value!r}",
+                    *(list(args) + ["{}={}".format(key, repr(value))]),
                     file=sys.stderr,
-                    flush=True,
+                    flush=True
                 )
         elif values is not None:
             for i, v in enumerate(values):
                 print(
                     "bootstrap:",
-                    *args,
-                    f"[{i}] {v!r}",
+                    *(list(args) + ["[{}] {}".format(i, repr(v))]),
                     file=sys.stderr,
-                    flush=True,
+                    flush=True
                 )
         else:
             print("bootstrap:", *args, file=sys.stderr, flush=True)


### PR DESCRIPTION
Fixes some f-strings, trailing commas, and out-of-order argument unpacking in the bootstrap template to restore compatibility with Python 3.4.x.