### PR TITLE
Fix whl_library file path inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ END_UNRELEASED_TEMPLATE
   various URL formats - URL encoded version strings get correctly resolved, sha256 value can be
   also retrieved from the URL as opposed to only the `--hash` parameter. Fixes
   [#2363](https://github.com/bazel-contrib/rules_python/issues/2363).
+* (pypi) `whl_library` now infers file names from its `urls` attribute correctly.
 
 {#v0-0-0-added}
 ### Added

--- a/python/private/pypi/whl_library.bzl
+++ b/python/private/pypi/whl_library.bzl
@@ -277,7 +277,7 @@ def _whl_library_impl(rctx):
             fail("could not download the '{}' from {}:\n{}".format(filename, urls, result))
 
         if filename.endswith(".whl"):
-            whl_path = rctx.path(rctx.attr.filename)
+            whl_path = rctx.path(filename)
         else:
             # It is an sdist and we need to tell PyPI to use a file in this directory
             # and, allow getting build dependencies from PYTHONPATH, which we


### PR DESCRIPTION
When given .whl file URLs and no file name, `whl_library` writes the
wheel it downloads to a file with the same file name as the first URL's.
But then at extraction time, it always consults ctx.attr.filename
for that file name, leading to failure when that attribute is None.
This patch should fix that.

Related #2363