### PR TITLE
fix(gazelle): Skip indexing py_binary rules if a corresponding py_library rule contains the same srcs

### DIFF
--- a/gazelle/python/generate.go
+++ b/gazelle/python/generate.go
@@ -123,6 +123,7 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 			pyFileNames.Add(f)
 			if !hasPyBinaryEntryPointFile && f == pyBinaryEntrypointFilename {
 				hasPyBinaryEntryPointFile = true
+				pyLibraryFilenames.Add(f)
 			} else if !hasPyTestEntryPointFile && f == pyTestEntrypointFilename {
 				hasPyTestEntryPointFile = true
 			} else if f == conftestFilename {
@@ -247,9 +248,9 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 
 				// Remove the file from srcs if we're doing per-file library generation so
 				// that we don't also generate a py_library target for it.
-				if cfg.PerFileGeneration() {
-					srcs.Remove(name)
-				}
+				// if cfg.PerFileGeneration() {
+				// 	srcs.Remove(name)
+				// }
 			}
 			sort.Strings(mainFileNames)
 			for _, filename := range mainFileNames {
@@ -352,6 +353,7 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 			collisionErrors.Add(err)
 		}
 
+		// Create the py_binary target that depends on the py_library
 		pyBinaryTarget := newTargetBuilder(pyBinaryKind, pyBinaryTargetName, pythonProjectRoot, args.Rel, pyFileNames).
 			setMain(pyBinaryEntrypointFilename).
 			addVisibility(visibility).

--- a/gazelle/python/generate.go
+++ b/gazelle/python/generate.go
@@ -48,8 +48,8 @@ var (
 	buildFilenames = []string{"BUILD", "BUILD.bazel"}
 )
 
