### PR TITLE
fix: ensure filenames with spaces are excluded from targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ Unreleased changes template.
   Fixes [#2685](https://github.com/bazel-contrib/rules_python/issues/2685).
 * (toolchains) Run the check on the Python interpreter in isolated mode, to ensure it's not affected by userland environment variables, such as `PYTHONPATH`.
 * (toolchains) Ensure temporary `.pyc` and `.pyo` files are also excluded from the interpreters repository files.
+* (pypi) Ensure files from external pypi dependencies with spaces in are excluded from globs.
 
 {#v0-0-0-added}
 ### Added

--- a/python/private/hermetic_runtime_repo_setup.bzl
+++ b/python/private/hermetic_runtime_repo_setup.bzl
@@ -76,8 +76,11 @@ def define_hermetic_runtime_toolchain_impl(
                 # tests for the standard libraries.
                 "lib/python{major}.{minor}*/**/test/**".format(**version_dict),
                 "lib/python{major}.{minor}*/**/tests/**".format(**version_dict),
-                # During pyc creation, temp files named *.pyc.NNN are created
+                # During pyc and pyo creation, temp files named *.pyc.NNN and *.pyo.NNN are created.
                 "**/__pycache__/*.pyc.*",
+                "**/__pycache__/*.pyo.*",
+                # File names with spaces should also be ignored.
+                "**/* *",
             ] + glob_excludes.version_dependent_exclusions() + extra_files_glob_exclude,
         ),
     )

--- a/python/private/pypi/whl_library_targets.bzl
+++ b/python/private/pypi/whl_library_targets.bzl
@@ -103,7 +103,14 @@ def whl_library_targets(
     for filegroup_name, glob in filegroups.items():
         native.filegroup(
             name = filegroup_name,
-            srcs = native.glob(glob, allow_empty = True),
+            srcs = native.glob(
+                glob,
+                exclude = [
+                    # File names with spaces should be excluded.
+                    "**/* *",
+                ],
+                allow_empty = True,
+            ),
             visibility = ["//visibility:public"],
         )
 
@@ -229,10 +236,13 @@ def whl_library_targets(
             "**/*.py",
             "**/*.pyc",
             "**/*.pyc.*",  # During pyc creation, temp files named *.pyc.NNNN are created
+            "**/*.pyo.*",  # During pyo creation, temp files named *.pyo.NNNN are created
             # RECORD is known to contain sha256 checksums of files which might include the checksums
             # of generated files produced when wheels are installed. The file is ignored to avoid
             # Bazel caching issues.
             "**/*.dist-info/RECORD",
+            # File names with spaces should be excluded.
+            "**/* *",
         ] + glob_excludes.version_dependent_exclusions()
         for item in data_exclude:
             if item not in _data_exclude:
@@ -242,7 +252,10 @@ def whl_library_targets(
             name = py_library_label,
             srcs = native.glob(
                 ["site-packages/**/*.py"],
-                exclude = srcs_exclude,
+                exclude = srcs_exclude + [
+                    # File names with spaces should be excluded.
+                    "**/* *",
+                ],
                 # Empty sources are allowed to support wheels that don't have any
                 # pure-Python code, e.g. pymssql, which is written in Cython.
                 allow_empty = True,

--- a/python/private/python_repository.bzl
+++ b/python/private/python_repository.bzl
@@ -193,9 +193,8 @@ def _python_repository_impl(rctx):
             # Exclude them from the glob because otherwise between the first time and second time a python toolchain is used,"
             # the definition of this filegroup will change, and depending rules will get invalidated."
             # See https://github.com/bazel-contrib/rules_python/issues/1008 for unconditionally adding these to toolchains so we can stop ignoring them."
-            # pyc* is ignored because pyc creation creates temporary .pyc.NNNN files
-            "**/__pycache__/*.pyc*",
-            "**/__pycache__/*.pyo*",
+            "**/__pycache__/*.pyc",
+            "**/__pycache__/*.pyo",
         ]
 
     if "windows" in platform:


### PR DESCRIPTION
Some dependencies contain files with spaces in the name. These should be excluded as they are generally unsupported, and when placed in a runfiles manifest file, they cause it to be malformed.

This changes omits files with spaces in the names from glob patterns.
It also changes the `.pyo.NNN` temp file inclusion added in https://github.com/bazel-contrib/rules_python/pull/2743 as it seems it was slightly misplaced, and missed form 3p dependency targets.