### PR TITLE
fix: parsing metadata with inline licenses

### DIFF
--- a/python/private/pypi/whl_metadata.bzl
+++ b/python/private/pypi/whl_metadata.bzl
@@ -52,7 +52,7 @@ def parse_whl_metadata(contents):
         "version": "",
     }
     for line in contents.strip().split("\n"):
-        if not line.strip():
+        if not line:
             # Stop parsing on first empty line, which marks the end of the
             # headers containing the metadata.
             break

--- a/python/private/pypi/whl_metadata.bzl
+++ b/python/private/pypi/whl_metadata.bzl
@@ -52,6 +52,11 @@ def parse_whl_metadata(contents):
         "version": "",
     }
     for line in contents.strip().split("\n"):
+        if not line:
+            # Stop parsing on first empty line, which marks the end of the
+            # headers containing the metadata.
+            break
+
         if line.startswith(_NAME):
             _, _, value = line.partition(_NAME)
             parsed["name"] = value.strip()

--- a/python/private/pypi/whl_metadata.bzl
+++ b/python/private/pypi/whl_metadata.bzl
@@ -52,11 +52,6 @@ def parse_whl_metadata(contents):
         "version": "",
     }
     for line in contents.strip().split("\n"):
-        if not line:
-            # Stop parsing on first empty line, which marks the end of the
-            # headers containing the metadata.
-            break
-
         if line.startswith(_NAME):
             _, _, value = line.partition(_NAME)
             parsed["name"] = value.strip()

--- a/tests/pypi/whl_metadata/whl_metadata_tests.bzl
+++ b/tests/pypi/whl_metadata/whl_metadata_tests.bzl
@@ -140,6 +140,37 @@ Requires-Dist: this will be ignored
 
 _tests.append(_test_parse_metadata_all)
 
+def _test_parse_metadata_multiline_license(env):
+    got = _parse_whl_metadata(
+        env,
+        # NOTE: The trailing whitespace here is meaningful as an empty line
+        # denotes the end of the header.
+        contents = """\
+Name: foo
+Version: 0.0.1
+License: some License
+        
+        some line
+        
+        another line
+        
+Requires-Dist: bar; extra == "all"
+Provides-Extra: all
+
+Requires-Dist: this will be ignored
+""",
+    )
+    got.name().equals("foo")
+    got.version().equals("0.0.1")
+    got.requires_dist().contains_exactly([
+        "bar; extra == \"all\"",
+    ])
+    got.provides_extra().contains_exactly([
+        "all",
+    ])
+
+_tests.append(_test_parse_metadata_multiline_license)
+
 def whl_metadata_test_suite(name):  # buildifier: disable=function-docstring
     test_suite(
         name = name,

--- a/tests/pypi/whl_metadata/whl_metadata_tests.bzl
+++ b/tests/pypi/whl_metadata/whl_metadata_tests.bzl
@@ -126,14 +126,13 @@ Version: 0.0.1
 Requires-Dist: bar; extra == "all"
 Provides-Extra: all
 
-Requires-Dist: baz
+Requires-Dist: this will be ignored
 """,
     )
     got.name().equals("foo")
     got.version().equals("0.0.1")
     got.requires_dist().contains_exactly([
         "bar; extra == \"all\"",
-        "baz",
     ])
     got.provides_extra().contains_exactly([
         "all",
@@ -158,14 +157,13 @@ License: some License
 Requires-Dist: bar; extra == "all"
 Provides-Extra: all
 
-Requires-Dist: baz
+Requires-Dist: this will be ignored
 """,
     )
     got.name().equals("foo")
     got.version().equals("0.0.1")
     got.requires_dist().contains_exactly([
         "bar; extra == \"all\"",
-        "baz",
     ])
     got.provides_extra().contains_exactly([
         "all",

--- a/tests/pypi/whl_metadata/whl_metadata_tests.bzl
+++ b/tests/pypi/whl_metadata/whl_metadata_tests.bzl
@@ -126,13 +126,14 @@ Version: 0.0.1
 Requires-Dist: bar; extra == "all"
 Provides-Extra: all
 
-Requires-Dist: this will be ignored
+Requires-Dist: baz
 """,
     )
     got.name().equals("foo")
     got.version().equals("0.0.1")
     got.requires_dist().contains_exactly([
         "bar; extra == \"all\"",
+        "baz",
     ])
     got.provides_extra().contains_exactly([
         "all",
@@ -157,13 +158,14 @@ License: some License
 Requires-Dist: bar; extra == "all"
 Provides-Extra: all
 
-Requires-Dist: this will be ignored
+Requires-Dist: baz
 """,
     )
     got.name().equals("foo")
     got.version().equals("0.0.1")
     got.requires_dist().contains_exactly([
         "bar; extra == \"all\"",
+        "baz",
     ])
     got.provides_extra().contains_exactly([
         "all",


### PR DESCRIPTION
The wheel `METADATA` parsing implemented in 1.4 missed the fact
that whitespace is significant and sometimes License is included
inline in the `METADATA` file itself.

This change ensures that we stop parsing the `METADATA` file only
on first completely empty line.

Fixes https://github.com/bazel-contrib/rules_python/issues/2796
