### PR TITLE
docs: fix sphinxdocs mis-redirect

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,7 +87,7 @@ redirects = {
     "api/sphinxdocs/sphinx": "/api/sphinxdocs/sphinxdocs/sphinx.html",
     "api/sphinxdocs/sphinx_stardoc": "/api/sphinxdocs/sphinxdocs/sphinx_stardoc.html",
     "api/sphinxdocs/readthedocs": "/api/sphinxdocs/sphinxdocs/readthedocs.html",
-    "api/sphinxdocs/index": "/api/sphinxdocs/sphinxdocs/index.html",
+    "api/sphinxdocs/index": "sphinxdocs/index.html",
     "api/sphinxdocs/private/sphinx_docs_library": "/api/sphinxdocs/sphinxdocs/private/sphinx_docs_library.html",
     "api/sphinxdocs/sphinx_docs_library": "/api/sphinxdocs/sphinxdocs/sphinx_docs_library.html",
     "api/sphinxdocs/inventories/index": "/api/sphinxdocs/sphinxdocs/inventories/index.html",


### PR DESCRIPTION
The redirect was going to a non-existent URL when viewed on the deployed docs.

This was happening because the absolute paths `/api/whatever` don't exist in the deployed
site -- it's actually `/en/latest/api/whatever`. This went unnoticed because it works
locally (where there is no /en/latest prefix).

To fix, use a relative url (relative urls are relative to the path that is redirected from)