### PR TITLE
fix: configure coverage helpers for test exec group

### DIFF
--- a/python/private/attributes.bzl
+++ b/python/private/attributes.bzl
@@ -397,14 +397,14 @@ COVERAGE_ATTRS = {
     "_collect_cc_coverage": lambda: attrb.Label(
         default = "@bazel_tools//tools/test:collect_cc_coverage",
         executable = True,
-        cfg = "exec",
+        cfg = config.exec(exec_group = "test"),
     ),
     # Magic attribute to make coverage work. There's no
     # docs about this; see TestActionBuilder.java
     "_lcov_merger": lambda: attrb.Label(
         default = configuration_field(fragment = "coverage", name = "output_generator"),
         executable = True,
-        cfg = "exec",
+        cfg = config.exec(exec_group = "test"),
     ),
 }
 

--- a/python/private/py_executable.bzl
+++ b/python/private/py_executable.bzl
@@ -78,7 +78,6 @@ EXECUTABLE_ATTRS = dicts.add(
     AGNOSTIC_EXECUTABLE_ATTRS,
     PY_SRCS_ATTRS,
     IMPORTS_ATTRS,
-    COVERAGE_ATTRS,
     {
         "interpreter_args": lambda: attrb.StringList(
             doc = """
@@ -1903,7 +1902,7 @@ def create_executable_rule_builder(implementation, **kwargs):
     """
     builder = ruleb.Rule(
         implementation = implementation,
-        attrs = EXECUTABLE_ATTRS,
+        attrs = EXECUTABLE_ATTRS | (COVERAGE_ATTRS if kwargs.get("test") else {}),
         exec_groups = dict(REQUIRED_EXEC_GROUP_BUILDERS),  # Mutable copy
         fragments = ["py", "bazel_py"],
         provides = [PyExecutableInfo, PyInfo] + _MaybeBuiltinPyInfo,


### PR DESCRIPTION
They are run on the test action's execution platform, which is resolved for the `test` exec group, not the default one.

