### PR TITLE
docs: fix some more bad xrefs

### DIFF
--- a/python/private/python_register_toolchains.bzl
+++ b/python/private/python_register_toolchains.bzl
@@ -48,7 +48,7 @@ def python_register_toolchains(
 
     With `bzlmod` enabled, this function is not needed since `rules_python` is
     handling everything. In order to override the default behaviour from the
-    root module one can see the docs for the {rule}`python` extension.
+    root module one can see the docs for the {obj}`python` extension.
 
     - Create a repository for each built-in platform like "python_3_8_linux_amd64" -
       this repository is lazily fetched when Python is needed for that platform.
@@ -71,9 +71,10 @@ def python_register_toolchains(
         tool_versions: {type}`dict` contains a mapping of version with SHASUM
             and platform info. If not supplied, the defaults in
             python/versions.bzl will be used.
-        platforms: {type}`dict[str, platform_info]` platforms to create toolchain
-            repositories for. Note that only a subset is created, depending
-            on what's available in `tool_versions`.
+        platforms: {type}`dict[str, struct]` platforms to create toolchain
+            repositories for. Keys are platform names, and values are platform_info
+            structs. Note that only a subset is created, depending on what's
+            available in `tool_versions`.
         minor_mapping: {type}`dict[str, str]` contains a mapping from `X.Y` to `X.Y.Z`
             version.
         **kwargs: passed to each {obj}`python_repository` call.

--- a/python/private/rule_builders.bzl
+++ b/python/private/rule_builders.bzl
@@ -192,7 +192,7 @@ ExecGroup = struct(
 )
 
 def _ToolchainType_typedef():
-    """Builder for {obj}`config_common.toolchain_type()`
+    """Builder for {obj}`config_common.toolchain_type`
 
     :::{include} /_includes/field_kwargs_doc.md
     :::
@@ -393,7 +393,7 @@ def _RuleCfg_update_inputs(self, *others):
 
     Args:
         self: implicitly added
-        *others: {type}`collection[Label]` collection of labels to add to
+        *others: {type}`list[Label]` collection of labels to add to
             inputs. Only values not already present are added. Note that a
             `Label`, not `str`, should be passed to ensure different apparent
             labels can be properly de-duplicated.
@@ -405,7 +405,7 @@ def _RuleCfg_update_outputs(self, *others):
 
     Args:
         self: implicitly added
-        *others: {type}`collection[Label]` collection of labels to add to
+        *others: {type}`list[Label]` collection of labels to add to
             outputs. Only values not already present are added. Note that a
             `Label`, not `str`, should be passed to ensure different apparent
             labels can be properly de-duplicated.
@@ -679,6 +679,17 @@ def _AttrsDict_build(self):
     for k, v in self.map.items():
         attrs[k] = v.build() if _is_builder(v) else v
     return attrs
+
+def _AttributeBuilder_typedef():
+    """An abstract base typedef for builder for a Bazel {obj}`Attribute`
+
+    Instances of this are a builder for a particular `Attribute` type,
+    e.g. `attr.label`, `attr.string`, etc.
+    """
+
+AttributeBuilder = struct(
+    TYPEDEF = _AttributeBuilder_typedef,
+)
 
 # buildifier: disable=name-conventions
 AttrsDict = struct(

--- a/python/uv/private/uv.bzl
+++ b/python/uv/private/uv.bzl
@@ -122,7 +122,7 @@ uv.configure(
         "urls": attr.string_list(
             doc = """\
 The urls to download the binary from. If this is used, {attr}`base_url` and
-{attr}`manifest_name` are ignored for the given version.
+{attr}`manifest_filename` are ignored for the given version.
 
 ::::note
 If the `urls` are specified, they need to be specified for all of the platforms


### PR DESCRIPTION
Misc updates to fix doc warnings

* Replace `collection` with `list`. Collections aren't a formal type. Just use list
  as a stand-in.
* Create faux AttributeBuilder typedef so that AttributeBuilder references don't
  give a xref warning.
* Change to object-lookup for `python` name (its a module extension, not rule)