### PR TITLE
fix: escape name segment of stamped wheel files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ Unreleased changes template.
   transitions transitioning on the `python_version` flag.
   Fixes [#2685](https://github.com/bazel-contrib/rules_python/issues/2685).
 * (toolchains) Run the check on the Python interpreter in isolated mode, to ensure it's not affected by userland environment variables, such as `PYTHONPATH`.
+* (py_wheel) Ensure the filename segment is escaped in when using stamping wheel names.
 
 {#v0-0-0-added}
 ### Added

--- a/python/private/py_wheel.bzl
+++ b/python/private/py_wheel.bzl
@@ -310,7 +310,7 @@ def _py_wheel_impl(ctx):
 
     filename_segments = [
         _escape_filename_distribution_name(ctx.attr.distribution),
-        normalize_pep440(version),
+        _escape_filename_segment(normalize_pep440(version)),
         _escape_filename_segment(python_tag),
         _escape_filename_segment(abi),
         _escape_filename_segment(ctx.attr.platform),


### PR DESCRIPTION
~1 year ago `py_wheel` changed to enforce PEP440, however the resulting stamp vars are no longer escaped.

For example:
Before: `bazel-bin/xxxx/xxxx-_STABLE_BUILD_SCM_VERSION_-py3-none-any.whl`
After: `bazel-bin/xxxx/xxxx-{STABLE_BUILD_SCM_VERSION}-py3-none-any.whl`

This results in downstream consumers of the wheel that are publishing, or generating "manifest" stye files of release artifacts and other metadata will now incorrectly replace the `{STABLE_BUILD_SCM_VERSION}` in the artifact name and path, leading to the incorrect artifact metadata and pathing.

Original reported here, however this could be seen as breaking, as it changes the unstamped wheel file names.
https://bazelbuild.slack.com/archives/C0174UDLAF3/p1706726049830819