### PR TITLE
feat(toolchain): Add new make vars for Python interpreter path compliant with `--no_legacy_external_runfiles`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,8 @@ Unreleased changes template.
 * (toolchains) Local Python installs can be used to create a toolchain
   equivalent to the standard toolchains. See [Local toolchains] docs for how to
   configure them.
+* (toolchains) Expose `$(PYTHON2_ROOTPATH)` and `$(PYTHON3_ROOTPATH)` which are runfiles
+  locations equivalents of `$(PYTHON2)` and `$(PYTHON3) respectively.
 
 
 {#v0-0-0-removed}

--- a/docs/toolchains.md
+++ b/docs/toolchains.md
@@ -215,7 +215,11 @@ attribute. You can obtain the path to the Python interpreter using the
 `$(PYTHON2)` and `$(PYTHON3)` ["Make"
 Variables](https://bazel.build/reference/be/make-variables). See the
 {gh-path}`test_current_py_toolchain <tests/load_from_macro/BUILD.bazel>` target
-for an example.
+for an example. We also make available `$(PYTHON2_ROOTPATH)` and `$(PYTHON3_ROOTPATH)`
+which are Make Variable equivalents of `$(PYTHON2)` and `$(PYTHON3)` but for runfiles
+locations. These will be helpful if you need to set env vars of binary/test rules
+while using [`--nolegacy_external_runfiles`](https://bazel.build/reference/command-line-reference#flag--legacy_external_runfiles).
+The original make variables still work in exec contexts such as genrules.
 
 ### Overriding toolchain defaults and adding more versions
 

--- a/python/current_py_toolchain.bzl
+++ b/python/current_py_toolchain.bzl
@@ -51,6 +51,11 @@ current_py_toolchain = rule(
     other rules, such as genrule. It allows exposing a python toolchain after toolchain resolution has
     happened, to a rule which expects a concrete implementation of a toolchain, rather than a
     toolchain_type which could be resolved to that toolchain.
+
+    :::{versionchanged} VERSION_NEXT_FEATURE
+    From now on, we also expose `$(PYTHON2_ROOTPATH)` and `$(PYTHON3_ROOTPATH)` which are runfiles
+    locations equivalents of `$(PYTHON2)` and `$(PYTHON3) respectively.
+    :::
     """,
     implementation = _current_py_toolchain_impl,
     attrs = {

--- a/python/current_py_toolchain.bzl
+++ b/python/current_py_toolchain.bzl
@@ -27,11 +27,13 @@ def _current_py_toolchain_impl(ctx):
         direct.append(toolchain.py3_runtime.interpreter)
         transitive.append(toolchain.py3_runtime.files)
         vars["PYTHON3"] = toolchain.py3_runtime.interpreter.path
+        vars["PYTHON3_ROOTPATH"] = toolchain.py3_runtime.interpreter.short_path
 
     if toolchain.py2_runtime and toolchain.py2_runtime.interpreter:
         direct.append(toolchain.py2_runtime.interpreter)
         transitive.append(toolchain.py2_runtime.files)
         vars["PYTHON2"] = toolchain.py2_runtime.interpreter.path
+        vars["PYTHON2_ROOTPATH"] = toolchain.py2_runtime.interpreter.short_path
 
     files = depset(direct, transitive = transitive)
     return [


### PR DESCRIPTION
Using these new make vars in `py_binary` or `py_test` will correctly find the interpreter when setting `--no_legacy_external_runfiles`.

Fixes #2728