### PR TITLE
fix: add target platform to extra exec platforms in analysis tests

### DIFF
--- a/tests/base_rules/py_executable_base_tests.bzl
+++ b/tests/base_rules/py_executable_base_tests.bzl
@@ -53,6 +53,7 @@ def _test_basic_windows(name, config):
             "//command_line_option:crosstool_top": CROSSTOOL_TOP,
             "//command_line_option:extra_toolchains": [CC_TOOLCHAIN],
             "//command_line_option:platforms": [WINDOWS_X86_64],
+            "//command_line_option:extra_execution_platforms": [WINDOWS_X86_64],
         },
         attr_values = {"target_compatible_with": target_compatible_with},
     )
@@ -98,6 +99,7 @@ def _test_basic_zip(name, config):
             "//command_line_option:crosstool_top": CROSSTOOL_TOP,
             "//command_line_option:extra_toolchains": [CC_TOOLCHAIN],
             "//command_line_option:platforms": [LINUX_X86_64],
+            "//command_line_option:extra_execution_platforms": [LINUX_X86_64],
         },
         attr_values = {"target_compatible_with": target_compatible_with},
     )

--- a/tests/base_rules/py_executable_base_tests.bzl
+++ b/tests/base_rules/py_executable_base_tests.bzl
@@ -51,9 +51,9 @@ def _test_basic_windows(name, config):
             "//command_line_option:build_python_zip": "true",
             "//command_line_option:cpu": "windows_x86_64",
             "//command_line_option:crosstool_top": CROSSTOOL_TOP,
+            "//command_line_option:extra_execution_platforms": [WINDOWS_X86_64],
             "//command_line_option:extra_toolchains": [CC_TOOLCHAIN],
             "//command_line_option:platforms": [WINDOWS_X86_64],
-            "//command_line_option:extra_execution_platforms": [WINDOWS_X86_64],
         },
         attr_values = {"target_compatible_with": target_compatible_with},
     )
@@ -97,9 +97,9 @@ def _test_basic_zip(name, config):
             "//command_line_option:build_python_zip": "true",
             "//command_line_option:cpu": "linux_x86_64",
             "//command_line_option:crosstool_top": CROSSTOOL_TOP,
+            "//command_line_option:extra_execution_platforms": [LINUX_X86_64],
             "//command_line_option:extra_toolchains": [CC_TOOLCHAIN],
             "//command_line_option:platforms": [LINUX_X86_64],
-            "//command_line_option:extra_execution_platforms": [LINUX_X86_64],
         },
         attr_values = {"target_compatible_with": target_compatible_with},
     )

--- a/tests/base_rules/py_test/py_test_tests.bzl
+++ b/tests/base_rules/py_test/py_test_tests.bzl
@@ -61,6 +61,7 @@ def _test_mac_requires_darwin_for_execution(name, config):
             "//command_line_option:crosstool_top": CROSSTOOL_TOP,
             "//command_line_option:extra_toolchains": CC_TOOLCHAIN,
             "//command_line_option:platforms": [MAC_X86_64],
+            "//command_line_option:extra_execution_platforms": [MAC_X86_64],
         },
         attr_values = _SKIP_WINDOWS,
     )
@@ -94,6 +95,7 @@ def _test_non_mac_doesnt_require_darwin_for_execution(name, config):
             "//command_line_option:crosstool_top": CROSSTOOL_TOP,
             "//command_line_option:extra_toolchains": CC_TOOLCHAIN,
             "//command_line_option:platforms": [LINUX_X86_64],
+            "//command_line_option:extra_execution_platforms": [LINUX_X86_64],
         },
         attr_values = _SKIP_WINDOWS,
     )

--- a/tests/base_rules/py_test/py_test_tests.bzl
+++ b/tests/base_rules/py_test/py_test_tests.bzl
@@ -59,9 +59,9 @@ def _test_mac_requires_darwin_for_execution(name, config):
         config_settings = {
             "//command_line_option:cpu": "darwin_x86_64",
             "//command_line_option:crosstool_top": CROSSTOOL_TOP,
+            "//command_line_option:extra_execution_platforms": [MAC_X86_64],
             "//command_line_option:extra_toolchains": CC_TOOLCHAIN,
             "//command_line_option:platforms": [MAC_X86_64],
-            "//command_line_option:extra_execution_platforms": [MAC_X86_64],
         },
         attr_values = _SKIP_WINDOWS,
     )
@@ -93,9 +93,9 @@ def _test_non_mac_doesnt_require_darwin_for_execution(name, config):
         config_settings = {
             "//command_line_option:cpu": "k8",
             "//command_line_option:crosstool_top": CROSSTOOL_TOP,
+            "//command_line_option:extra_execution_platforms": [LINUX_X86_64],
             "//command_line_option:extra_toolchains": CC_TOOLCHAIN,
             "//command_line_option:platforms": [LINUX_X86_64],
-            "//command_line_option:extra_execution_platforms": [LINUX_X86_64],
         },
         attr_values = _SKIP_WINDOWS,
     )


### PR DESCRIPTION
This is required as of https://github.com/bazelbuild/bazel/commit/2780393d35ad0607cf5e344ae082b00a5569a964 as tests now require an execution platform that matches their target constraints by default.

Fixes #2850
