### PR TITLE
docs: correct some xrefs, add various missing Bazel external xrefs

### DIFF
--- a/python/private/rule_builders.bzl
+++ b/python/private/rule_builders.bzl
@@ -253,7 +253,7 @@ def _ToolchainType_build(self):
         self: implicitly added
 
     Returns:
-        {type}`config_common.toolchain_type`
+        {type}`toolchain_type`
     """
     kwargs = dict(self.kwargs)
     name = kwargs.pop("name")  # Name must be positional
@@ -673,7 +673,7 @@ def _AttrsDict_build(self):
     """Build an attribute dict for passing to `rule()`.
 
     Returns:
-        {type}`dict[str, attribute]` where the values are `attr.XXX` objects
+        {type}`dict[str, Attribute]` where the values are `attr.XXX` objects
     """
     attrs = {}
     for k, v in self.map.items():

--- a/sphinxdocs/inventories/bazel_inventory.txt
+++ b/sphinxdocs/inventories/bazel_inventory.txt
@@ -3,8 +3,10 @@
 # Version: 7.3.0
 # The remainder of this file is compressed using zlib
 Action bzl:type 1 rules/lib/Action -
+Attribute bzl:type 1 rules/lib/builtins/Attribute -
 CcInfo bzl:provider 1 rules/lib/providers/CcInfo -
 CcInfo.linking_context bzl:provider-field 1 rules/lib/providers/CcInfo#linking_context -
+DefaultInfo bzl:type 1 rules/lib/providers/DefaultInfo -
 ExecutionInfo bzl:type 1 rules/lib/providers/ExecutionInfo -
 File bzl:type 1 rules/lib/File -
 Label bzl:type 1 rules/lib/Label -
@@ -38,6 +40,7 @@ config.string_list bzl:function 1 rules/lib/toplevel/config#string_list -
 config.target bzl:function 1 rules/lib/toplevel/config#target -
 config_common.FeatureFlagInfo bzl:type 1 rules/lib/toplevel/config_common#FeatureFlagInfo -
 config_common.toolchain_type bzl:function 1 rules/lib/toplevel/config_common#toolchain_type -
+ctx bzl:type 1 rules/lib/builtins/repository_ctx -
 ctx.actions bzl:obj 1 rules/lib/builtins/ctx#actions -
 ctx.aspect_ids bzl:obj 1 rules/lib/builtins/ctx#aspect_ids -
 ctx.attr bzl:obj 1 rules/lib/builtins/ctx#attr -
@@ -96,6 +99,7 @@ module_ctx.report_progress bzl:function 1 rules/lib/builtins/module_ctx#report_p
 module_ctx.root_module_has_non_dev_dependency bzl:function 1 rules/lib/builtins/module_ctx#root_module_has_non_dev_dependency -
 module_ctx.watch bzl:function 1 rules/lib/builtins/module_ctx#watch -
 module_ctx.which bzl:function 1 rules/lib/builtins/module_ctx#which -
+native bzl:obj 1 rules/lib/toplevel/native -
 native.existing_rule bzl:function 1 rules/lib/toplevel/native#existing_rule -
 native.existing_rules bzl:function 1 rules/lib/toplevel/native#existing_rules -
 native.exports_files bzl:function 1 rules/lib/toplevel/native#exports_files -
@@ -140,6 +144,8 @@ repository_os bzl:type 1 rules/lib/builtins/repository_os -
 repository_os.arch bzl:obj 1 rules/lib/builtins/repository_os#arch
 repository_os.environ bzl:obj 1 rules/lib/builtins/repository_os#environ
 repository_os.name bzl:obj 1 rules/lib/builtins/repository_os#name
+rule bzl:type 1 rules/lib/builtins/rule -
+rule bzl:function rules/lib/globals/bzl.html#rule -
 runfiles bzl:type 1 rules/lib/builtins/runfiles -
 runfiles.empty_filenames bzl:type 1 rules/lib/builtins/runfiles#empty_filenames -
 runfiles.files bzl:type 1 rules/lib/builtins/runfiles#files -
@@ -156,6 +162,8 @@ testing.TestEnvironment bzl:function 1 rules/lib/toplevel/testing#TestEnvironmen
 testing.analysis_test bzl:rule 1 rules/lib/toplevel/testing#analysis_test -
 toolchain bzl:rule 1 reference/be/platforms-and-toolchains#toolchain -
 toolchain.exec_compatible_with bzl:rule 1 reference/be/platforms-and-toolchains#toolchain.exec_compatible_with -
-toolchain.target_settings bzl:attr 1 reference/be/platforms-and-toolchains#toolchain.target_settings -
 toolchain.target_compatible_with bzl:attr 1 reference/be/platforms-and-toolchains#toolchain.target_compatible_with -
+toolchain.target_settings bzl:attr 1 reference/be/platforms-and-toolchains#toolchain.target_settings -
 toolchain_type bzl:type 1 rules/lib/builtins/toolchain_type.html -
+transition bzl:type 1 rules/lib/builtins/transition -
+tuple bzl:type 1 rules/lib/core/tuple -


### PR DESCRIPTION
Adds a variety of Bazel builtins to the external Bazel inventory.

Along the way, fFixes a couple of bad xrefs in rule_builders.