### PR TITLE
refactor: rename host_toolchain rule to host_compatible_python_repo

### DIFF
--- a/python/private/python.bzl
+++ b/python/private/python.bzl
@@ -21,7 +21,7 @@ load(":full_version.bzl", "full_version")
 load(":python_register_toolchains.bzl", "python_register_toolchains")
 load(":pythons_hub.bzl", "hub_repo")
 load(":repo_utils.bzl", "repo_utils")
-load(":toolchains_repo.bzl", "host_toolchain", "multi_toolchain_aliases", "sorted_host_platforms")
+load(":toolchains_repo.bzl", "host_compatible_python_repo", "multi_toolchain_aliases", "sorted_host_platforms")
 load(":util.bzl", "IS_BAZEL_6_4_OR_HIGHER")
 load(":version.bzl", "version")
 
@@ -321,7 +321,7 @@ def _python_impl(module_ctx):
                 host_platforms[platform_name] = platform_info
 
         host_platforms = sorted_host_platforms(host_platforms)
-        host_toolchain(
+        host_compatible_python_repo(
             name = toolchain_info.name + "_host",
             # NOTE: Order matters. The first found to be compatible is (usually) used.
             platforms = host_platforms.keys(),

--- a/python/private/python_register_toolchains.bzl
+++ b/python/private/python_register_toolchains.bzl
@@ -28,7 +28,7 @@ load(":full_version.bzl", "full_version")
 load(":python_repository.bzl", "python_repository")
 load(
     ":toolchains_repo.bzl",
-    "host_toolchain",
+    "host_compatible_python_repo",
     "toolchain_aliases",
     "toolchains_repo",
 )
@@ -185,7 +185,7 @@ def python_register_toolchains(
             impl_repos = impl_repos,
         )
 
-    host_toolchain(
+    host_compatible_python_repo(
         name = name + "_host",
         platforms = loaded_platforms,
         python_version = python_version,

--- a/python/private/toolchains_repo.bzl
+++ b/python/private/toolchains_repo.bzl
@@ -379,7 +379,7 @@ def _host_toolchain_impl(rctx):
 
 # NOTE: The term "toolchain" is a misnomer for this rule. This doesn't define
 # a repo with toolchains or toolchain implementations.
-host_toolchain = repository_rule(
+host_compatible_python_repo = repository_rule(
     _host_toolchain_impl,
     doc = """\
 Creates a repository with a shorter name meant to be used in the repository_ctx,
@@ -400,7 +400,7 @@ If set, overrides the platform metadata. Keyed by index in `platforms`
         ),
         "platforms": attr.string_list(mandatory = True),
         "python_version": attr.string(mandatory = True),
-        "_rule_name": attr.string(default = "host_toolchain"),
+        "_rule_name": attr.string(default = "host_compatible_python_repo"),
         "_rules_python_workspace": attr.label(default = Label("//:WORKSPACE")),
     },
 )


### PR DESCRIPTION
The host_toolchain name is misleading, so rename it to some more accurate.

Work towards https://github.com/bazel-contrib/rules_python/issues/2913