### PR TITLE
feat: implement less/greater operators for string for env marker evaluation

### DIFF
--- a/python/private/pypi/pep508_evaluate.bzl
+++ b/python/private/pypi/pep508_evaluate.bzl
@@ -344,6 +344,14 @@ def _env_expr(left, op, right):
         return left in right
     elif op == "not in":
         return left not in right
+    elif op == "<":
+        return left < right
+    elif op == "<=":
+        return left <= right
+    elif op == ">":
+        return left > right
+    elif op == ">=":
+        return left >= right
     else:
         return fail("TODO: op unsupported: '{}'".format(op))
 

--- a/tests/pypi/pep508/evaluate_tests.bzl
+++ b/tests/pypi/pep508/evaluate_tests.bzl
@@ -68,18 +68,28 @@ def _evaluate_non_version_env_tests(env):
 
         # When
         for input, want in {
-            "{} == 'osx'".format(var_name): True,
-            "{} != 'osx'".format(var_name): False,
-            "'osx' == {}".format(var_name): True,
             "'osx' != {}".format(var_name): False,
-            "'x' in {}".format(var_name): True,
+            "'osx' < {}".format(var_name): False,
+            "'osx' <= {}".format(var_name): True,
+            "'osx' == {}".format(var_name): True,
+            "'osx' >= {}".format(var_name): True,
             "'w' not in {}".format(var_name): True,
-        }.items():  # buildifier: @unsorted-dict-items
+            "'x' in {}".format(var_name): True,
+            "{} != 'osx'".format(var_name): False,
+            "{} < 'osx'".format(var_name): False,
+            "{} <= 'osx'".format(var_name): True,
+            "{} == 'osx'".format(var_name): True,
+            "{} > 'osx'".format(var_name): False,
+            "{} >= 'osx'".format(var_name): True,
+        }.items():
             got = evaluate(
                 input,
                 env = marker_env,
             )
-            env.expect.that_bool(got).equals(want)
+            env.expect.where(
+                expr = input,
+                env = marker_env,
+            ).that_bool(got).equals(want)
 
             # Check that the non-strict eval gives us back the input when no
             # env is supplied.


### PR DESCRIPTION
Right now, if two strings are compared, it results in an error.

Per spec, strings are suppose to "use the python behavior". Starlark is going
to use Java semantics underneath, but it should behave close enough for the (almost
exclusively) ASCII input that will be used.

Work towards https://github.com/bazel-contrib/rules_python/issues/2826