### PR TITLE
fix(rules): make the srcs trully optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ Unreleased changes template.
   extension has been marked reproducible.
   Fixes [#2434](https://github.com/bazel-contrib/rules_python/issues/2434).
 * (rules) {attr}`py_binary.srcs` and {attr}`py_test.srcs` is no longer mandatory when
-  `main_module` is specified.
+  `main_module` is specified (for `--bootstrap_impl=script`)
 
 [20250317]: https://github.com/astral-sh/python-build-standalone/releases/tag/20250317
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ Unreleased changes template.
 * (pypi) The PyPI extension will no longer write the lock file entries as the
   extension has been marked reproducible.
   Fixes [#2434](https://github.com/bazel-contrib/rules_python/issues/2434).
+* (rules) {attr}`py_binary.srcs` and {attr}`py_test.srcs` is no longer mandatory when
+  `main_module` is specified.
 
 [20250317]: https://github.com/astral-sh/python-build-standalone/releases/tag/20250317
 

--- a/python/private/py_executable.bzl
+++ b/python/private/py_executable.bzl
@@ -808,7 +808,7 @@ def _create_stage1_bootstrap(
         subs["%imports%"] = ":".join(imports.to_list())
         subs["%main%"] = "{}/{}".format(ctx.workspace_name, main_py.short_path)
     else:
-        fail("'main' or 'srcs' must be specified")
+        fail("mandatory 'srcs' attribute has not been specified")
 
     ctx.actions.expand_template(
         template = template,

--- a/python/private/py_executable.bzl
+++ b/python/private/py_executable.bzl
@@ -786,7 +786,7 @@ def _create_stage1_bootstrap(
         )
         template = runtime.bootstrap_template
         subs["%shebang%"] = runtime.stub_shebang
-    else:
+    elif main_py:
         if (ctx.configuration.coverage_enabled and
             runtime and
             runtime.coverage_tool):
@@ -807,6 +807,8 @@ def _create_stage1_bootstrap(
         subs["%import_all%"] = ("True" if ctx.fragments.bazel_py.python_import_all_repositories else "False")
         subs["%imports%"] = ":".join(imports.to_list())
         subs["%main%"] = "{}/{}".format(ctx.workspace_name, main_py.short_path)
+    else:
+        fail("'main' or 'srcs' must be specified")
 
     ctx.actions.expand_template(
         template = template,
@@ -1888,7 +1890,6 @@ def create_executable_rule_builder(implementation, **kwargs):
         ),
         **kwargs
     )
-    builder.attrs.get("srcs").set_mandatory(True)
     return builder
 
 def cc_configure_features(

--- a/python/private/py_executable.bzl
+++ b/python/private/py_executable.bzl
@@ -786,7 +786,9 @@ def _create_stage1_bootstrap(
         )
         template = runtime.bootstrap_template
         subs["%shebang%"] = runtime.stub_shebang
-    elif main_py:
+    elif not ctx.files.srcs:
+        fail("mandatory 'srcs' files have not been provided")
+    else:
         if (ctx.configuration.coverage_enabled and
             runtime and
             runtime.coverage_tool):
@@ -807,8 +809,6 @@ def _create_stage1_bootstrap(
         subs["%import_all%"] = ("True" if ctx.fragments.bazel_py.python_import_all_repositories else "False")
         subs["%imports%"] = ":".join(imports.to_list())
         subs["%main%"] = "{}/{}".format(ctx.workspace_name, main_py.short_path)
-    else:
-        fail("mandatory 'srcs' attribute has not been specified")
 
     ctx.actions.expand_template(
         template = template,

--- a/tests/base_rules/py_executable_base_tests.bzl
+++ b/tests/base_rules/py_executable_base_tests.bzl
@@ -342,28 +342,28 @@ def _test_name_cannot_end_in_py_impl(env, target):
         matching.str_matches("name must not end in*.py"),
     )
 
-def _test_py_runtime_info_provided(name, config):
+def _test_no_srcs(name, config):
     rt_util.helper_target(
         config.rule,
         name = name + "_subject",
-        srcs = [name + "_subject.py"],
+        main_module = "dummy",
     )
     analysis_test(
         name = name,
-        impl = _test_py_runtime_info_provided_impl,
+        impl = _test_no_srcs_impl,
         target = name + "_subject",
+        config_settings = {
+            "//command_line_option:platforms": [LINUX_X86_64],
+        },
+        expect_failure = True,
     )
 
-def _test_py_runtime_info_provided_impl(env, target):
-    # Make sure that the rules_python loaded symbol is provided.
-    env.expect.that_target(target).has_provider(RulesPythonPyRuntimeInfo)
+def _test_no_srcs_impl(env, target):
+    env.expect.that_target(target).failures().contains_predicate(
+        matching.str_matches("mandatory*srcs"),
+    )
 
-    if BuiltinPyRuntimeInfo != None:
-        # For compatibility during the transition, the builtin PyRuntimeInfo should
-        # also be provided.
-        env.expect.that_target(target).has_provider(BuiltinPyRuntimeInfo)
-
-_tests.append(_test_py_runtime_info_provided)
+_tests.append(_test_no_srcs)
 
 def _test_no_srcs_script_bootstrap(name, config):
     rt_util.helper_target(
@@ -388,49 +388,28 @@ def _test_no_srcs_script_bootstrap_impl(env, target):
 
 _tests.append(_test_no_srcs_script_bootstrap)
 
-def _test_no_srcs(name, config):
+def _test_py_runtime_info_provided(name, config):
     rt_util.helper_target(
         config.rule,
         name = name + "_subject",
-        main_module = "dummy",
+        srcs = [name + "_subject.py"],
     )
     analysis_test(
         name = name,
-        impl = _test_no_srcs_impl,
+        impl = _test_py_runtime_info_provided_impl,
         target = name + "_subject",
-        config_settings = {
-            "//command_line_option:platforms": [LINUX_X86_64],
-        },
-        expect_failure = True,
     )
 
-def _test_no_srcs_impl(_, __):
-    pass
+def _test_py_runtime_info_provided_impl(env, target):
+    # Make sure that the rules_python loaded symbol is provided.
+    env.expect.that_target(target).has_provider(RulesPythonPyRuntimeInfo)
 
-_tests.append(_test_no_srcs)
+    if BuiltinPyRuntimeInfo != None:
+        # For compatibility during the transition, the builtin PyRuntimeInfo should
+        # also be provided.
+        env.expect.that_target(target).has_provider(BuiltinPyRuntimeInfo)
 
-# Can't test this -- mandatory validation happens before analysis test
-# can intercept it
-# TODO(#1069): Once re-implemented in Starlark, modify rule logic to make this
-# testable.
-# def _test_srcs_is_mandatory(name, config):
-#     rt_util.helper_target(
-#         config.rule,
-#         name = name + "_subject",
-#     )
-#     analysis_test(
-#         name = name,
-#         impl = _test_srcs_is_mandatory,
-#         target = name + "_subject",
-#         expect_failure = True,
-#     )
-#
-# _tests.append(_test_srcs_is_mandatory)
-#
-# def _test_srcs_is_mandatory_impl(env, target):
-#     env.expect.that_target(target).failures().contains_predicate(
-#         matching.str_matches("mandatory*srcs"),
-#     )
+_tests.append(_test_py_runtime_info_provided)
 
 # =====
 # You were gonna add a test at the end, weren't you?

--- a/tests/base_rules/py_executable_base_tests.bzl
+++ b/tests/base_rules/py_executable_base_tests.bzl
@@ -342,7 +342,7 @@ def _test_name_cannot_end_in_py_impl(env, target):
         matching.str_matches("name must not end in*.py"),
     )
 
-def _test_no_srcs(name, config):
+def _test_main_module_bootstrap_system_python(name, config):
     rt_util.helper_target(
         config.rule,
         name = name + "_subject",
@@ -350,7 +350,7 @@ def _test_no_srcs(name, config):
     )
     analysis_test(
         name = name,
-        impl = _test_no_srcs_impl,
+        impl = _test_main_module_bootstrap_system_python_impl,
         target = name + "_subject",
         config_settings = {
             "//command_line_option:platforms": [LINUX_X86_64],
@@ -358,14 +358,14 @@ def _test_no_srcs(name, config):
         expect_failure = True,
     )
 
-def _test_no_srcs_impl(env, target):
+def _test_main_module_bootstrap_system_python_impl(env, target):
     env.expect.that_target(target).failures().contains_predicate(
         matching.str_matches("mandatory*srcs"),
     )
 
-_tests.append(_test_no_srcs)
+_tests.append(_test_main_module_bootstrap_system_python)
 
-def _test_no_srcs_script_bootstrap(name, config):
+def _test_main_module_bootstrap_script(name, config):
     rt_util.helper_target(
         config.rule,
         name = name + "_subject",
@@ -373,7 +373,7 @@ def _test_no_srcs_script_bootstrap(name, config):
     )
     analysis_test(
         name = name,
-        impl = _test_no_srcs_script_bootstrap_impl,
+        impl = _test_main_module_bootstrap_script_impl,
         target = name + "_subject",
         config_settings = {
             BOOTSTRAP_IMPL: "script",
@@ -381,12 +381,12 @@ def _test_no_srcs_script_bootstrap(name, config):
         },
     )
 
-def _test_no_srcs_script_bootstrap_impl(env, target):
+def _test_main_module_bootstrap_script_impl(env, target):
     env.expect.that_target(target).default_outputs().contains(
         "{package}/{test_name}_subject",
     )
 
-_tests.append(_test_no_srcs_script_bootstrap)
+_tests.append(_test_main_module_bootstrap_script)
 
 def _test_py_runtime_info_provided(name, config):
     rt_util.helper_target(

--- a/tests/base_rules/py_executable_base_tests.bzl
+++ b/tests/base_rules/py_executable_base_tests.bzl
@@ -24,7 +24,7 @@ load("//python/private:util.bzl", "IS_BAZEL_7_OR_HIGHER")  # buildifier: disable
 load("//tests/base_rules:base_tests.bzl", "create_base_tests")
 load("//tests/base_rules:util.bzl", "WINDOWS_ATTR", pt_util = "util")
 load("//tests/support:py_executable_info_subject.bzl", "PyExecutableInfoSubject")
-load("//tests/support:support.bzl", "CC_TOOLCHAIN", "CROSSTOOL_TOP", "LINUX_X86_64", "WINDOWS_X86_64")
+load("//tests/support:support.bzl", "BOOTSTRAP_IMPL", "CC_TOOLCHAIN", "CROSSTOOL_TOP", "LINUX_X86_64", "WINDOWS_X86_64")
 
 _tests = []
 
@@ -364,6 +364,50 @@ def _test_py_runtime_info_provided_impl(env, target):
         env.expect.that_target(target).has_provider(BuiltinPyRuntimeInfo)
 
 _tests.append(_test_py_runtime_info_provided)
+
+def _test_no_srcs_script_bootstrap(name, config):
+    rt_util.helper_target(
+        config.rule,
+        name = name + "_subject",
+        main_module = "dummy",
+    )
+    analysis_test(
+        name = name,
+        impl = _test_no_srcs_script_bootstrap_impl,
+        target = name + "_subject",
+        config_settings = {
+            BOOTSTRAP_IMPL: "script",
+            "//command_line_option:platforms": [LINUX_X86_64],
+        },
+    )
+
+def _test_no_srcs_script_bootstrap_impl(env, target):
+    env.expect.that_target(target).default_outputs().contains(
+        "{package}/{test_name}_subject",
+    )
+
+_tests.append(_test_no_srcs_script_bootstrap)
+
+def _test_no_srcs(name, config):
+    rt_util.helper_target(
+        config.rule,
+        name = name + "_subject",
+        main_module = "dummy",
+    )
+    analysis_test(
+        name = name,
+        impl = _test_no_srcs_impl,
+        target = name + "_subject",
+        config_settings = {
+            "//command_line_option:platforms": [LINUX_X86_64],
+        },
+        expect_failure = True,
+    )
+
+def _test_no_srcs_impl(_, __):
+    pass
+
+_tests.append(_test_no_srcs)
 
 # Can't test this -- mandatory validation happens before analysis test
 # can intercept it

--- a/tests/base_rules/py_executable_base_tests.bzl
+++ b/tests/base_rules/py_executable_base_tests.bzl
@@ -353,6 +353,7 @@ def _test_main_module_bootstrap_system_python(name, config):
         impl = _test_main_module_bootstrap_system_python_impl,
         target = name + "_subject",
         config_settings = {
+            BOOTSTRAP_IMPL: "system_python",
             "//command_line_option:platforms": [LINUX_X86_64],
         },
         expect_failure = True,

--- a/tests/support/support.bzl
+++ b/tests/support/support.bzl
@@ -35,6 +35,7 @@ CROSSTOOL_TOP = Label("//tests/support/cc_toolchains:cc_toolchain_suite")
 # str() around Label() is necessary because rules_testing's config_settings
 # doesn't accept yet Label objects.
 ADD_SRCS_TO_RUNFILES = str(Label("//python/config_settings:add_srcs_to_runfiles"))
+BOOTSTRAP_IMPL = str(Label("//python/config_settings:bootstrap_impl"))
 EXEC_TOOLS_TOOLCHAIN = str(Label("//python/config_settings:exec_tools_toolchain"))
 PRECOMPILE = str(Label("//python/config_settings:precompile"))
 PRECOMPILE_SOURCE_RETENTION = str(Label("//python/config_settings:precompile_source_retention"))


### PR DESCRIPTION
With this PR we mark the srcs attribute as optional as we can
leverage the `main_module` to just run things from the deps.

This also removes a long-standing `TODO` note.

Fixes #2765
