### PR TITLE
fix: run check on interpreter in isolated mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Unreleased changes template.
 * (toolchains) The toolchain matching is has been fixed when writing
   transitions transitioning on the `python_version` flag.
   Fixes [#2685](https://github.com/bazel-contrib/rules_python/issues/2685).
+* (toolchains) Run the check on the Python interpreter in isolated mode, to ensure it's not affected by userland environment variables, such as `PYTHONPATH`.
 
 {#v0-0-0-added}
 ### Added

--- a/python/private/toolchains_repo.bzl
+++ b/python/private/toolchains_repo.bzl
@@ -275,7 +275,14 @@ assert want_python == got_python, \
     repo_utils.execute_checked(
         rctx,
         op = "CheckHostInterpreter",
-        arguments = [rctx.path(python_binary), python_tester],
+        arguments = [
+            rctx.path(python_binary),
+            # Run the interpreter in isolated mode, this options implies -E, -P and -s.
+            # This ensures that environment variables are ignored that are set in userspace, such as PYTHONPATH,
+            # which may interfere with this invocation.
+            "-I",
+            python_tester,
+        ],
     )
     if not rctx.delete(python_tester):
         fail("Failed to delete the python tester")


### PR DESCRIPTION
Runs the check on the interpreter in the toolchain repo in isolated mode via `-I`. This ensures it's not influenced by userland environment variables, such as `PYTHONPATH` which will cause issues if it allows this invocation to use into another interpreter versions site-packages.