### PR TITLE
WIP add custom shebang on py_console_script_binary

### DIFF
--- a/python/private/py_console_script_binary.bzl
+++ b/python/private/py_console_script_binary.bzl
@@ -52,6 +52,7 @@ def py_console_script_binary(
         entry_points_txt = None,
         script = None,
         binary_rule = py_binary,
+        shebang = None,
         **kwargs):
     """Generate a py_binary for a console_script entry_point.
 
@@ -68,6 +69,8 @@ def py_console_script_binary(
         binary_rule: {any}`rule callable`, The rule/macro to use to instantiate
             the target. It's expected to behave like {any}`py_binary`.
             Defaults to {any}`py_binary`.
+        shebang: [`str`], The shebang to use for the entry point python file.
+            Defaults to empty string.
         **kwargs: Extra parameters forwarded to `binary_rule`.
     """
     main = "rules_python_entry_point_{}.py".format(name)
@@ -81,6 +84,7 @@ def py_console_script_binary(
         out = main,
         console_script = script,
         console_script_guess = name,
+        shebang = shebang,
         visibility = ["//visibility:private"],
     )
 

--- a/python/private/py_console_script_gen.bzl
+++ b/python/private/py_console_script_gen.bzl
@@ -42,6 +42,7 @@ def _py_console_script_gen_impl(ctx):
     args = ctx.actions.args()
     args.add("--console-script", ctx.attr.console_script)
     args.add("--console-script-guess", ctx.attr.console_script_guess)
+    args.add("--shebang", ctx.attr.shebang)
     args.add(entry_points_txt)
     args.add(ctx.outputs.out)
 
@@ -80,6 +81,10 @@ py_console_script_gen = rule(
         "out": attr.output(
             doc = "Output file location.",
             mandatory = True,
+        ),
+        "shebang": attr.string(
+            doc = "The shebang to use for the entry point python file.",
+            default = "",
         ),
         "_tool": attr.label(
             default = ":py_console_script_gen_py",

--- a/python/private/py_console_script_gen.py
+++ b/python/private/py_console_script_gen.py
@@ -44,6 +44,8 @@ import textwrap
 _ENTRY_POINTS_TXT = "entry_points.txt"
 
 _TEMPLATE = """\
+{shebang}
+
 import sys
 
 # See @rules_python//python/private:py_console_script_gen.py for explanation
@@ -87,6 +89,7 @@ def run(
     out: pathlib.Path,
     console_script: str,
     console_script_guess: str,
+    shebang: str = "#!/usr/bin/env python3",
 ):
     """Run the generator
 
@@ -94,6 +97,8 @@ def run(
         entry_points: The entry_points.txt file to be parsed.
         out: The output file.
         console_script: The console_script entry in the entry_points.txt file.
+        console_script_guess: The string used for guessing the console_script if it is not provided.
+        shebang: The shebang to use for the entry point python file. Defaults to "#!/usr/bin/env python3".
     """
     config = EntryPointsParser()
     config.read(entry_points)
@@ -136,6 +141,7 @@ def run(
     with open(out, "w") as f:
         f.write(
             _TEMPLATE.format(
+                shebang=shebang,
                 module=module,
                 attr=attr,
                 entry_point=entry_point,
@@ -153,6 +159,11 @@ def main():
         "--console-script-guess",
         required=True,
         help="The string used for guessing the console_script if it is not provided.",
+    )
+    parser.add_argument(
+        "--shebang",
+        default="#!/usr/bin/env python3",
+        help="The shebang to use for the entry point python file.",
     )
     parser.add_argument(
         "entry_points",
@@ -173,6 +184,7 @@ def main():
         out=args.out,
         console_script=args.console_script,
         console_script_guess=args.console_script_guess,
+        shebang=args.shebang,
     )
 
 


### PR DESCRIPTION
This functionality came with wheel entry points, but if one uses py_console_script_binary, they're unable to use it with a shebang.