### PR TITLE
revert: change default bootstrap back to system_python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,14 +55,6 @@ END_UNRELEASED_TEMPLATE
 {#v0-0-0-changed}
 ### Changed
 
-* If using the (deprecated) autodetecting/runtime_env toolchain, then the Python
-  version specified at build-time *must* match the Python version used at
-  runtime (the {obj}`--@rules_python//python/config_settings:python_version`
-  flag and the {attr}`python_version` attribute control the build-time version
-  for a target). If they don't match, dependencies won't be importable. (Such a
-  misconfiguration was unlikely to work to begin with; this is called out as an
-  FYI).
-* (rules) {obj}`--bootstrap_impl=script` is the default for non-Windows.
 * (rules) On Windows, {obj}`--bootstrap_impl=system_python` is forced. This
   allows setting `--bootstrap_impl=script` in bazelrc for mixed-platform
   environments.

--- a/docs/api/rules_python/python/config_settings/index.md
+++ b/docs/api/rules_python/python/config_settings/index.md
@@ -245,12 +245,8 @@ Values:
 ::::{bzl:flag} bootstrap_impl
 Determine how programs implement their startup process.
 
-The default for this depends on the platform:
-* Windows: `system_python` (**always** used)
-* Other: `script`
-
 Values:
-* `system_python`: Use a bootstrap that requires a system Python available
+* `system_python`: (default) Use a bootstrap that requires a system Python available
   in order to start programs. This requires
   {obj}`PyRuntimeInfo.bootstrap_template` to be a Python program.
 * `script`: Use a bootstrap that uses an arbitrary executable script (usually a
@@ -271,11 +267,6 @@ instead.
 :::
 
 :::{versionadded} 0.33.0
-:::
-
-:::{versionchanged} VERSION_NEXT_FEATURE
-* The default for non-Windows changed from `system_python` to `script`.
-* On Windows, the value is forced to `system_python`.
 :::
 
 ::::

--- a/python/config_settings/BUILD.bazel
+++ b/python/config_settings/BUILD.bazel
@@ -90,7 +90,7 @@ string_flag(
 
 rp_string_flag(
     name = "bootstrap_impl",
-    build_setting_default = BootstrapImplFlag.SCRIPT,
+    build_setting_default = BootstrapImplFlag.SYSTEM_PYTHON,
     override = select({
         # Windows doesn't yet support bootstrap=script, so force disable it
         ":_is_windows": BootstrapImplFlag.SYSTEM_PYTHON,


### PR DESCRIPTION
Switch the default bootstrap back to system_python, per maintainer discussion.

The main reason is downstream consumers are unlikely to be fully ready for the
usage of raw symlinks (declare_symlink artifacts). APIs to detect them aren't
available until Bazel 8, which makes it difficult for packaging rules, such
as rules_pkg, bazel-lib, or tar rules.

This reverts the core part of commit 9f3512fe0cc6d7229170e45724e22e64be0b8300