### PR TITLE
chore: remove unnecessary DEFAULT_BOOTSTRAP_TEMPLATE global

### DIFF
--- a/python/private/py_runtime_info.bzl
+++ b/python/private/py_runtime_info.bzl
@@ -17,8 +17,6 @@ load(":util.bzl", "define_bazel_6_provider")
 
 DEFAULT_STUB_SHEBANG = "#!/usr/bin/env python3"
 
-DEFAULT_BOOTSTRAP_TEMPLATE = Label("//python/private:bootstrap_template")
-
 _PYTHON_VERSION_VALUES = ["PY2", "PY3"]
 
 def _optional_int(value):

--- a/python/private/py_runtime_rule.bzl
+++ b/python/private/py_runtime_rule.bzl
@@ -19,7 +19,7 @@ load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load(":attributes.bzl", "NATIVE_RULES_ALLOWLIST_ATTRS")
 load(":flags.bzl", "FreeThreadedFlag")
 load(":py_internal.bzl", "py_internal")
-load(":py_runtime_info.bzl", "DEFAULT_BOOTSTRAP_TEMPLATE", "DEFAULT_STUB_SHEBANG", "PyRuntimeInfo")
+load(":py_runtime_info.bzl", "DEFAULT_STUB_SHEBANG", "PyRuntimeInfo")
 load(":reexports.bzl", "BuiltinPyRuntimeInfo")
 load(":util.bzl", "IS_BAZEL_7_OR_HIGHER")
 
@@ -201,7 +201,7 @@ If not set, then it will be set based on flags.
             ),
             "bootstrap_template": attr.label(
                 allow_single_file = True,
-                default = DEFAULT_BOOTSTRAP_TEMPLATE,
+                default = Label("//python/private:bootstrap_template"),
                 doc = """
 The bootstrap script template file to use. Should have %python_binary%,
 %workspace_name%, %main%, and %imports%.


### PR DESCRIPTION
I think the DEFAULT_BOOTSTRAP_TEMPLATE global was used by something in the original
Bazel impl, but now it's just used in one place. Remove the shared global and just
inline the single usage.