### PR TITLE
refactor(gazelle) Types for exposed members of `python.ParserOutput` are now all public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,27 @@ BEGIN_UNRELEASED_TEMPLATE
 END_UNRELEASED_TEMPLATE
 -->
 
+{#v0-0-0}
+## Unreleased
+
+[0.0.0]: https://github.com/bazel-contrib/rules_python/releases/tag/0.0.0
+
+{#v0-0-0-changed}
+### Changed
+* (gazelle) Types for exposed members of `python.ParserOutput` are now all public.
+
+{#v0-0-0-fixed}
+### Fixed
+* Nothing fixed.
+
+{#v0-0-0-added}
+### Added
+* Nothing added.
+
+{#v0-0-0-removed}
+### Removed
+* Nothing removed.
+
 {#1-5-0}
 ## [1.5.0] - 2025-06-11
 
@@ -71,7 +92,6 @@ END_UNRELEASED_TEMPLATE
 * (providers) (experimental) {obj}`PyInfo.venv_symlinks` replaces
   `PyInfo.site_packages_symlinks`
 * (deps) Updating setuptools to patch CVE-2025-47273.
-  (gazelle) Export `parser.Module` as a public struct.
 
 {#1-5-0-fixed}
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ END_UNRELEASED_TEMPLATE
 * (providers) (experimental) {obj}`PyInfo.venv_symlinks` replaces
   `PyInfo.site_packages_symlinks`
 * (deps) Updating setuptools to patch CVE-2025-47273.
+  (gazelle) Export `parser.Module` as a public struct.
 
 {#1-5-0-fixed}
 ### Fixed

--- a/gazelle/python/file_parser.go
+++ b/gazelle/python/file_parser.go
@@ -41,8 +41,8 @@ const (
 
 type ParserOutput struct {
 	FileName string
-	Modules  []module
-	Comments []comment
+	Modules  []Module
+	Comments []Comment
 	HasMain  bool
 }
 
@@ -127,24 +127,24 @@ func (p *FileParser) parseMain(ctx context.Context, node *sitter.Node) bool {
 	return false
 }
 
-// parseImportStatement parses a node for an import statement, returning a `module` and a boolean
+// parseImportStatement parses a node for an import statement, returning a `Module` and a boolean
 // representing if the parse was OK or not.
-func parseImportStatement(node *sitter.Node, code []byte) (module, bool) {
+func parseImportStatement(node *sitter.Node, code []byte) (Module, bool) {
 	switch node.Type() {
 	case sitterNodeTypeDottedName:
-		return module{
+		return Module{
 			Name:       node.Content(code),
 			LineNumber: node.StartPoint().Row + 1,
 		}, true
 	case sitterNodeTypeAliasedImport:
 		return parseImportStatement(node.Child(0), code)
 	case sitterNodeTypeWildcardImport:
-		return module{
+		return Module{
 			Name:       "*",
 			LineNumber: node.StartPoint().Row + 1,
 		}, true
 	}
-	return module{}, false
+	return Module{}, false
 }
 
 // parseImportStatements parses a node for import statements, returning true if the node is
@@ -188,7 +188,7 @@ func (p *FileParser) parseImportStatements(node *sitter.Node) bool {
 // It updates FileParser.output.Comments with the parsed comment.
 func (p *FileParser) parseComments(node *sitter.Node) bool {
 	if node.Type() == sitterNodeTypeComment {
-		p.output.Comments = append(p.output.Comments, comment(node.Content(p.code)))
+		p.output.Comments = append(p.output.Comments, Comment(node.Content(p.code)))
 		return true
 	}
 	return false

--- a/gazelle/python/file_parser_test.go
+++ b/gazelle/python/file_parser_test.go
@@ -27,7 +27,7 @@ func TestParseImportStatements(t *testing.T) {
 		name     string
 		code     string
 		filepath string
-		result   []module
+		result   []Module
 	}{
 		{
 			name:     "not has import",
@@ -39,7 +39,7 @@ func TestParseImportStatements(t *testing.T) {
 			name:     "has import",
 			code:     "import unittest\nimport os.path\nfrom foo.bar import abc.xyz",
 			filepath: "abc.py",
-			result: []module{
+			result: []Module{
 				{
 					Name:       "unittest",
 					LineNumber: 1,
@@ -66,7 +66,7 @@ func TestParseImportStatements(t *testing.T) {
 	import unittest
 `,
 			filepath: "abc.py",
-			result: []module{
+			result: []Module{
 				{
 					Name:       "unittest",
 					LineNumber: 2,
@@ -79,7 +79,7 @@ func TestParseImportStatements(t *testing.T) {
 			name:     "invalid syntax",
 			code:     "import os\nimport",
 			filepath: "abc.py",
-			result: []module{
+			result: []Module{
 				{
 					Name:       "os",
 					LineNumber: 1,
@@ -92,7 +92,7 @@ func TestParseImportStatements(t *testing.T) {
 			name:     "import as",
 			code:     "import os as b\nfrom foo import bar as c# 123",
 			filepath: "abc.py",
-			result: []module{
+			result: []Module{
 				{
 					Name:       "os",
 					LineNumber: 1,
@@ -111,7 +111,7 @@ func TestParseImportStatements(t *testing.T) {
 		{
 			name: "complex import",
 			code: "from unittest import *\nfrom foo import (bar as c, baz, qux as d)\nfrom . import abc",
-			result: []module{
+			result: []Module{
 				{
 					Name:       "unittest.*",
 					LineNumber: 1,
@@ -152,7 +152,7 @@ func TestParseComments(t *testing.T) {
 	units := []struct {
 		name   string
 		code   string
-		result []comment
+		result []Comment
 	}{
 		{
 			name:   "not has comment",
@@ -162,17 +162,17 @@ func TestParseComments(t *testing.T) {
 		{
 			name:   "has comment",
 			code:   "# a = 1\n# b = 2",
-			result: []comment{"# a = 1", "# b = 2"},
+			result: []Comment{"# a = 1", "# b = 2"},
 		},
 		{
 			name:   "has comment in if",
 			code:   "if True:\n  # a = 1\n  # b = 2",
-			result: []comment{"# a = 1", "# b = 2"},
+			result: []Comment{"# a = 1", "# b = 2"},
 		},
 		{
 			name:   "has comment inline",
 			code:   "import os# 123\nfrom pathlib import Path as b#456",
-			result: []comment{"# 123", "#456"},
+			result: []Comment{"# 123", "#456"},
 		},
 	}
 	for _, u := range units {
@@ -248,7 +248,7 @@ func TestParseFull(t *testing.T) {
 	output, err := p.Parse(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, ParserOutput{
-		Modules:  []module{{Name: "bar.abc", LineNumber: 1, Filepath: "foo/a.py", From: "bar"}},
+		Modules:  []Module{{Name: "bar.abc", LineNumber: 1, Filepath: "foo/a.py", From: "bar"}},
 		Comments: nil,
 		HasMain:  false,
 		FileName: "a.py",

--- a/gazelle/python/generate.go
+++ b/gazelle/python/generate.go
@@ -471,7 +471,7 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 
 	for _, pyTestTarget := range pyTestTargets {
 		if conftest != nil {
-			pyTestTarget.addModuleDependency(module{Name: strings.TrimSuffix(conftestFilename, ".py")})
+			pyTestTarget.addModuleDependency(Module{Name: strings.TrimSuffix(conftestFilename, ".py")})
 		}
 		pyTest := pyTestTarget.build()
 

--- a/gazelle/python/parser.go
+++ b/gazelle/python/parser.go
@@ -145,9 +145,9 @@ func removeDupesFromStringTreeSetSlice(array []string) []string {
 	return dedupe
 }
 
-// module represents a fully-qualified, dot-separated, Python module as seen on
+// Module represents a fully-qualified, dot-separated, Python module as seen on
 // the import statement, alongside the line number where it happened.
-type module struct {
+type Module struct {
 	// The fully-qualified, dot-separated, Python module name as seen on import
 	// statements.
 	Name string `json:"name"`
@@ -162,7 +162,7 @@ type module struct {
 
 // moduleComparator compares modules by name.
 func moduleComparator(a, b interface{}) int {
-	return godsutils.StringComparator(a.(module).Name, b.(module).Name)
+	return godsutils.StringComparator(a.(Module).Name, b.(Module).Name)
 }
 
 // annotationKind represents Gazelle annotation kinds.
@@ -176,12 +176,12 @@ const (
 	annotationKindIncludeDep annotationKind = "include_dep"
 )
 
-// comment represents a Python comment.
-type comment string
+// Comment represents a Python comment.
+type Comment string
 
 // asAnnotation returns an annotation object if the comment has the
 // annotationPrefix.
-func (c *comment) asAnnotation() (*annotation, error) {
+func (c *Comment) asAnnotation() (*annotation, error) {
 	uncomment := strings.TrimLeft(string(*c), "# ")
 	if !strings.HasPrefix(uncomment, annotationPrefix) {
 		return nil, nil
@@ -215,7 +215,7 @@ type annotations struct {
 
 // annotationsFromComments returns all the annotations parsed out of the
 // comments of a Python module.
-func annotationsFromComments(comments []comment) (*annotations, error) {
+func annotationsFromComments(comments []Comment) (*annotations, error) {
 	ignore := make(map[string]struct{})
 	includeDeps := []string{}
 	for _, comment := range comments {

--- a/gazelle/python/resolve.go
+++ b/gazelle/python/resolve.go
@@ -151,7 +151,7 @@ func (py *Resolver) Resolve(
 		hasFatalError := false
 	MODULES_LOOP:
 		for it.Next() {
-			mod := it.Value().(module)
+			mod := it.Value().(Module)
 			moduleParts := strings.Split(mod.Name, ".")
 			possibleModules := []string{mod.Name}
 			for len(moduleParts) > 1 {
@@ -214,7 +214,7 @@ func (py *Resolver) Resolve(
 						matches := ix.FindRulesByImportWithConfig(c, imp, languageName)
 						if len(matches) == 0 {
 							// Check if the imported module is part of the standard library.
-							if isStdModule(module{Name: moduleName}) {
+							if isStdModule(Module{Name: moduleName}) {
 								continue MODULES_LOOP
 							} else if cfg.ValidateImportStatements() {
 								err := fmt.Errorf(

--- a/gazelle/python/std_modules.go
+++ b/gazelle/python/std_modules.go
@@ -34,7 +34,7 @@ func init() {
 	}
 }
 
-func isStdModule(m module) bool {
+func isStdModule(m Module) bool {
 	_, ok := stdModules[m.Name]
 	return ok
 }

--- a/gazelle/python/std_modules_test.go
+++ b/gazelle/python/std_modules_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestIsStdModule(t *testing.T) {
-	assert.True(t, isStdModule(module{Name: "unittest"}))
-	assert.True(t, isStdModule(module{Name: "os.path"}))
-	assert.False(t, isStdModule(module{Name: "foo"}))
+	assert.True(t, isStdModule(Module{Name: "unittest"}))
+	assert.True(t, isStdModule(Module{Name: "os.path"}))
+	assert.False(t, isStdModule(Module{Name: "foo"}))
 }

--- a/gazelle/python/target.go
+++ b/gazelle/python/target.go
@@ -69,7 +69,7 @@ func (t *targetBuilder) addSrcs(srcs *treeset.Set) *targetBuilder {
 }
 
 // addModuleDependency adds a single module dep to the target.
-func (t *targetBuilder) addModuleDependency(dep module) *targetBuilder {
+func (t *targetBuilder) addModuleDependency(dep Module) *targetBuilder {
 	fileName := dep.Name + ".py"
 	if dep.From != "" {
 		fileName = dep.From + ".py"
@@ -87,7 +87,7 @@ func (t *targetBuilder) addModuleDependency(dep module) *targetBuilder {
 func (t *targetBuilder) addModuleDependencies(deps *treeset.Set) *targetBuilder {
 	it := deps.Iterator()
 	for it.Next() {
-		t.addModuleDependency(it.Value().(module))
+		t.addModuleDependency(it.Value().(Module))
 	}
 	return t
 }


### PR DESCRIPTION
Export the members of `python.ParserOutput` struct to make it publicly accessible. This allows other `py` extensions to leverage the Python resolver logic for resolving Python imports, instead of have to duplicate the resolving logic.