### PR TITLE
docs: fix xref to toolchain docs from getting starting

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,7 +7,7 @@ and the older way of using `WORKSPACE`.
 It assumes you have a `requirements.txt` file with your PyPI dependencies.
 
 For more details information about configuring `rules_python`, see:
-* [Configuring the runtime](toolchains)
+* [Configuring the runtime](configuring-toolchains)
 * [Configuring third party dependencies (pip/pypi)](pypi-dependencies)
 * [API docs](api/index)
 

--- a/docs/toolchains.md
+++ b/docs/toolchains.md
@@ -1,6 +1,7 @@
 :::{default-domain} bzl
 :::
 
+(configuring-toolchains)=
 # Configuring Python toolchains and runtimes
 
 This documents how to configure the Python toolchain and runtimes for different


### PR DESCRIPTION
The "toolchains" xref is ambiguous. Create a unique header for the toolchain configuration
section and link to that name instead.