### PR TITLE
release: 1.4.0 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ Unreleased changes template.
 {#v0-0-0-removed}
 ### Removed
 * Nothing removed.
--->
+END_UNRELEASED_TEMPLATE -->
 
 
 {#v0-0-0}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,15 +43,17 @@ Unreleased changes template.
 {#v0-0-0-removed}
 ### Removed
 * Nothing removed.
-END_UNRELEASED_TEMPLATE -->
+
+END_UNRELEASED_TEMPLATE
+-->
 
 
-{#v0-0-0}
-## Unreleased
+{#1-4-0}
+## [1.4.0] - 2025-04-19
 
-[0.0.0]: https://github.com/bazel-contrib/rules_python/releases/tag/0.0.0
+[1.4.0]: https://github.com/bazel-contrib/rules_python/releases/tag/1.4.0
 
-{#v0-0-0-changed}
+{#1-4-0-changed}
 ### Changed
 * (toolchain) The `exec` configuration toolchain now has the forwarded
   `exec_interpreter` now also forwards the `ToolchainInfo` provider. This is
@@ -72,7 +74,7 @@ END_UNRELEASED_TEMPLATE -->
 * (toolchains) Previously [#2636](https://github.com/bazel-contrib/rules_python/pull/2636)
   changed the semantics of `ignore_root_user_error` from "ignore" to "warning". This is now
   flipped back to ignoring the issue, and will only emit a warning when the attribute is set
-  `False`.  
+  `False`.
 * (pypi) The PyPI extension will no longer write the lock file entries as the
   extension has been marked reproducible.
   Fixes [#2434](https://github.com/bazel-contrib/rules_python/issues/2434).
@@ -84,7 +86,7 @@ END_UNRELEASED_TEMPLATE -->
 
 [20250317]: https://github.com/astral-sh/python-build-standalone/releases/tag/20250317
 
-{#v0-0-0-fixed}
+{#1-4-0-fixed}
 ### Fixed
 * (pypi) Platform specific extras are now correctly handled when using
   universal lock files with environment markers. Fixes [#2690](https://github.com/bazel-contrib/rules_python/pull/2690).
@@ -103,7 +105,7 @@ END_UNRELEASED_TEMPLATE -->
 * (rules) py_wheel and sphinxdocs rules now propagate `target_compatible_with` to all targets they create.
   [PR #2788](https://github.com/bazel-contrib/rules_python/pull/2788).
 
-{#v0-0-0-added}
+{#1-4-0-added}
 ### Added
 * (pypi) From now on `sha256` values in the `requirements.txt` is no longer
   mandatory when enabling {attr}`pip.parse.experimental_index_url` feature.
@@ -134,13 +136,13 @@ END_UNRELEASED_TEMPLATE -->
   locations equivalents of `$(PYTHON2)` and `$(PYTHON3) respectively.
 
 
-{#v0-0-0-removed}
+{#1-4-0-removed}
 ### Removed
 * Nothing removed.
 
 
 {#v1-3-0}
-## Unreleased
+## [1.3.0] - 2025-03-27
 
 [1.3.0]: https://github.com/bazel-contrib/rules_python/releases/tag/1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ A brief description of the categories of changes:
   `(docs)`.
 
 <!--
-Unreleased changes template.
+BEGIN_UNRELEASED_TEMPLATE
 
 {#v0-0-0}
 ## Unreleased

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -97,6 +97,20 @@ It will be promoted to stable next week, pending feedback.
 It's traditional to include notable changes from the changelog, but not
 required.
 
+### Re-releasing a version
+
+Re-releasing a version (i.e. changing the commit a tag points to)  is
+*sometimes* possible, but it depends on how far into the release process it got.
+
+The two points of no return are:
+ * If the PyPI package has been published: PyPI disallows using the same
+   filename/version twice. Once published, it cannot be replaced.
+ * If the BCR package has been published: Once it's been committed to the BCR
+   registry, it cannot be replaced.
+
+If release steps fail _prior_ to those steps, then its OK to change the tag. You
+may need to manually delete the GitHub release.
+
 ## Secrets
 
 ### PyPI user rules-python

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,6 +15,10 @@ These are the steps for a regularly scheduled release from HEAD.
 1. [Determine the next semantic version number](#determining-semantic-version).
 1. Update CHANGELOG.md: replace the `v0-0-0` and `0.0.0` with `X.Y.0`.
 1. Replace `VERSION_NEXT_*` strings with `X.Y.0`.
+   ```
+   grep -l --exclude=CONTRIBUTING.md --exclude=RELEASING.md --exclude-dir=.* VERSION_NEXT_ -r \
+     | xargs sed -i -e 's/VERSION_NEXT_FEATURE/X.Y.0/' -e 's/VERSION_NEXT_PATCH/X.Y.0/'
+   ```
 1. Send these changes for review and get them merged.
 1. Create a branch for the new release, named `release/X.Y`
    ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,6 +14,9 @@ These are the steps for a regularly scheduled release from HEAD.
 
 1. [Determine the next semantic version number](#determining-semantic-version).
 1. Update CHANGELOG.md: replace the `v0-0-0` and `0.0.0` with `X.Y.0`.
+   ```
+   awk -v version=X.Y.0 'BEGIN { hv=version; gsub(/\./, "-", hv) } /END_UNRELEASED_TEMPLATE/ { found_marker = 1 } found_marker { gsub(/v0-0-0/, hv, $0); gsub(/Unreleased/, "[" version "] - " strftime("%Y-%m-%d"), $0); gsub(/0.0.0/, version, $0); } { print } ' CHANGELOG.md > /tmp/changelog && cp /tmp/changelog CHANGELOG.md
+   ```
 1. Replace `VERSION_NEXT_*` strings with `X.Y.0`.
    ```
    grep -l --exclude=CONTRIBUTING.md --exclude=RELEASING.md --exclude-dir=.* VERSION_NEXT_ -r \

--- a/python/current_py_toolchain.bzl
+++ b/python/current_py_toolchain.bzl
@@ -52,7 +52,7 @@ current_py_toolchain = rule(
     happened, to a rule which expects a concrete implementation of a toolchain, rather than a
     toolchain_type which could be resolved to that toolchain.
 
-    :::{versionchanged} VERSION_NEXT_FEATURE
+    :::{versionchanged} 1.4.0
     From now on, we also expose `$(PYTHON2_ROOTPATH)` and `$(PYTHON3_ROOTPATH)` which are runfiles
     locations equivalents of `$(PYTHON2)` and `$(PYTHON3) respectively.
     :::

--- a/python/features.bzl
+++ b/python/features.bzl
@@ -35,7 +35,7 @@ def _features_typedef():
 
     True if the `PyInfo.site_packages_symlinks` field is available.
 
-    :::{versionadded} VERSION_NEXT_FEATURE
+    :::{versionadded} 1.4.0
     :::
     ::::
 

--- a/python/local_toolchains/repos.bzl
+++ b/python/local_toolchains/repos.bzl
@@ -1,6 +1,6 @@
 """Rules/macros for repository phase for local toolchains.
 
-:::{versionadded} VERSION_NEXT_FEATURE
+:::{versionadded} 1.4.0
 :::
 """
 

--- a/python/packaging.bzl
+++ b/python/packaging.bzl
@@ -101,7 +101,7 @@ def py_wheel(
 
     Currently only pure-python wheels are supported.
 
-    :::{versionchanged} VERSION_NEXT_FEATURE
+    :::{versionchanged} 1.4.0
     From now on, an empty `requires_file` is treated as if it were omitted, resulting in a valid
     `METADATA` file.
     :::

--- a/python/private/py_exec_tools_toolchain.bzl
+++ b/python/private/py_exec_tools_toolchain.bzl
@@ -77,7 +77,7 @@ handle all the necessary transitions and runtime setup to invoke a program.
 
 See {obj}`PyExecToolsInfo.exec_interpreter` for further docs.
 
-:::{versionchanged} VERSION_NEXT_FEATURE
+:::{versionchanged} 1.4.0
 From now on the provided target also needs to provide `platform_common.ToolchainInfo`
 so that the toolchain `py_runtime` field can be correctly forwarded.
 :::

--- a/python/private/py_info.bzl
+++ b/python/private/py_info.bzl
@@ -168,7 +168,7 @@ values from further way dependencies, such as forcing symlinks to point to
 specific paths or preventing symlinks from being created.
 :::
 
-:::{versionadded} VERSION_NEXT_FEATURE
+:::{versionadded} 1.4.0
 :::
 """,
         "transitive_implicit_pyc_files": """

--- a/python/private/py_library.bzl
+++ b/python/private/py_library.bzl
@@ -94,7 +94,7 @@ to a consumer have precedence. See {obj}`PyInfo.site_packages_symlinks` for
 more information.
 :::
 
-:::{versionadded} VERSION_NEXT_FEATURE
+:::{versionadded} 1.4.0
 :::
 """,
         ),

--- a/python/private/pypi/extension.bzl
+++ b/python/private/pypi/extension.bzl
@@ -686,7 +686,7 @@ If {attr}`download_only` is set, then `sdist` archives will be discarded and `pi
 operate in wheel-only mode.
 :::
 
-:::{versionchanged} VERSION_NEXT_FEATURE
+:::{versionchanged} 1.4.0
 Index metadata will be used to deduct `sha256` values for packages even if the
 `sha256` values are not present in the requirements.txt lock file.
 :::
@@ -767,7 +767,7 @@ to `rules_python` and use this attribute until the bug is fixed.
 
 EXPERIMENTAL: this may be removed without notice.
 
-:::{versionadded} VERSION_NEXT_FEATURE
+:::{versionadded} 1.4.0
 :::
 """,
         ),

--- a/python/private/python.bzl
+++ b/python/private/python.bzl
@@ -695,7 +695,7 @@ matches the {attr}`python_version` attribute of a toolchain, this
 toolchain is the default version. If this attribute is set, the
 {attr}`is_default` attribute of the toolchain is ignored.
 
-:::{versionadded} VERSION_NEXT_FEATURE
+:::{versionadded} 1.4.0
 :::
 """,
         ),
@@ -707,7 +707,7 @@ If the string matches the {attr}`python_version` attribute of a
 toolchain, this toolchain is the default version. If this attribute is
 set, the {attr}`is_default` attribute of the toolchain is ignored.
 
-:::{versionadded} VERSION_NEXT_FEATURE
+:::{versionadded} 1.4.0
 :::
 """,
         ),
@@ -720,7 +720,7 @@ of the file match the {attr}`python_version` attribute of a toolchain,
 this toolchain is the default version. If this attribute is set, the
 {attr}`is_default` attribute of the toolchain is ignored.
 
-:::{versionadded} VERSION_NEXT_FEATURE
+:::{versionadded} 1.4.0
 :::
 """,
         ),
@@ -813,7 +813,7 @@ this to `False`.
             doc = """\
 Whether the toolchain is the default version.
 
-:::{versionchanged} VERSION_NEXT_FEATURE
+:::{versionchanged} 1.4.0
 This setting is ignored if the default version is set using the `defaults`
 tag class.
 :::


### PR DESCRIPTION
Updates changelog and version markers.

Also updates the release docs with some shell-one liners to copy and paste to make it
a bit more mechanical.