### PR TITLE
refactor: Add log_std(out|err) bools to repo_utils that execute a subprocess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,9 @@ END_UNRELEASED_TEMPLATE
 
 {#v0-0-0-added}
 ### Added
-* Nothing added.
+* Repo utilities `execute_unchecked`, `execute_checked`, and `execute_checked_stdout` now
+  support `log_stdout` and `log_stderr` keyword arg booleans. When these are `True`
+  (the default), the subprocess's stdout/stderr will be logged.
 
 {#v0-0-0-removed}
 ### Removed


### PR DESCRIPTION
While making a local patch to work around #2640, I found that I had a need for running a subprocess (`gcloud auth print-access-token`) via `repo_utils.execute_checked_stdout`. However, doing so would log that access token when debug logging was enabled via `RULES_PYTHON_REPO_DEBUG=1`. This is a security concern for us, so I hacked in an option to allow a particular `execute_(un)checked(_stdout)` call to disable logging stdout, stderr, or both.

I figure this might be useful to others so I thought I'd upstream it.

`execute_(un)checked(_stdout)` now support `log_stdout` and `log_stderr` bools that default to `True` (which is the same behavior as before this PR.

When the subprocess writes to stdout and `log_stdout = False`, the logged message will show:

```
===== stdout start =====
<log_stdout = False; skipping>
===== stdout end =====
```

If the subprocess does not write to stdout, the debug log shows the same as before:

```
<stdout empty>
```

The above also applies for stderr, with text adjusted accordingly.