### PR TITLE
sphinxdocs: make Any and object types no-ops to avoid missing xrefs

### DIFF
--- a/sphinxdocs/src/sphinx_bzl/bzl.py
+++ b/sphinxdocs/src/sphinx_bzl/bzl.py
@@ -1766,6 +1766,11 @@ def _on_missing_reference(app, env: environment.BuildEnvironment, node, contnode
     # There's no Bazel docs for None, so prevent missing xrefs warning
     if node["reftarget"] == "None":
         return contnode
+
+    # Any and object are just conventions from Python, but useful for
+    # indicating what something is in Starlark, so treat them specially.
+    if node["reftarget"] in ("Any", "object"):
+        return contnode
     return None
 
 


### PR DESCRIPTION
The "Any" and "object" types are useful in expression starlark types, but aren't actually
real things. Treat them like None and make them no-ops so they aren't treated like
missing xrefs.