### PR TITLE
docs: doc version when RULES_PYTHON_ENABLE_PYSTAR was introduced

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -46,11 +46,19 @@ When `1`, the rules_python will warn users about deprecated functionality that w
 be removed in a subsequent major `rules_python` version. Defaults to `0` if unset.
 :::
 
-:::{envvar} RULES_PYTHON_ENABLE_PYSTAR
+::::{envvar} RULES_PYTHON_ENABLE_PYSTAR
 
 When `1`, the rules_python Starlark implementation of the core rules is used
-instead of the Bazel-builtin rules. Note this requires Bazel 7+.
+instead of the Bazel-builtin rules. Note this requires Bazel 7+. Defaults
+to `1`.
+
+:::{versionadded} 0.26.0
+Defaults to `0` if unspecified.
 :::
+:::{versionchanged} 0.40.0
+The default became `1` if unspecified
+:::
+::::
 
 ::::{envvar} RULES_PYTHON_EXTRACT_ROOT
 


### PR DESCRIPTION
While figuring out an upgrade from an old rules_python version, I had to look up when the
environment variable first became available.

Also note what version it defaulted to 1.