### PR TITLE
sphinxdocs: make xrefs to tag class attributes using attr role work

### DIFF
--- a/sphinxdocs/src/sphinx_bzl/bzl.py
+++ b/sphinxdocs/src/sphinx_bzl/bzl.py
@@ -1156,10 +1156,10 @@ class _BzlTagClass(_BzlCallable):
 
     doc_field_types = [
         _BzlGroupedField(
-            "arg",
+            "attr",
             label=_("Attributes"),
             names=["attr"],
-            rolename="arg",
+            rolename="attr",
             can_collapse=False,
         ),
     ]

--- a/sphinxdocs/tests/sphinx_stardoc/sphinx_output_test.py
+++ b/sphinxdocs/tests/sphinx_stardoc/sphinx_output_test.py
@@ -63,6 +63,7 @@ class SphinxOutputTest(parameterized.TestCase):
         ("full_repo_provider", "@testrepo//lang:provider.bzl%LangInfo", "provider.html#LangInfo"),
         ("full_repo_aspect", "@testrepo//lang:aspect.bzl%myaspect", "aspect.html#myaspect"),
         ("full_repo_target", "@testrepo//lang:relativetarget", "target.html#relativetarget"),
+        ("tag_class_attr_using_attr_role", "myext.mytag.ta1", "module_extension.html#myext.mytag.ta1"),
         # fmt: on
     )
     def test_xrefs(self, text, href):

--- a/sphinxdocs/tests/sphinx_stardoc/xrefs.md
+++ b/sphinxdocs/tests/sphinx_stardoc/xrefs.md
@@ -41,3 +41,7 @@ Various tests of cross referencing support
 ## Any xref
 
 * {any}`LangInfo`
+
+## Tag class refs
+
+* tag class attribute using attr role: {attr}`myext.mytag.ta1`


### PR DESCRIPTION
The role assigned to attributes within the tag class directive were being given the
role `arg`, when they should be `attr`. This caused xrefs using the attr role to
be unable to find them.

To fix, set them to have the correct role, like the repo rule and regular rule
directives do. Also add a test.