### PR TITLE
fix: escape more invalid repo string characters

### DIFF
--- a/python/private/pypi/whl_repo_name.bzl
+++ b/python/private/pypi/whl_repo_name.bzl
@@ -44,7 +44,7 @@ def whl_repo_name(filename, sha256):
     else:
         parsed = parse_whl_name(filename)
         name = normalize_name(parsed.distribution)
-        version = parsed.version.replace(".", "_").replace("!", "_")
+        version = parsed.version.replace(".", "_").replace("!", "_").replace("+", "_").replace("%", "_")
         python_tag, _, _ = parsed.python_tag.partition(".")
         abi_tag, _, _ = parsed.abi_tag.partition(".")
         platform_tag, _, _ = parsed.platform_tag.partition(".")

--- a/tests/pypi/whl_repo_name/whl_repo_name_tests.bzl
+++ b/tests/pypi/whl_repo_name/whl_repo_name_tests.bzl
@@ -54,6 +54,18 @@ def _test_platform_whl(env):
 
 _tests.append(_test_platform_whl)
 
+def _test_name_with_plus(env):
+    got = whl_repo_name("gptqmodel-2.0.0+cu126torch2.6-cp312-cp312-linux_x86_64.whl", "")
+    env.expect.that_str(got).equals("gptqmodel_2_0_0_cu126torch2_6_cp312_cp312_linux_x86_64")
+
+_tests.append(_test_name_with_plus)
+
+def _test_name_with_percent(env):
+    got = whl_repo_name("gptqmodel-2.0.0%2Bcu126torch2.6-cp312-cp312-linux_x86_64.whl", "")
+    env.expect.that_str(got).equals("gptqmodel_2_0_0_2Bcu126torch2_6_cp312_cp312_linux_x86_64")
+
+_tests.append(_test_name_with_percent)
+
 def whl_repo_name_test_suite(name):
     """Create the test suite.
 


### PR DESCRIPTION
Also escape plus and percent when generating the repo name from the wheel version.
Sometimes they have such characters in them.

Fixes https://github.com/bazel-contrib/rules_python/issues/2799
