### PR TITLE
fix: try multiple times to get win32 version to handle flakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ END_UNRELEASED_TEMPLATE
   * The `sys._base_executable` value will reflect the underlying interpreter,
     not venv interpreter.
   * The {obj}`//python/runtime_env_toolchains:all` toolchain now works with it.
+* (rules) Better handle flakey platform.win32_ver() calls by calling them
+  multiple times.
 
 {#v0-0-0-added}
 ### Added

--- a/python/private/python_bootstrap_template.txt
+++ b/python/private/python_bootstrap_template.txt
@@ -46,7 +46,15 @@ def GetWindowsPathWithUNCPrefix(path):
   # removed from common Win32 file and directory functions.
   # Related doc: https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=cmd#enable-long-paths-in-windows-10-version-1607-and-later
   import platform
-  if platform.win32_ver()[1] >= '10.0.14393':
+  win32_version = None
+  # Windows 2022 with Python 3.12.8 gives flakey errors, so try a couple times.
+  for _ in range(3):
+    try:
+      win32_version = platform.win32_ver()[1]
+      break
+    except (ValueError, KeyError):
+      pass
+  if win32_version and win32_version >= '10.0.14393':
     return path
 
   # import sysconfig only now to maintain python 2.6 compatibility

--- a/python/private/stage2_bootstrap_template.py
+++ b/python/private/stage2_bootstrap_template.py
@@ -58,7 +58,15 @@ def get_windows_path_with_unc_prefix(path):
     # Related doc: https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=cmd#enable-long-paths-in-windows-10-version-1607-and-later
     import platform
 
-    if platform.win32_ver()[1] >= "10.0.14393":
+    win32_version = None
+    # Windows 2022 with Python 3.12.8 gives flakey errors, so try a couple times.
+    for _ in range(3):
+        try:
+            win32_version = platform.win32_ver()[1]
+            break
+        except (ValueError, KeyError):
+            pass
+    if win32_version and win32_version >= '10.0.14393':
         return path
 
     # import sysconfig only now to maintain python 2.6 compatibility


### PR DESCRIPTION
The Google tensorflow/jax devinfra team reported that Windows 2022 with Python 3.12.8
has a tendency to be flaky when calling the platform.win32 APIs. I'm very certain I
saw similar behavior in the past myself.

To fix, just call the APIs a couple times; it seems to fix itself.

cc @vam-google