### PR TITLE
fix(pypi): inherit proxy env variables in compile_pip_requirements test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ END_UNRELEASED_TEMPLATE
   [#2363](https://github.com/bazel-contrib/rules_python/issues/2363).
 * (pypi) `whl_library` now infers file names from its `urls` attribute correctly.
 * (py_test, py_binary) Allow external files to be used for main
+* (pypi) `compile_pip_requirements` test rule works behind the proxy
 
 {#v0-0-0-added}
 ### Added

--- a/python/private/pypi/dependency_resolver/dependency_resolver.py
+++ b/python/private/pypi/dependency_resolver/dependency_resolver.py
@@ -158,7 +158,7 @@ def main(
     update_command = (
         os.getenv("CUSTOM_COMPILE_COMMAND") or f"bazel run {target_label_prefix}.update"
     )
-    test_command = f"bazel test {target_label_prefix}_test"
+    test_command = f"bazel test {target_label_prefix}.test"
 
     os.environ["CUSTOM_COMPILE_COMMAND"] = update_command
     os.environ["PIP_CONFIG_FILE"] = os.getenv("PIP_CONFIG_FILE") or os.devnull

--- a/python/private/pypi/pip_compile.bzl
+++ b/python/private/pypi/pip_compile.bzl
@@ -44,7 +44,6 @@ def pip_compile(
     By default this rules generates a filegroup named "[name]" which can be included in the data
     of some other compile_pip_requirements rule that references these requirements
     (e.g. with `-r ../other/requirements.txt`).
-
     It also generates two targets for running pip-compile:
 
     - validate with `bazel test [name].test`
@@ -178,6 +177,7 @@ def pip_compile(
             "@@platforms//os:windows": {"USERPROFILE": "Z:\\FakeSetuptoolsHomeDirectoryHack"},
             "//conditions:default": {},
         }) | env,
+        env_inherit = ["https_proxy", "http_proxy", "no_proxy", "HTTPS_PROXY", "HTTP_PROXY", "NO_PROXY"],
         # kwargs could contain test-specific attributes like size
         **dict(attrs, **kwargs)
     )


### PR DESCRIPTION
Bazel does not pass environment variables implicitly (even running test outside of sandbox). This forces compile_pip_requirements test to fail with timeout when attempting to run it behind the proxy. Also changes test_command in dependency_resolver string helper to use dot instead of underscore following deprecation notice