### PR TITLE
Fix argument name typo

### DIFF
--- a/python/private/pypi/whl_library_targets.bzl
+++ b/python/private/pypi/whl_library_targets.bzl
@@ -336,7 +336,7 @@ def whl_library_targets(
                 Label("//python/config_settings:is_venvs_site_packages"): [],
                 "//conditions:default": create_inits(
                     srcs = srcs + data + pyi_srcs,
-                    ignore_dirnames = [],  # If you need to ignore certain folders, you can patch rules_python here to do so.
+                    ignored_dirnames = [],  # If you need to ignore certain folders, you can patch rules_python here to do so.
                     root = "site-packages",
                 ),
             })


### PR DESCRIPTION
```
ERROR: Traceback (most recent call last):
        File ".../rules_python++pip+rules_mypy_pip_312_click/BUILD.bazel", line 5, column 20, in <toplevel>
                whl_library_targets(
        File ".../rules_python+/python/private/pypi/whl_library_targets.bzl", line 337, column 53, in whl_library_targets
                "//conditions:default": create_inits(
        File ".../rules_python+/python/private/pypi/namespace_pkgs.bzl", line 72, column 25, in create_inits
                for out in get_files(**kwargs):
        File ".../rules_python+/python/private/pypi/namespace_pkgs.bzl", line 20, column 5, in get_files
                def get_files(*, srcs, ignored_dirnames = [], root = None):
Error: get_files() got unexpected keyword argument: ignore_dirnames (did you mean 'ignored_dirnames'?)
```
