### PR TITLE
sphinxdocs: allow unqualified arg/attr name for xref

### DIFF
--- a/sphinxdocs/src/sphinx_bzl/bzl.py
+++ b/sphinxdocs/src/sphinx_bzl/bzl.py
@@ -390,8 +390,12 @@ class _BzlXrefField(docfields.Field):
                     descr=index_description,
                 ),
             ),
-            # This allows referencing an arg as e.g `funcname.argname`
-            alt_names=[anchor_id],
+            alt_names=[
+                # This allows referencing an arg as e.g `funcname.argname`
+                anchor_id,
+                # This allows referencing an arg as simply `argname`
+                arg_name
+            ],
         )
 
         # Two changes to how arg xrefs are created:

--- a/sphinxdocs/tests/sphinx_stardoc/sphinx_output_test.py
+++ b/sphinxdocs/tests/sphinx_stardoc/sphinx_output_test.py
@@ -64,6 +64,8 @@ class SphinxOutputTest(parameterized.TestCase):
         ("full_repo_aspect", "@testrepo//lang:aspect.bzl%myaspect", "aspect.html#myaspect"),
         ("full_repo_target", "@testrepo//lang:relativetarget", "target.html#relativetarget"),
         ("tag_class_attr_using_attr_role", "myext.mytag.ta1", "module_extension.html#myext.mytag.ta1"),
+        ("tag_class_attr_using_attr_role_just_attr_name", "ta1", "module_extension.html#myext.mytag.ta1"),
+
         # fmt: on
     )
     def test_xrefs(self, text, href):

--- a/sphinxdocs/tests/sphinx_stardoc/xrefs.md
+++ b/sphinxdocs/tests/sphinx_stardoc/xrefs.md
@@ -45,3 +45,4 @@ Various tests of cross referencing support
 ## Tag class refs
 
 * tag class attribute using attr role: {attr}`myext.mytag.ta1`
+* tag class attribute, just attr name, attr role: {attr}`ta1`


### PR DESCRIPTION
It's common to simply refer to an arg or attribute by its sole name, especially for
ones that are unique.

This fixes about ~20 broken xrefs in our docs. Also add test for this behavior.