-func GetActualKindName(kind string, args language.GenerateArgs) string {
-	if kindOverride, ok := args.Config.KindMap[kind]; ok {
+func GetActualKindName(kind string, c *config.Config) string {
+	if kindOverride, ok := c.KindMap[kind]; ok {
 		return kindOverride.KindName
 	}
 	return kind
@@ -90,9 +90,9 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 		}
 	}
 
-	actualPyBinaryKind := GetActualKindName(pyBinaryKind, args)
-	actualPyLibraryKind := GetActualKindName(pyLibraryKind, args)
-	actualPyTestKind := GetActualKindName(pyTestKind, args)
+	actualPyBinaryKind := GetActualKindName(pyBinaryKind, args.Config)
+	actualPyLibraryKind := GetActualKindName(pyLibraryKind, args.Config)
+	actualPyTestKind := GetActualKindName(pyTestKind, args.Config)
 
 	pythonProjectRoot := cfg.PythonProjectRoot()
 

--- a/gazelle/python/resolve.go
+++ b/gazelle/python/resolve.go
@@ -55,7 +55,7 @@ func (*Resolver) Name() string { return languageName }
 // If nil is returned, the rule will not be indexed. If any non-nil slice is
 // returned, including an empty slice, the rule will be indexed.
 func (py *Resolver) Imports(c *config.Config, r *rule.Rule, f *rule.File) []resolve.ImportSpec {
-	if !indexPyBinaryImport(r, f) {
+	if r.Kind() == "py_binary" {
 		return nil
 	}
 	cfgs := c.Exts[languageName].(pythonconfig.Configs)
@@ -368,30 +368,4 @@ func convertDependencySetToExpr(set *treeset.Set) bzl.Expr {
 		deps[it.Index()] = &bzl.StringExpr{Value: dep}
 	}
 	return &bzl.ListExpr{List: deps}
-}
-
-// indexPyBinaryImport returns whether the corresponding py_binary rule need to be indexed.
-// To avoid multiple labels indexing the same import,
-// check if there is a corresponding py_library rule with the same srcs.
-func indexPyBinaryImport(r *rule.Rule, f *rule.File) bool {
-	// If the rule is not a py_binary, it should be indexed.
-	if r.Kind() != "py_binary" {
-		return true
-	}
-	pyBinarySrcs := r.AttrStrings("srcs")
-	if len(pyBinarySrcs) == 0 {
-		return false
-	}
-	for _, otherRule := range f.Rules {
-		if otherRule.Kind() != "py_library" {
-			continue
-		}
-		pyLibrarySrcs := otherRule.AttrStrings("srcs")
-		for _, src := range pyLibrarySrcs {
-			if src == pyBinarySrcs[0] {
-				return false
-			}
-		}
-	}
-	return true
 }

--- a/gazelle/python/resolve.go
+++ b/gazelle/python/resolve.go
@@ -57,6 +57,11 @@ func (*Resolver) Name() string { return languageName }
 func (py *Resolver) Imports(c *config.Config, r *rule.Rule, f *rule.File) []resolve.ImportSpec {
 	cfgs := c.Exts[languageName].(pythonconfig.Configs)
 	cfg := cfgs[f.Pkg]
+	if !cfg.PerFileGeneration() && GetActualKindName(r.Kind(), c) == pyBinaryKind {
+		// Don't index py_binary in except in file mode, because all non-test Python files
+		// are in py_library already.
+		return nil
+	}
 	srcs := r.AttrStrings("srcs")
 	provides := make([]resolve.ImportSpec, 0, len(srcs)+1)
 	for _, src := range srcs {

--- a/gazelle/python/resolve.go
+++ b/gazelle/python/resolve.go
@@ -55,11 +55,13 @@ func (*Resolver) Name() string { return languageName }
 // If nil is returned, the rule will not be indexed. If any non-nil slice is
 // returned, including an empty slice, the rule will be indexed.
 func (py *Resolver) Imports(c *config.Config, r *rule.Rule, f *rule.File) []resolve.ImportSpec {
-	if r.Kind() == "py_binary" {
-		return nil
-	}
 	cfgs := c.Exts[languageName].(pythonconfig.Configs)
 	cfg := cfgs[f.Pkg]
+	if !cfg.PerFileGeneration() && GetActualKindName(r.Kind(), c) == pyBinaryKind {
+		// Don't index py_binary in except in file mode, because all non-test Python files
+		// are in py_library already.
+		return nil
+	}
 	srcs := r.AttrStrings("srcs")
 	provides := make([]resolve.ImportSpec, 0, len(srcs)+1)
 	for _, src := range srcs {

--- a/gazelle/python/resolve.go
+++ b/gazelle/python/resolve.go
@@ -57,11 +57,6 @@ func (*Resolver) Name() string { return languageName }
 func (py *Resolver) Imports(c *config.Config, r *rule.Rule, f *rule.File) []resolve.ImportSpec {
 	cfgs := c.Exts[languageName].(pythonconfig.Configs)
 	cfg := cfgs[f.Pkg]
-	if !cfg.PerFileGeneration() && GetActualKindName(r.Kind(), c) == pyBinaryKind {
-		// Don't index py_binary in except in file mode, because all non-test Python files
-		// are in py_library already.
-		return nil
-	}
 	srcs := r.AttrStrings("srcs")
 	provides := make([]resolve.ImportSpec, 0, len(srcs)+1)
 	for _, src := range srcs {

--- a/gazelle/python/testdata/import_with_same_srcs_library_and_binary/BUILD.in
+++ b/gazelle/python/testdata/import_with_same_srcs_library_and_binary/BUILD.in
@@ -1,0 +1,3 @@
+# gazelle:python_extension enabled
+# gazelle:python_library_naming_convention py_default_library
+# gazelle:python_generation_mode package

--- a/gazelle/python/testdata/import_with_same_srcs_library_and_binary/BUILD.out
+++ b/gazelle/python/testdata/import_with_same_srcs_library_and_binary/BUILD.out
@@ -1,0 +1,3 @@
+# gazelle:python_extension enabled
+# gazelle:python_library_naming_convention py_default_library
+# gazelle:python_generation_mode package

--- a/gazelle/python/testdata/import_with_same_srcs_library_and_binary/README.md
+++ b/gazelle/python/testdata/import_with_same_srcs_library_and_binary/README.md
@@ -1,0 +1,2 @@
+# Import with same srcs for library and binary
+This test case asserts a file with py_library and py_binary rules that include the same .py file in srcs will resolve to the py_library rule correctly.

--- a/gazelle/python/testdata/import_with_same_srcs_library_and_binary/WORKSPACE
+++ b/gazelle/python/testdata/import_with_same_srcs_library_and_binary/WORKSPACE
@@ -1,0 +1,1 @@
+# This is a Bazel workspace for the Gazelle test data.

--- a/gazelle/python/testdata/import_with_same_srcs_library_and_binary/bar/BUILD.in
+++ b/gazelle/python/testdata/import_with_same_srcs_library_and_binary/bar/BUILD.in
@@ -1,0 +1,8 @@
+load("@rules_python//python:defs.bzl", "py_library")
+
+py_library(
+    name = "bar",
+    srcs = ["bar.py"],
+    visibility = ["//:__subpackages__"],
+    deps = ["//foo"],
+)

--- a/gazelle/python/testdata/import_with_same_srcs_library_and_binary/bar/BUILD.out
+++ b/gazelle/python/testdata/import_with_same_srcs_library_and_binary/bar/BUILD.out
@@ -1,0 +1,8 @@
+load("@rules_python//python:defs.bzl", "py_library")
+
+py_library(
+    name = "bar",
+    srcs = ["bar.py"],
+    visibility = ["//:__subpackages__"],
+    deps = ["//foo:py_default_library"],
+)

--- a/gazelle/python/testdata/import_with_same_srcs_library_and_binary/bar/bar.py
+++ b/gazelle/python/testdata/import_with_same_srcs_library_and_binary/bar/bar.py
@@ -1,0 +1,1 @@
+import foo.script

--- a/gazelle/python/testdata/import_with_same_srcs_library_and_binary/foo/BUILD.out
+++ b/gazelle/python/testdata/import_with_same_srcs_library_and_binary/foo/BUILD.out
@@ -1,0 +1,13 @@
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+
+py_binary(
+    name = "script",
+    srcs = ["script.py"],
+    visibility = ["//:__subpackages__"],
+)
+
+py_library(
+    name = "py_default_library",
+    srcs = ["script.py"],
+    visibility = ["//:__subpackages__"],
+)

--- a/gazelle/python/testdata/import_with_same_srcs_library_and_binary/foo/script.py
+++ b/gazelle/python/testdata/import_with_same_srcs_library_and_binary/foo/script.py
@@ -1,0 +1,3 @@
+
+if __name__ == "__main__":
+    print("Hello, world!")

--- a/gazelle/python/testdata/import_with_same_srcs_library_and_binary/test.yaml
+++ b/gazelle/python/testdata/import_with_same_srcs_library_and_binary/test.yaml
@@ -1,0 +1,17 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+expect:
+  exit_code: 0


### PR DESCRIPTION
This PR ensures that py_binary rules are not indexed into Gazelle's IndexMap when there is a corresponding py_library rule with the same srcs. When both py_library and py_binary targets share the same file in their `srcs`, Gazelle previously indexed both under the same import path. This led to ambiguity and resolution errors, as Gazelle found multiple rules for the same language (py).

To resolve this, the PR updates Gazelle to skip indexing py_binary rules, allowing py_library to be the only import being indexed.

Testing
An integration test was added where both a py_library and a py_binary rule include the same script.py in their srcs. The test verifies that Gazelle correctly resolves the import to the py_library target.


