### PR TITLE
refactor(bzlmod): stop using 'repo' attr in whl_library

### DIFF
--- a/python/private/pypi/extension.bzl
+++ b/python/private/pypi/extension.bzl
@@ -181,7 +181,6 @@ def _create_whl_repos(
         # Construct args separately so that the lock file can be smaller and does not include unused
         # attrs.
         whl_library_args = dict(
-            repo = pip_name,
             dep_template = "@{}//{{name}}:{{target}}".format(hub_name),
         )
         maybe_args = dict(

--- a/python/private/pypi/whl_library.bzl
+++ b/python/private/pypi/whl_library.bzl
@@ -517,8 +517,10 @@ and the target that we need respectively.
         doc = "Name of the group, if any.",
     ),
     "repo": attr.string(
-        mandatory = True,
-        doc = "Pointer to parent repo name. Used to make these rules rerun if the parent repo changes.",
+        doc = """\
+Pointer to parent repo name. Used to make these rules rerun if the parent repo changes.
+Only used in WORKSPACE when the {attr}`dep_template` is not set.
+""",
     ),
     "repo_prefix": attr.string(
         doc = """

--- a/tests/pypi/extension/extension_tests.bzl
+++ b/tests/pypi/extension/extension_tests.bzl
@@ -174,7 +174,6 @@ def _test_simple(env):
         "pypi_315_simple": {
             "dep_template": "@pypi//{name}:{target}",
             "python_interpreter_target": "unit_test_interpreter_target",
-            "repo": "pypi_315",
             "requirement": "simple==0.0.1 --hash=sha256:deadbeef --hash=sha256:deadbaaf",
         },
     })
@@ -234,13 +233,11 @@ def _test_simple_multiple_requirements(env):
         "pypi_315_simple_osx_aarch64_osx_x86_64": {
             "dep_template": "@pypi//{name}:{target}",
             "python_interpreter_target": "unit_test_interpreter_target",
-            "repo": "pypi_315",
             "requirement": "simple==0.0.2 --hash=sha256:deadb00f",
         },
         "pypi_315_simple_windows_x86_64": {
             "dep_template": "@pypi//{name}:{target}",
             "python_interpreter_target": "unit_test_interpreter_target",
-            "repo": "pypi_315",
             "requirement": "simple==0.0.1 --hash=sha256:deadbeef",
         },
     })
@@ -307,13 +304,11 @@ torch==2.4.1 ; platform_machine != 'x86_64' \
         "pypi_315_torch_linux_aarch64_linux_arm_linux_ppc_linux_s390x_osx_aarch64": {
             "dep_template": "@pypi//{name}:{target}",
             "python_interpreter_target": "unit_test_interpreter_target",
-            "repo": "pypi_315",
             "requirement": "torch==2.4.1 --hash=sha256:deadbeef",
         },
         "pypi_315_torch_linux_x86_64_osx_x86_64_windows_x86_64": {
             "dep_template": "@pypi//{name}:{target}",
             "python_interpreter_target": "unit_test_interpreter_target",
-            "repo": "pypi_315",
             "requirement": "torch==2.4.1+cpu",
         },
     })
@@ -444,7 +439,6 @@ torch==2.4.1+cpu ; platform_machine == 'x86_64' \
             "experimental_target_platforms": ["cp312_linux_x86_64"],
             "filename": "torch-2.4.1+cpu-cp312-cp312-linux_x86_64.whl",
             "python_interpreter_target": "unit_test_interpreter_target",
-            "repo": "pypi_312",
             "requirement": "torch==2.4.1+cpu",
             "sha256": "8800deef0026011d502c0c256cc4b67d002347f63c3a38cd8e45f1f445c61364",
             "urls": ["https://torch.index/whl/cpu/torch-2.4.1%2Bcpu-cp312-cp312-linux_x86_64.whl"],
@@ -454,7 +448,6 @@ torch==2.4.1+cpu ; platform_machine == 'x86_64' \
             "experimental_target_platforms": ["cp312_linux_aarch64"],
             "filename": "torch-2.4.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
             "python_interpreter_target": "unit_test_interpreter_target",
-            "repo": "pypi_312",
             "requirement": "torch==2.4.1",
             "sha256": "36109432b10bd7163c9b30ce896f3c2cca1b86b9765f956a1594f0ff43091e2a",
             "urls": ["https://torch.index/whl/cpu/torch-2.4.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"],
@@ -464,7 +457,6 @@ torch==2.4.1+cpu ; platform_machine == 'x86_64' \
             "experimental_target_platforms": ["cp312_windows_x86_64"],
             "filename": "torch-2.4.1+cpu-cp312-cp312-win_amd64.whl",
             "python_interpreter_target": "unit_test_interpreter_target",
-            "repo": "pypi_312",
             "requirement": "torch==2.4.1+cpu",
             "sha256": "3a570e5c553415cdbddfe679207327b3a3806b21c6adea14fba77684d1619e97",
             "urls": ["https://torch.index/whl/cpu/torch-2.4.1%2Bcpu-cp312-cp312-win_amd64.whl"],
@@ -474,7 +466,6 @@ torch==2.4.1+cpu ; platform_machine == 'x86_64' \
             "experimental_target_platforms": ["cp312_osx_aarch64"],
             "filename": "torch-2.4.1-cp312-none-macosx_11_0_arm64.whl",
             "python_interpreter_target": "unit_test_interpreter_target",
-            "repo": "pypi_312",
             "requirement": "torch==2.4.1",
             "sha256": "72b484d5b6cec1a735bf3fa5a1c4883d01748698c5e9cfdbeb4ffab7c7987e0d",
             "urls": ["https://torch.index/whl/cpu/torch-2.4.1-cp312-none-macosx_11_0_arm64.whl"],
@@ -560,7 +551,6 @@ simple==0.0.3 \
             "experimental_target_platforms": ["cp315_linux_x86_64"],
             "extra_pip_args": ["--platform=manylinux_2_17_x86_64", "--python-version=315", "--implementation=cp", "--abi=cp315"],
             "python_interpreter_target": "unit_test_interpreter_target",
-            "repo": "pypi_315",
             "requirement": "extra==0.0.1 --hash=sha256:deadb00f",
         },
         "pypi_315_simple_linux_x86_64": {
@@ -569,7 +559,6 @@ simple==0.0.3 \
             "experimental_target_platforms": ["cp315_linux_x86_64"],
             "extra_pip_args": ["--platform=manylinux_2_17_x86_64", "--python-version=315", "--implementation=cp", "--abi=cp315"],
             "python_interpreter_target": "unit_test_interpreter_target",
-            "repo": "pypi_315",
             "requirement": "simple==0.0.1 --hash=sha256:deadbeef",
         },
         "pypi_315_simple_osx_aarch64": {
@@ -578,7 +567,6 @@ simple==0.0.3 \
             "experimental_target_platforms": ["cp315_osx_aarch64"],
             "extra_pip_args": ["--platform=macosx_10_9_arm64", "--python-version=315", "--implementation=cp", "--abi=cp315"],
             "python_interpreter_target": "unit_test_interpreter_target",
-            "repo": "pypi_315",
             "requirement": "simple==0.0.3 --hash=sha256:deadbaaf",
         },
     })
@@ -766,7 +754,6 @@ git_dep @ git+https://git.server/repo/project@deadbeefdeadbeef
             "extra_pip_args": ["--extra-args-for-sdist-building"],
             "filename": "any-name.tar.gz",
             "python_interpreter_target": "unit_test_interpreter_target",
-            "repo": "pypi_315",
             "requirement": "direct_sdist_without_sha @ some-archive/any-name.tar.gz",
             "sha256": "",
             "urls": ["some-archive/any-name.tar.gz"],
@@ -776,7 +763,6 @@ git_dep @ git+https://git.server/repo/project@deadbeefdeadbeef
             "experimental_target_platforms": ["cp315_linux_aarch64", "cp315_linux_arm", "cp315_linux_ppc", "cp315_linux_s390x", "cp315_linux_x86_64", "cp315_osx_aarch64", "cp315_osx_x86_64", "cp315_windows_x86_64"],
             "filename": "direct_without_sha-0.0.1-py3-none-any.whl",
             "python_interpreter_target": "unit_test_interpreter_target",
-            "repo": "pypi_315",
             "requirement": "direct_without_sha==0.0.1 @ example-direct.org/direct_without_sha-0.0.1-py3-none-any.whl",
             "sha256": "",
             "urls": ["example-direct.org/direct_without_sha-0.0.1-py3-none-any.whl"],
@@ -785,14 +771,12 @@ git_dep @ git+https://git.server/repo/project@deadbeefdeadbeef
             "dep_template": "@pypi//{name}:{target}",
             "extra_pip_args": ["--extra-args-for-sdist-building"],
             "python_interpreter_target": "unit_test_interpreter_target",
-            "repo": "pypi_315",
             "requirement": "git_dep @ git+https://git.server/repo/project@deadbeefdeadbeef",
         },
         "pypi_315_pip_fallback": {
             "dep_template": "@pypi//{name}:{target}",
             "extra_pip_args": ["--extra-args-for-sdist-building"],
             "python_interpreter_target": "unit_test_interpreter_target",
-            "repo": "pypi_315",
             "requirement": "pip_fallback==0.0.1",
         },
         "pypi_315_simple_py3_none_any_deadb00f": {
@@ -800,7 +784,6 @@ git_dep @ git+https://git.server/repo/project@deadbeefdeadbeef
             "experimental_target_platforms": ["cp315_linux_aarch64", "cp315_linux_arm", "cp315_linux_ppc", "cp315_linux_s390x", "cp315_linux_x86_64", "cp315_osx_aarch64", "cp315_osx_x86_64", "cp315_windows_x86_64"],
             "filename": "simple-0.0.1-py3-none-any.whl",
             "python_interpreter_target": "unit_test_interpreter_target",
-            "repo": "pypi_315",
             "requirement": "simple==0.0.1",
             "sha256": "deadb00f",
             "urls": ["example2.org"],
@@ -811,7 +794,6 @@ git_dep @ git+https://git.server/repo/project@deadbeefdeadbeef
             "extra_pip_args": ["--extra-args-for-sdist-building"],
             "filename": "simple-0.0.1.tar.gz",
             "python_interpreter_target": "unit_test_interpreter_target",
-            "repo": "pypi_315",
             "requirement": "simple==0.0.1",
             "sha256": "deadbeef",
             "urls": ["example.org"],
@@ -821,7 +803,6 @@ git_dep @ git+https://git.server/repo/project@deadbeefdeadbeef
             "experimental_target_platforms": ["cp315_linux_aarch64", "cp315_linux_arm", "cp315_linux_ppc", "cp315_linux_s390x", "cp315_linux_x86_64", "cp315_osx_aarch64", "cp315_osx_x86_64", "cp315_windows_x86_64"],
             "filename": "some_pkg-0.0.1-py3-none-any.whl",
             "python_interpreter_target": "unit_test_interpreter_target",
-            "repo": "pypi_315",
             "requirement": "some_pkg==0.0.1 @ example-direct.org/some_pkg-0.0.1-py3-none-any.whl --hash=sha256:deadbaaf",
             "sha256": "deadbaaf",
             "urls": ["example-direct.org/some_pkg-0.0.1-py3-none-any.whl"],
@@ -831,7 +812,6 @@ git_dep @ git+https://git.server/repo/project@deadbeefdeadbeef
             "experimental_target_platforms": ["cp315_linux_aarch64", "cp315_linux_arm", "cp315_linux_ppc", "cp315_linux_s390x", "cp315_linux_x86_64", "cp315_osx_aarch64", "cp315_osx_x86_64", "cp315_windows_x86_64"],
             "filename": "some-other-pkg-0.0.1-py3-none-any.whl",
             "python_interpreter_target": "unit_test_interpreter_target",
-            "repo": "pypi_315",
             "requirement": "some_other_pkg==0.0.1",
             "sha256": "deadb33f",
             "urls": ["example2.org/index/some_other_pkg/"],
@@ -920,13 +900,11 @@ optimum[onnxruntime-gpu]==1.17.1 ; sys_platform == 'linux'
         "pypi_315_optimum_linux_aarch64_linux_arm_linux_ppc_linux_s390x_linux_x86_64": {
             "dep_template": "@pypi//{name}:{target}",
             "python_interpreter_target": "unit_test_interpreter_target",
-            "repo": "pypi_315",
             "requirement": "optimum[onnxruntime-gpu]==1.17.1",
         },
         "pypi_315_optimum_osx_aarch64_osx_x86_64": {
             "dep_template": "@pypi//{name}:{target}",
             "python_interpreter_target": "unit_test_interpreter_target",
-            "repo": "pypi_315",
             "requirement": "optimum[onnxruntime]==1.17.1",
         },
     })


### PR DESCRIPTION
A simple non-functional cleanup that just removes legacy code paths from
bzlmod PyPI integration.
