### PR TITLE
fix(docs): CHANGELOG "astral" typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ Unreleased changes template.
   `exec_interpreter` now also forwards the `ToolchainInfo` provider. This is
   for increased compatibility with the `RBE` setups where access to the `exec`
   configuration interpreter is needed.
-* (toolchains) Use the latest astrahl-sh toolchain release [20250317] for Python versions:
+* (toolchains) Use the latest astral-sh toolchain release [20250317] for Python versions:
     * 3.9.21
     * 3.10.16
     * 3.11.11


### PR DESCRIPTION
It appears to have been copied from the 1.1.0 "Added" section, but I'm not sure whether "fixing" old changelogs is acceptable.