### PR TITLE
cleanup: remove unused sanitize_platform_name function

### DIFF
--- a/python/private/toolchains_repo.bzl
+++ b/python/private/toolchains_repo.bzl
@@ -404,9 +404,6 @@ multi_toolchain_aliases = repository_rule(
     },
 )
 
-def sanitize_platform_name(platform):
-    return platform.replace("-", "_")
-
 def _get_host_platform(*, rctx, logger, python_version, os_name, cpu_name, platforms):
     """Gets the host platform.
 


### PR DESCRIPTION
The sanitize_platform_name function is unused, so remove it.