### PR TITLE
fix: run python version call in isolated mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ Unreleased changes template.
   Fixes [#2685](https://github.com/bazel-contrib/rules_python/issues/2685).
 * (toolchains) Run the check on the Python interpreter in isolated mode, to ensure it's not affected by userland environment variables, such as `PYTHONPATH`.
 * (toolchains) Ensure temporary `.pyc` and `.pyo` files are also excluded from the interpreters repository files.
+* (pypi) Run interpreter version call in isolated mode, to ensure it's not affected by userland environment variables, such as `PYTHONPATH`.
 
 {#v0-0-0-added}
 ### Added

--- a/python/private/pypi/whl_library.bzl
+++ b/python/private/pypi/whl_library.bzl
@@ -109,6 +109,10 @@ def _get_toolchain_unix_cflags(rctx, python_interpreter, logger = None):
         op = "GetPythonVersionForUnixCflags",
         python = python_interpreter,
         arguments = [
+            # Run the interpreter in isolated mode, this options implies -E, -P and -s.
+            # Ensures environment variables are ignored that are set in userspace, such as PYTHONPATH,
+            # which may interfere with this invocation.
+            "-I",
             "-c",
             "import sys; print(f'{sys.version_info[0]}.{sys.version_info[1]}', end='')",
         ],


### PR DESCRIPTION
Similar to https://github.com/bazel-contrib/rules_python/pull/2738, runs the call to get the Python interpreter version in isolated mode via `-I`, ensuring userland Python variables do not affect this call.