### PR TITLE
fix: allow warn logging to be disabled via RULES_PYTHON_REPO_DEBUG_VERBOSITY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Unreleased changes template.
 * (toolchains) Do not try to run `chmod` when downloading non-windows hermetic toolchain
   repositories on Windows. Fixes
   [#2660](https://github.com/bazel-contrib/rules_python/issues/2660).
+* (logging) Allow repo rule logging level to be set to `FAIL` via the `RULES_PYTHON_REPO_DEBUG_VERBOSITY` environment variable.
 
 {#v0-0-0-added}
 ### Added

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -101,6 +101,7 @@ doing. This is mostly useful for development to debug errors.
 Determines the verbosity of logging output for repo rules. Valid values:
 
 * `DEBUG`
+* `FAIL`
 * `INFO`
 * `TRACE`
 :::

--- a/python/private/repo_utils.bzl
+++ b/python/private/repo_utils.bzl
@@ -56,6 +56,7 @@ def _logger(mrctx, name = None):
 
     verbosity = {
         "DEBUG": 2,
+        "FAIL": -1,
         "INFO": 1,
         "TRACE": 3,
     }.get(verbosity_level, 0)


### PR DESCRIPTION
Allows the logging level to be set to `FAIL`, removing `WARN` logging.