### PR TITLE
docs: fix xrefs in 

### DIFF
--- a/python/private/attr_builders.bzl
+++ b/python/private/attr_builders.bzl
@@ -1222,7 +1222,7 @@ def _StringList_typedef():
     :::
 
     :::{field} default
-    :type: Value[list[str] | configuration_field]
+    :type: list[str] | configuration_field
     :::
 
     :::{function} doc() -> str
@@ -1235,6 +1235,9 @@ def _StringList_typedef():
     :::
 
     :::{function} set_allow_empty(v: bool)
+    :::
+
+    :::{function} set_default(v: list[str] | configuration_field)
     :::
 
     :::{function} set_doc(v: str)

--- a/python/private/py_console_script_binary.bzl
+++ b/python/private/py_console_script_binary.bzl
@@ -56,18 +56,18 @@ def py_console_script_binary(
     """Generate a py_binary for a console_script entry_point.
 
     Args:
-        name: [`target-name`] The name of the resulting target.
-        pkg: {any}`simple label` the package for which to generate the script.
-        entry_points_txt: optional [`label`], the entry_points.txt file to parse
+        name: {type}`Name` The name of the resulting target.
+        pkg: {type}`Label` the package for which to generate the script.
+        entry_points_txt: {type}`label | None`, the entry_points.txt file to parse
             for available console_script values. It may be a single file, or a
             group of files, but must contain a file named `entry_points.txt`.
             If not specified, defaults to the `dist_info` target in the same
             package as the `pkg` Label.
-        script: [`str`], The console script name that the py_binary is going to be
+        script: {type}`str`, The console script name that the py_binary is going to be
             generated for. Defaults to the normalized name attribute.
-        binary_rule: {any}`rule callable`, The rule/macro to use to instantiate
-            the target. It's expected to behave like {any}`py_binary`.
-            Defaults to {any}`py_binary`.
+        binary_rule: {type}`callable`, The rule/macro to use to instantiate
+            the target. It's expected to behave like {obj}`py_binary`.
+            Defaults to {obj}`py_binary`.
         **kwargs: Extra parameters forwarded to `binary_rule`.
     """
     main = "rules_python_entry_point_{}.py".format(name)

--- a/python/private/pypi/attrs.bzl
+++ b/python/private/pypi/attrs.bzl
@@ -210,7 +210,7 @@ If True, suppress printing stdout and stderr output to the terminal.
 If you would like to get more diagnostic output, set
 {envvar}`RULES_PYTHON_REPO_DEBUG=1 <RULES_PYTHON_REPO_DEBUG>`
 or
-{envvar}`RULES_PYTHON_REPO_DEBUG_VERBOSITY=<INFO|DEBUG|TRACE> <RULES_PYTHON_REPO_DEBUG_VERBOSITY>`
+{envvar}`RULES_PYTHON_REPO_DEBUG_VERBOSITY=INFO|DEBUG|TRACE <RULES_PYTHON_REPO_DEBUG_VERBOSITY>`
 """,
     ),
     # 600 is documented as default here: https://docs.bazel.build/versions/master/skylark/lib/repository_ctx.html#execute


### PR DESCRIPTION
More misc xrefs fixes in:

* attr_builders
* py_console_script_binary
* pypi envvar ref