### PR TITLE
refactor: make bzlmod create host repos for toolchains

### DIFF
--- a/python/private/python.bzl
+++ b/python/private/python.bzl
@@ -315,6 +315,12 @@ def _python_impl(module_ctx):
                 # The last toolchain is the default; it can't have version constraints
                 set_python_version_constraint = is_last,
             ))
+            if _is_compatible_with_host(mctx, platform_info):
+                host_toolchain(
+                    name = toolchain_info.name,
+                    platforms = [platform_name],
+                    python_version = full_python_version,
+                )
 
     # List of the base names ("python_3_10") for the toolchain repos
     base_toolchain_repo_names = []
@@ -405,6 +411,11 @@ def _python_impl(module_ctx):
         return module_ctx.extension_metadata(reproducible = True)
     else:
         return None
+
+def _is_compatible_with_host(mctx, platform_info):
+    os_name = repo_utils.get_platforms_os_name(rctx)
+    cpu_name = repo_utils.get_platforms_cpu_name(rctx)
+    return platform_info.os_name == os_name and platform_info.arch == cpu_name
 
 def _one_or_the_same(first, second, *, onerror = None):
     if not first:

--- a/python/private/python.bzl
+++ b/python/private/python.bzl
@@ -21,7 +21,7 @@ load(":full_version.bzl", "full_version")
 load(":python_register_toolchains.bzl", "python_register_toolchains")
 load(":pythons_hub.bzl", "hub_repo")
 load(":repo_utils.bzl", "repo_utils")
-load(":toolchains_repo.bzl", "multi_toolchain_aliases")
+load(":toolchains_repo.bzl", "host_toolchain", "multi_toolchain_aliases")
 load(":util.bzl", "IS_BAZEL_6_4_OR_HIGHER")
 load(":version.bzl", "version")
 
@@ -298,6 +298,7 @@ def _python_impl(module_ctx):
             _internal_bzlmod_toolchain_call = True,
             **kwargs
         )
+        host_compatible = []
         for repo_name, (platform_name, platform_info) in register_result.impl_repos.items():
             toolchain_impls.append(struct(
                 # str: The base name to use for the toolchain() target
@@ -315,12 +316,15 @@ def _python_impl(module_ctx):
                 # The last toolchain is the default; it can't have version constraints
                 set_python_version_constraint = is_last,
             ))
-            if _is_compatible_with_host(mctx, platform_info):
-                host_toolchain(
-                    name = toolchain_info.name,
-                    platforms = [platform_name],
-                    python_version = full_python_version,
-                )
+            if _is_compatible_with_host(module_ctx, platform_info):
+                host_compatible.append(platform_name)
+
+        host_toolchain(
+            name = toolchain_info.name + "_host",
+            # NOTE: Order matters. The first found to be compatible is (usually) used.
+            platforms = host_compatible,
+            python_version = full_python_version,
+        )
 
     # List of the base names ("python_3_10") for the toolchain repos
     base_toolchain_repo_names = []
@@ -413,8 +417,8 @@ def _python_impl(module_ctx):
         return None
 
 def _is_compatible_with_host(mctx, platform_info):
-    os_name = repo_utils.get_platforms_os_name(rctx)
-    cpu_name = repo_utils.get_platforms_cpu_name(rctx)
+    os_name = repo_utils.get_platforms_os_name(mctx)
+    cpu_name = repo_utils.get_platforms_cpu_name(mctx)
     return platform_info.os_name == os_name and platform_info.arch == cpu_name
 
 def _one_or_the_same(first, second, *, onerror = None):

--- a/python/private/python_register_toolchains.bzl
+++ b/python/private/python_register_toolchains.bzl
@@ -170,12 +170,6 @@ def python_register_toolchains(
                 platform = platform,
             ))
 
-    host_toolchain(
-        name = name + "_host",
-        platforms = loaded_platforms,
-        python_version = python_version,
-    )
-
     toolchain_aliases(
         name = name,
         python_version = python_version,
@@ -183,12 +177,18 @@ def python_register_toolchains(
         platforms = loaded_platforms,
     )
 
-    # in bzlmod we write out our own toolchain repos
+    # in bzlmod we write out our own toolchain repos and host repos
     if bzlmod_toolchain_call:
         return struct(
             # dict[str name, tuple[str platform_name, platform_info]]
             impl_repos = impl_repos,
         )
+
+    host_toolchain(
+        name = name + "_host",
+        platforms = loaded_platforms,
+        python_version = python_version,
+    )
 
     toolchains_repo(
         name = toolchain_repo_name,

--- a/python/private/toolchains_repo.bzl
+++ b/python/private/toolchains_repo.bzl
@@ -375,6 +375,8 @@ def _host_toolchain_impl(rctx):
     if not rctx.delete(python_tester):
         fail("Failed to delete the python tester")
 
+# NOTE: The term "toolchain" is a misnomer for this rule. This doesn't define
+# a repo with toolchains or toolchain implementations.
 host_toolchain = repository_rule(
     _host_toolchain_impl,
     doc = """\


### PR DESCRIPTION
This moves the creation of the host_toolchain repos into the bzlmod phase.

This is to facilitate future work to allow for when a a particular version
doesn't provide a host-compatible variant

Work towards https://github.com/bazel-contrib/rules_python/issues/2081