### PR TITLE
feat: Support constraints in pip_compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,9 @@ END_UNRELEASED_TEMPLATE
   Set the `RULES_PYTHON_ENABLE_PIPSTAR=1` environment variable to enable it.
 * (utils) Add a way to run a REPL for any `rules_python` target that returns
   a `PyInfo` provider.
+* (rules) Added support for a constraints file that is passed to pip-compile.
+  Useful when an intermediate dependency needs to be upgraded to pull in
+  security patches.
 
 {#v0-0-0-removed}
 ### Removed

--- a/python/private/pypi/pip_compile.bzl
+++ b/python/private/pypi/pip_compile.bzl
@@ -38,6 +38,7 @@ def pip_compile(
         requirements_windows = None,
         visibility = ["//visibility:private"],
         tags = None,
+        constraints = None,
         **kwargs):
     """Generates targets for managing pip dependencies with pip-compile.
 
@@ -77,6 +78,7 @@ def pip_compile(
         requirements_windows: File of windows specific resolve output to check validate if requirement.in has changes.
         tags: tagging attribute common to all build rules, passed to both the _test and .update rules.
         visibility: passed to both the _test and .update rules.
+        constraints: file containing constraints to pass to pip-compile with `--constraint`.
         **kwargs: other bazel attributes passed to the "_test" rule.
     """
     if len([x for x in [srcs, src, requirements_in] if x != None]) > 1:
@@ -100,7 +102,7 @@ def pip_compile(
         visibility = visibility,
     )
 
-    data = [name, requirements_txt] + srcs + [f for f in (requirements_linux, requirements_darwin, requirements_windows) if f != None]
+    data = [name, requirements_txt] + srcs + [f for f in (requirements_linux, requirements_darwin, requirements_windows) if f != None] + ([constraints] if constraints else [])
 
     # Use the Label constructor so this is expanded in the context of the file
     # where it appears, which is to say, in @rules_python
@@ -122,6 +124,8 @@ def pip_compile(
         args.append("--requirements-darwin={}".format(loc.format(requirements_darwin)))
     if requirements_windows:
         args.append("--requirements-windows={}".format(loc.format(requirements_windows)))
+    if constraints:
+        args.append("--constraint=$(location {})".format(constraints))
     args.extend(extra_args)
 
     deps = [


### PR DESCRIPTION
This adds in support to pass in a constraints file to pip-compile.
This is extremly useful when you want to uprade an indirect/intermediate
dependency to pull in security fixes but don't want to add said dependency to
the requirements.in file.
