### PR TITLE
sphinxdocs: make bazel package xrefs work

### DIFF
--- a/sphinxdocs/tests/sphinx_stardoc/sphinx_output_test.py
+++ b/sphinxdocs/tests/sphinx_stardoc/sphinx_output_test.py
@@ -67,6 +67,8 @@ class SphinxOutputTest(parameterized.TestCase):
         ("tag_class_attr_using_attr_role_just_attr_name", "ta1", "module_extension.html#myext.mytag.ta1"),
         ("file_without_repo", "//lang:rule.bzl", "rule.html"),
         ("file_with_repo", "@testrepo//lang:rule.bzl", "rule.html"),
+        ("package_absolute", "//lang", "target.html"),
+        ("package_basename", "lang", "target.html"),
         # fmt: on
     )
     def test_xrefs(self, text, href):

--- a/sphinxdocs/tests/sphinx_stardoc/xrefs.md
+++ b/sphinxdocs/tests/sphinx_stardoc/xrefs.md
@@ -51,3 +51,8 @@ Various tests of cross referencing support
 
 * without repo {obj}`//lang:rule.bzl`
 * with repo {obj}`@testrepo//lang:rule.bzl`
+
+## Package refs
+
+* absolute label {obj}`//lang`
+* package basename {obj}`lang`


### PR DESCRIPTION
This allows using xrefs like `//python/runtime_env_toolchains` and `runtime_env_toolchains`.