### PR TITLE
refactor: have bzlmod pass platforms to python_register_toolchains

### DIFF
--- a/tests/python/python_tests.bzl
+++ b/tests/python/python_tests.bzl
@@ -149,6 +149,7 @@ def _test_default(env):
         "base_url",
         "ignore_root_user_error",
         "tool_versions",
+        "platforms",
     ])
     env.expect.that_bool(py.config.default["ignore_root_user_error"]).equals(True)
     env.expect.that_str(py.default_python_version).equals("3.11")


### PR DESCRIPTION
This is to facilitate eventually allowing overrides to add additional platforms.

Instead of the PLATFORMS global being used, the python bzlmod extension passing the
mapping directly to python_register_toolchains, then receives back the subset of
platforms that had repos defined. That subset is then later used when (re)constructing
the list of repo names for the toolchains.