### PR TITLE
fix: fix test analysis error on macOS arm64

### DIFF
--- a/python/private/pypi/pep508_env.bzl
+++ b/python/private/pypi/pep508_env.bzl
@@ -29,11 +29,13 @@ platform_machine_aliases = {
 
 # NOTE: There are many cpus, and unfortunately, the value isn't directly
 # accessible to Starlark. Using CcToolchain.cpu might work, though.
+# Some targets are aliases and are omitted below as their value is implied
+# by the target they resolve to.
 platform_machine_select_map = {
     "@platforms//cpu:aarch32": "aarch32",
     "@platforms//cpu:aarch64": "aarch64",
-    "@platforms//cpu:arm": "arm",
-    "@platforms//cpu:arm64": "arm64",
+    # @platforms//cpu:arm is an alias for @platforms//cpu:aarch32
+    # @platforms//cpu:arm64 is an alias for @platforms//cpu:aarch64
     "@platforms//cpu:arm64_32": "arm64_32",
     "@platforms//cpu:arm64e": "arm64e",
     "@platforms//cpu:armv6-m": "armv6-m",


### PR DESCRIPTION
Fixes:
```
ERROR: /Users/fmeum/git/rules_python/tests/pypi/env_marker_setting/BUILD.bazel:3:30: Illegal ambiguous match on configurable attribute "platform_machine" in //tests/pypi/env_marker_setting:test_expr_python_full_version_lt_negative_subject:
@@platforms//cpu:aarch64
@@platforms//cpu:arm64
Multiple matches are not allowed unless one is unambiguously more specialized or they resolve to the same value. See https://bazel.build/reference/be/functions#select.
```

Work towards #2850.
Work towards #2826.