### PR TITLE
fix(rules): copy_propagating_kwargs() now also copies target_compatible_with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,8 @@ Unreleased changes template.
 * (toolchains) Ensure temporary `.pyc` and `.pyo` files are also excluded from the interpreters repository files.
 * (pypi) Run interpreter version call in isolated mode, to ensure it's not affected by userland environment variables, such as `PYTHONPATH`.
 * (packaging) An empty `requires_file` is treated as if it were omitted, resulting in a valid `METADATA` file.
+* (rules) Macros now propagate `target_compatible_with` to all rules they create.
+  [PR #2788](https://github.com/bazel-contrib/rules_python/pull/2788).
 
 {#v0-0-0-added}
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,7 +100,7 @@ Unreleased changes template.
 * (toolchains) Ensure temporary `.pyc` and `.pyo` files are also excluded from the interpreters repository files.
 * (pypi) Run interpreter version call in isolated mode, to ensure it's not affected by userland environment variables, such as `PYTHONPATH`.
 * (packaging) An empty `requires_file` is treated as if it were omitted, resulting in a valid `METADATA` file.
-* (rules) Macros now propagate `target_compatible_with` to all rules they create.
+* (rules) py_wheel and sphinxdocs rules now propagate `target_compatible_with` to all targets they create.
   [PR #2788](https://github.com/bazel-contrib/rules_python/pull/2788).
 
 {#v0-0-0-added}

--- a/python/private/util.bzl
+++ b/python/private/util.bzl
@@ -42,7 +42,7 @@ def copy_propagating_kwargs(from_kwargs, into_kwargs = None):
         into_kwargs = {}
 
     # Include tags because people generally expect tags to propagate.
-    for attr in ("testonly", "tags", "compatible_with", "restricted_to"):
+    for attr in ("testonly", "tags", "compatible_with", "restricted_to", "target_compatible_with"):
         if attr in from_kwargs and attr not in into_kwargs:
             into_kwargs[attr] = from_kwargs[attr]
     return into_kwargs


### PR DESCRIPTION
This routine already copies `compatible_with`, which is little used, but does not copy `target_compatible_with`, which is broadly used. This seems like an oversight.

I noticed this discrepancy when working on a system that assumes that any `tags` or `target_compatible_with` parameters supplied to a macro will propagate to all rules created by that macro. In rules_python, this already works for `tags`, but not for `target_compatible_with`.

It would be great to get this accepted upstream, so that I can stop patching rules_python.
