### PR TITLE
feat: allow custom platform when overriding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,10 @@ END_UNRELEASED_TEMPLATE
 * (pypi) Starlark-based evaluation of environment markers (requirements.txt conditionals)
   available (not enabled by default) for improved multi-platform build support.
   Set the `RULES_PYTHON_ENABLE_PIPSTAR=1` environment variable to enable it.
+* (toolchains) Arbitrary python-build-standalone runtimes can be registered
+  and activated with custom flags. See the [Registering custom runtimes]
+  docs and {obj}`single_version_platform_override()` API docs for more
+  information.
 
 {#v0-0-0-removed}
 ### Removed

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -126,6 +126,25 @@ dev_python.override(
     register_all_versions = True,
 )
 
+# Necessary so single_platform_override with a new version works
+dev_python.toolchain(python_version = "3.13.3")
+
+# For testing an arbitrary runtime triggered by a custom flag.
+# See //tests/toolchains:custom_platform_toolchain_test
+dev_python.single_version_platform_override(
+    platform = "linux-x86-install-only-stripped",
+    python_version = "3.13.3",
+    sha256 = "01d08b9bc8a96698b9d64c2fc26da4ecc4fa9e708ce0a34fb88f11ab7e552cbd",
+    target_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    target_settings = [
+        "@@//tests/support:is_custom_runtime_linux-x86-install-only-stripped",
+    ],
+    urls = ["https://github.com/astral-sh/python-build-standalone/releases/download/20250409/cpython-3.13.3+20250409-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"],
+)
+
 dev_pip = use_extension(
     "//python/extensions:pip.bzl",
     "pip",

--- a/docs/toolchains.md
+++ b/docs/toolchains.md
@@ -236,6 +236,79 @@ existing attributes:
 * Adding additional Python versions via {bzl:obj}`python.single_version_override` or
   {bzl:obj}`python.single_version_platform_override`.
 
+### Registering custom runtimes
+
+Because the python-build-standalone project has _thousands_ of prebuilt runtimes
+available, rules_python only includes popular runtimes in its built in
+configurations. If you want to use a runtime that isn't already known to
+rules_python then {obj}`single_version_platform_override()` can be used to do
+so. In short, it allows specifying an arbitrary URL and using custom flags
+to control when a runtime is used.
+
+In the example below, we register a particular python-build-standalone runtime
+that is activated for Linux x86 builds when the custom flag
+`--//:runtime=my-custom-runtime` is set.
+
+```
+# File: MODULE.bazel
+bazel_dep(name = "bazel_skylib", version = "1.7.1.")
+bazel_dep(name = "rules_python", version = "1.5.0")
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(python_version="3.13.3")
+python.single_version_platform_override(
+    platform = "my-platform",
+    python_version = "3.13.3",
+    sha256 = "01d08b9bc8a96698b9d64c2fc26da4ecc4fa9e708ce0a34fb88f11ab7e552cbd",
+    target_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    target_settings = [
+        "@@//:runtime=my-custom-runtime",
+    ],
+    urls = ["https://github.com/astral-sh/python-build-standalone/releases/download/20250409/cpython-3.13.3+20250409-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"],
+)
+
+# File: //:BUILD.bazel
+
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+string_flag(
+    name = "custom_runtime",
+    build_setting_default = "",
+)
+
+config_setting(
+    name = "is_custom_runtime_linux-x86-install-only-stripped",
+    flag_values = {
+        ":custom_runtime": "linux-x86-install-only-stripped",
+    },
+)
+```
+
+Notes:
+- While any URL and archive can be used, it's assumed their content looks how
+  a python-build-standalone archive looks.
+- `python.toolchain()` is required if the version is unknown; if the version
+  is already known, it can be omitted.
+- A "version aware" toolchain is registered, which means the Python version flag
+  must also match (e.g. `--@rules_python//python/config_settings:python_version=3.13.3`
+  must be set -- see `minor_mapping` and `is_default` for controls and docs
+  about version matching and selection).
+- The labels in `target_settings` must be absolute; `@@` refers to the main repo.
+- The `target_settings` are `config_setting` targets, which means you can
+  customize how matching occurs.
+
+:::{seealso}
+See {obj}`//python/config_settings` for flags rules_python already defines
+that can be used with `target_settings`. Some particular ones of note are:
+{flag}`--py_linux_libc` and {flag}`--py_freethreaded`, among others.
+:::
+
+:::{versionadded} VERSION_NEXT_FEATURE
+Added support for custom platform names, `target_compatible_with`, and
+`target_settings` with `single_version_platform_override`.
+:::
+
 ### Using defined toolchains from WORKSPACE
 
 It is possible to use toolchains defined in `MODULE.bazel` in `WORKSPACE`. For example

--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -247,6 +247,7 @@ bzl_library(
     name = "versions_bzl",
     srcs = ["versions.bzl"],
     visibility = ["//:__subpackages__"],
+    deps = ["//python/private:platform_info_bzl"],
 )
 
 # NOTE: Remember to add bzl_library targets to //tests:bzl_libraries

--- a/python/private/BUILD.bazel
+++ b/python/private/BUILD.bazel
@@ -242,10 +242,16 @@ bzl_library(
 )
 
 bzl_library(
+    name = "platform_info_bzl",
+    srcs = ["platform_info.bzl"],
+)
+
+bzl_library(
     name = "python_bzl",
     srcs = ["python.bzl"],
     deps = [
         ":full_version_bzl",
+        ":platform_info_bzl",
         ":python_register_toolchains_bzl",
         ":pythons_hub_bzl",
         ":repo_utils_bzl",

--- a/python/private/platform_info.bzl
+++ b/python/private/platform_info.bzl
@@ -1,0 +1,34 @@
+"""Helper to define a struct used to define platform metadata."""
+
+def platform_info(
+        *,
+        compatible_with = [],
+        flag_values = {},
+        target_settings = [],
+        os_name,
+        arch):
+    """Creates a struct of platform metadata.
+
+    This is just a helper to ensure structs are created the same and
+    the meaning/values are documented.
+
+    Args:
+        compatible_with: list[str], where the values are string labels. These
+            are the target_compatible_with values to use with the toolchain
+        flag_values: dict[str|Label, Any] of config_setting.flag_values
+            compatible values. DEPRECATED -- use target_settings instead
+        target_settings: list[str], where the values are string labels. These
+            are the target_settings values to use with the toolchain.
+        os_name: str, the os name; must match the name used in `@platfroms//os`
+        arch: str, the cpu name; must match the name used in `@platforms//cpu`
+
+    Returns:
+        A struct with attributes and values matching the args.
+    """
+    return struct(
+        compatible_with = compatible_with,
+        flag_values = flag_values,
+        target_settings = target_settings,
+        os_name = os_name,
+        arch = arch,
+    )

--- a/python/private/python_register_toolchains.bzl
+++ b/python/private/python_register_toolchains.bzl
@@ -42,6 +42,7 @@ def python_register_toolchains(
         set_python_version_constraint = False,
         tool_versions = None,
         minor_mapping = None,
+        platforms = PLATFORMS,
         **kwargs):
     """Convenience macro for users which does typical setup.
 
@@ -72,6 +73,10 @@ def python_register_toolchains(
             python/versions.bzl will be used.
         minor_mapping: {type}`dict[str, str]` contains a mapping from `X.Y` to `X.Y.Z`
             version.
+        platforms: {type}`dict[str, platform_info}` The mapping of platforms to create
+            toolchains for. The `platform_info` values are structs from
+            `python/versions.bzl#platform_info`. Platforms are only created if
+            sufficient info exists in `tool_versions`.
         **kwargs: passed to each {obj}`python_repository` call.
 
     Returns:
@@ -105,7 +110,7 @@ def python_register_toolchains(
             register_coverage_tool = False
 
     loaded_platforms = []
-    for platform in PLATFORMS.keys():
+    for platform in platforms.keys():
         sha256 = tool_versions[python_version]["sha256"].get(platform, None)
         if not sha256:
             continue

--- a/python/private/python_repository.bzl
+++ b/python/private/python_repository.bzl
@@ -15,7 +15,7 @@
 """This file contains repository rules and macros to support toolchain registration.
 """
 
-load("//python:versions.bzl", "FREETHREADED", "INSTALL_ONLY", "PLATFORMS")
+load("//python:versions.bzl", "FREETHREADED", "INSTALL_ONLY")
 load(":auth.bzl", "get_auth")
 load(":repo_utils.bzl", "REPO_DEBUG_ENV_VAR", "repo_utils")
 load(":text_util.bzl", "render")
@@ -327,7 +327,6 @@ function defaults (e.g. `single_version_override` for `MODULE.bazel` files.
         "platform": attr.string(
             doc = "The platform name for the Python interpreter tarball.",
             mandatory = True,
-            values = PLATFORMS.keys(),
         ),
         "python_version": attr.string(
             doc = "The Python version.",

--- a/python/versions.bzl
+++ b/python/versions.bzl
@@ -15,6 +15,8 @@
 """The Python versions we use for the toolchains.
 """
 
+load("//python/private:platform_info.bzl", "platform_info")
+
 # Values present in the @platforms//os package
 MACOS_NAME = "osx"
 LINUX_NAME = "linux"
@@ -682,42 +684,12 @@ MINOR_MAPPING = {
     "3.13": "3.13.2",
 }
 
-def _platform_info(
-        *,
-        compatible_with = [],
-        flag_values = {},
-        target_settings = [],
-        os_name,
-        arch):
-    """Creates a struct of platform metadata.
-
-    Args:
-        compatible_with: list[str], where the values are string labels. These
-            are the target_compatible_with values to use with the toolchain
-        flag_values: dict[str|Label, Any] of config_setting.flag_values
-            compatible values. DEPRECATED -- use target_settings instead
-        target_settings: list[str], where the values are string labels. These
-            are the target_settings values to use with the toolchain.
-        os_name: str, the os name; must match the name used in `@platfroms//os`
-        arch: str, the cpu name; must match the name used in `@platforms//cpu`
-
-    Returns:
-        A struct with attributes and values matching the args.
-    """
-    return struct(
-        compatible_with = compatible_with,
-        flag_values = flag_values,
-        target_settings = target_settings,
-        os_name = os_name,
-        arch = arch,
-    )
-
 def _generate_platforms():
     is_libc_glibc = str(Label("//python/config_settings:_is_py_linux_libc_glibc"))
     is_libc_musl = str(Label("//python/config_settings:_is_py_linux_libc_musl"))
 
     platforms = {
-        "aarch64-apple-darwin": _platform_info(
+        "aarch64-apple-darwin": platform_info(
             compatible_with = [
                 "@platforms//os:macos",
                 "@platforms//cpu:aarch64",
@@ -725,7 +697,7 @@ def _generate_platforms():
             os_name = MACOS_NAME,
             arch = "aarch64",
         ),
-        "aarch64-unknown-linux-gnu": _platform_info(
+        "aarch64-unknown-linux-gnu": platform_info(
             compatible_with = [
                 "@platforms//os:linux",
                 "@platforms//cpu:aarch64",
@@ -736,7 +708,7 @@ def _generate_platforms():
             os_name = LINUX_NAME,
             arch = "aarch64",
         ),
-        "armv7-unknown-linux-gnu": _platform_info(
+        "armv7-unknown-linux-gnu": platform_info(
             compatible_with = [
                 "@platforms//os:linux",
                 "@platforms//cpu:armv7",
@@ -747,7 +719,7 @@ def _generate_platforms():
             os_name = LINUX_NAME,
             arch = "arm",
         ),
-        "i386-unknown-linux-gnu": _platform_info(
+        "i386-unknown-linux-gnu": platform_info(
             compatible_with = [
                 "@platforms//os:linux",
                 "@platforms//cpu:i386",
@@ -758,7 +730,7 @@ def _generate_platforms():
             os_name = LINUX_NAME,
             arch = "x86_32",
         ),
-        "ppc64le-unknown-linux-gnu": _platform_info(
+        "ppc64le-unknown-linux-gnu": platform_info(
             compatible_with = [
                 "@platforms//os:linux",
                 "@platforms//cpu:ppc",
@@ -769,7 +741,7 @@ def _generate_platforms():
             os_name = LINUX_NAME,
             arch = "ppc",
         ),
-        "riscv64-unknown-linux-gnu": _platform_info(
+        "riscv64-unknown-linux-gnu": platform_info(
             compatible_with = [
                 "@platforms//os:linux",
                 "@platforms//cpu:riscv64",
@@ -780,7 +752,7 @@ def _generate_platforms():
             os_name = LINUX_NAME,
             arch = "riscv64",
         ),
-        "s390x-unknown-linux-gnu": _platform_info(
+        "s390x-unknown-linux-gnu": platform_info(
             compatible_with = [
                 "@platforms//os:linux",
                 "@platforms//cpu:s390x",
@@ -791,7 +763,7 @@ def _generate_platforms():
             os_name = LINUX_NAME,
             arch = "s390x",
         ),
-        "x86_64-apple-darwin": _platform_info(
+        "x86_64-apple-darwin": platform_info(
             compatible_with = [
                 "@platforms//os:macos",
                 "@platforms//cpu:x86_64",
@@ -799,7 +771,7 @@ def _generate_platforms():
             os_name = MACOS_NAME,
             arch = "x86_64",
         ),
-        "x86_64-pc-windows-msvc": _platform_info(
+        "x86_64-pc-windows-msvc": platform_info(
             compatible_with = [
                 "@platforms//os:windows",
                 "@platforms//cpu:x86_64",
@@ -807,7 +779,7 @@ def _generate_platforms():
             os_name = WINDOWS_NAME,
             arch = "x86_64",
         ),
-        "x86_64-unknown-linux-gnu": _platform_info(
+        "x86_64-unknown-linux-gnu": platform_info(
             compatible_with = [
                 "@platforms//os:linux",
                 "@platforms//cpu:x86_64",
@@ -818,7 +790,7 @@ def _generate_platforms():
             os_name = LINUX_NAME,
             arch = "x86_64",
         ),
-        "x86_64-unknown-linux-musl": _platform_info(
+        "x86_64-unknown-linux-musl": platform_info(
             compatible_with = [
                 "@platforms//os:linux",
                 "@platforms//cpu:x86_64",
@@ -834,7 +806,7 @@ def _generate_platforms():
     is_freethreaded_yes = str(Label("//python/config_settings:_is_py_freethreaded_yes"))
     is_freethreaded_no = str(Label("//python/config_settings:_is_py_freethreaded_no"))
     return {
-        p + suffix: _platform_info(
+        p + suffix: platform_info(
             compatible_with = v.compatible_with,
             target_settings = [
                 freethreadedness,

--- a/tests/support/BUILD.bazel
+++ b/tests/support/BUILD.bazel
@@ -18,6 +18,7 @@
 # to force them to resolve in the proper context.
 # ====================
 
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load(":sh_py_run_test.bzl", "current_build_settings")
 
 package(
@@ -89,4 +90,16 @@ platform(
 
 current_build_settings(
     name = "current_build_settings",
+)
+
+string_flag(
+    name = "custom_runtime",
+    build_setting_default = "",
+)
+
+config_setting(
+    name = "is_custom_runtime_linux-x86-install-only-stripped",
+    flag_values = {
+        ":custom_runtime": "linux-x86-install-only-stripped",
+    },
 )

--- a/tests/support/sh_py_run_test.bzl
+++ b/tests/support/sh_py_run_test.bzl
@@ -32,25 +32,24 @@ def _perform_transition_impl(input_settings, attr, base_impl):
 
     settings[VISIBLE_FOR_TESTING] = True
     settings["//command_line_option:build_python_zip"] = attr.build_python_zip
-    if attr.bootstrap_impl:
-        settings["//python/config_settings:bootstrap_impl"] = attr.bootstrap_impl
-    if attr.extra_toolchains:
-        settings["//command_line_option:extra_toolchains"] = attr.extra_toolchains
-    if attr.python_src:
-        settings["//python/bin:python_src"] = attr.python_src
-    if attr.venvs_use_declare_symlink:
-        settings["//python/config_settings:venvs_use_declare_symlink"] = attr.venvs_use_declare_symlink
-    if attr.venvs_site_packages:
-        settings["//python/config_settings:venvs_site_packages"] = attr.venvs_site_packages
+
+    for attr_name, setting_label in _RECONFIG_ATTR_SETTING_MAP.items():
+        if getattr(attr, attr_name):
+            settings[setting_label] = getattr(attr, attr_name)
     return settings
 
-_RECONFIG_INPUTS = [
-    "//python/config_settings:bootstrap_impl",
-    "//python/bin:python_src",
-    "//command_line_option:extra_toolchains",
-    "//python/config_settings:venvs_use_declare_symlink",
-    "//python/config_settings:venvs_site_packages",
-]
+# Attributes that, if non-falsey (`if attr.<name>`), will copy their
+# value into the output settings
+_RECONFIG_ATTR_SETTING_MAP = {
+    "bootstrap_impl": "//python/config_settings:bootstrap_impl",
+    "custom_runtime": "//tests/support:custom_runtime",
+    "extra_toolchains": "//command_line_option:extra_toolchains",
+    "python_src": "//python/bin:python_src",
+    "venvs_site_packages": "//python/config_settings:venvs_site_packages",
+    "venvs_use_declare_symlink": "//python/config_settings:venvs_use_declare_symlink",
+}
+
+_RECONFIG_INPUTS = _RECONFIG_ATTR_SETTING_MAP.values()
 _RECONFIG_OUTPUTS = _RECONFIG_INPUTS + [
     "//command_line_option:build_python_zip",
     VISIBLE_FOR_TESTING,
@@ -60,6 +59,7 @@ _RECONFIG_INHERITED_OUTPUTS = [v for v in _RECONFIG_OUTPUTS if v in _RECONFIG_IN
 _RECONFIG_ATTRS = {
     "bootstrap_impl": attrb.String(),
     "build_python_zip": attrb.String(default = "auto"),
+    "custom_runtime": attrb.String(),
     "extra_toolchains": attrb.StringList(
         doc = """
 Value for the --extra_toolchains flag.

--- a/tests/toolchains/BUILD.bazel
+++ b/tests/toolchains/BUILD.bazel
@@ -12,8 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//tests/support:sh_py_run_test.bzl", "py_reconfig_test")
 load(":defs.bzl", "define_toolchain_tests")
 
 define_toolchain_tests(
     name = "toolchain_tests",
+)
+
+py_reconfig_test(
+    name = "custom_platform_toolchain_test",
+    srcs = ["custom_platform_toolchain_test.py"],
+    custom_runtime = "linux-x86-install-only-stripped",
+    python_version = "3.13.3",
+    target_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
 )

--- a/tests/toolchains/custom_platform_toolchain_test.py
+++ b/tests/toolchains/custom_platform_toolchain_test.py
@@ -1,0 +1,15 @@
+import sys
+import unittest
+
+
+class VerifyCustomPlatformToolchainTest(unittest.TestCase):
+
+    def test_custom_platform_interpreter_used(self):
+        # We expect the repo name, and thus path, to have the
+        # platform name in it.
+        self.assertIn("linux-x86-install-only-stripped", sys._base_executable)
+        print(sys._base_executable)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This basically allows using any python-build-standalone archive and using it
if custom flags are set. This is done through the `single_version_platform_override()`
API, because such archives are inherently version and platform specific.

Key changes:
* The `platform` arg can be any value (mostly; it ends up in repo names)
* Added `target_compatible_with` and `target_settings` args, which become the
  settings used on the generated toolchain() definition.

The platform settings are version specific, i.e. the key `(python_version, platform)`
is what maps to the TCW/TS values.

If an existing platform is used, it'll override the defaults that normally come
from the PLATFORMS global for the particular version. If a new platform is used,
it creates a new platform entry with those settings.

Along the way:
* Added various docs about internal variables so they're easier to grok at a glance.

Work towards https://github.com/bazel-contrib/rules_python/issues/2081