### PR TITLE
chore: remove defunct comment about py2 compatibility

### DIFF
--- a/python/private/python_bootstrap_template.txt
+++ b/python/private/python_bootstrap_template.txt
@@ -1,11 +1,5 @@
 %shebang%
 
-# This script must retain compatibility with a wide variety of Python versions
-# since it is run for every py_binary target. Currently we guarantee support
-# going back to Python 2.7, and try to support even Python 2.6 on a best-effort
-# basis. We might abandon 2.6 support once users have the ability to control the
-# above shebang string via the Python toolchain (#8685).
-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function


### PR DESCRIPTION
The comment in the bootstrap about requiring compatibility with older Python versions
is defunct and outdated.

Python 2 support was dropped years ago. While compatibility with older Python versions is
best effort for the system_python bootstrap, Python 2 doesn't need to be supported