### PR TITLE
docs: ignore warnings about missing external py xrefs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -125,6 +125,12 @@ templates_path = ["_templates"]
 primary_domain = None  # The default is 'py', which we don't make much use of
 nitpicky = True
 
+nitpick_ignore_regex = [
+    # External xrefs aren't setup: ignore missing xref warnings
+    # External xrefs to sphinx isn't setup: ignore missing xref warnings
+    ("py:.*", "(sphinx|docutils|ast|enum|collections|typing_extensions).*"),
+]
+
 # --- Intersphinx configuration
 
 intersphinx_mapping = {


### PR DESCRIPTION
Crossreferencing to py code outside our project isn't setup, so these are just a lot
of warning spam. Disable them for now.