### PR TITLE
docs: move devguide to sphinx for more powerful markup

### DIFF
--- a/docs/devguide.md
+++ b/docs/devguide.md
@@ -1,4 +1,4 @@
-# For Developers
+# Dev Guide
 
 This document covers tips and guidance for working on the rules_python code
 base. A primary audience for it is first time contributors.

--- a/docs/index.md
+++ b/docs/index.md
@@ -104,6 +104,7 @@ gazelle
 REPL <repl>
 Extending <extending>
 Contributing <contributing>
+devguide
 support
 Changelog <changelog>
 api/index


### PR DESCRIPTION
Having the devguide processed by Sphinx will let us use more powerful markup, which
will help make it possible to create richer documentation.