### PR TITLE
test(pypi): add a test case for simpleapi html parsing with %

### DIFF
--- a/tests/pypi/parse_simpleapi_html/parse_simpleapi_html_tests.bzl
+++ b/tests/pypi/parse_simpleapi_html/parse_simpleapi_html_tests.bzl
@@ -303,6 +303,24 @@ def _test_whls(env):
                 yanked = False,
             ),
         ),
+        (
+            struct(
+                attrs = [
+                    'href="/whl/cpu/torch-2.6.0%2Bcpu-cp39-cp39-manylinux_2_28_aarch64.whl#sha256=deadbeef"',
+                ],
+                filename = "torch-2.6.0+cpu-cp39-cp39-manylinux_2_28_aarch64.whl",
+                url = "https://example.org/",
+            ),
+            struct(
+                filename = "torch-2.6.0+cpu-cp39-cp39-manylinux_2_28_aarch64.whl",
+                metadata_sha256 = "",
+                metadata_url = "",
+                sha256 = "deadbeef",
+                version = "2.6.0+cpu",
+                url = "https://example.org/whl/cpu/torch-2.6.0%2Bcpu-cp39-cp39-manylinux_2_28_aarch64.whl",
+                yanked = False,
+            ),
+        ),
     ]
 
     for (input, want) in tests:

--- a/tests/pypi/parse_simpleapi_html/parse_simpleapi_html_tests.bzl
+++ b/tests/pypi/parse_simpleapi_html/parse_simpleapi_html_tests.bzl
@@ -317,6 +317,7 @@ def _test_whls(env):
                 metadata_url = "",
                 sha256 = "deadbeef",
                 version = "2.6.0+cpu",
+                # A URL with % could occur if directly written in requirements.
                 url = "https://example.org/whl/cpu/torch-2.6.0%2Bcpu-cp39-cp39-manylinux_2_28_aarch64.whl",
                 yanked = False,
             ),


### PR DESCRIPTION
In addition to #2801 I wanted to ensure that we are getting the correct
filename when downloading wheels. It seems that the `%` in the wheel
filename might get through wheels that get referenced via direct URL in
the requirements.txt files.
