### PR TITLE
fix: Ensure temporary .pyc & .pyo files are excluded from the interpreters repository files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ Unreleased changes template.
   transitions transitioning on the `python_version` flag.
   Fixes [#2685](https://github.com/bazel-contrib/rules_python/issues/2685).
 * (toolchains) Run the check on the Python interpreter in isolated mode, to ensure it's not affected by userland environment variables, such as `PYTHONPATH`.
+* (toolchains) Ensure temporary `.pyc` and `.pyo` files are also excluded from the interpreters repository files.
 
 {#v0-0-0-added}
 ### Added

--- a/python/private/python_repository.bzl
+++ b/python/private/python_repository.bzl
@@ -193,6 +193,7 @@ def _python_repository_impl(rctx):
             # Exclude them from the glob because otherwise between the first time and second time a python toolchain is used,"
             # the definition of this filegroup will change, and depending rules will get invalidated."
             # See https://github.com/bazel-contrib/rules_python/issues/1008 for unconditionally adding these to toolchains so we can stop ignoring them."
+            # pyc* is ignored because pyc creation creates temporary .pyc.NNNN files
             "**/__pycache__/*.pyc*",
             "**/__pycache__/*.pyo*",
         ]

--- a/python/private/python_repository.bzl
+++ b/python/private/python_repository.bzl
@@ -193,8 +193,8 @@ def _python_repository_impl(rctx):
             # Exclude them from the glob because otherwise between the first time and second time a python toolchain is used,"
             # the definition of this filegroup will change, and depending rules will get invalidated."
             # See https://github.com/bazel-contrib/rules_python/issues/1008 for unconditionally adding these to toolchains so we can stop ignoring them."
-            "**/__pycache__/*.pyc",
-            "**/__pycache__/*.pyo",
+            "**/__pycache__/*.pyc*",
+            "**/__pycache__/*.pyo*",
         ]
 
     if "windows" in platform:


### PR DESCRIPTION
We've seen cases the temporary versions for the `.pyc` and `.pyo` files are unstable on certain interpreter toolchains. The temp files take for form of `.pyc.NNN`, so the amended glob patten will still match both the `.pyc` and `.pyc.NNN` versions of the file names.