### PR TITLE
do not index py_binary unless in file mode

### DIFF
--- a/gazelle/python/generate.go
+++ b/gazelle/python/generate.go
@@ -48,8 +48,8 @@ var (
 	buildFilenames = []string{"BUILD", "BUILD.bazel"}
 )
 
-func GetActualKindName(kind string, args language.GenerateArgs) string {
-	if kindOverride, ok := args.Config.KindMap[kind]; ok {
+func GetActualKindName(kind string, c *config.Config) string {
+	if kindOverride, ok := c.KindMap[kind]; ok {
 		return kindOverride.KindName
 	}
 	return kind
@@ -90,9 +90,9 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 		}
 	}
 
-	actualPyBinaryKind := GetActualKindName(pyBinaryKind, args)
-	actualPyLibraryKind := GetActualKindName(pyLibraryKind, args)
-	actualPyTestKind := GetActualKindName(pyTestKind, args)
+	actualPyBinaryKind := GetActualKindName(pyBinaryKind, args.Config)
+	actualPyLibraryKind := GetActualKindName(pyLibraryKind, args.Config)
+	actualPyTestKind := GetActualKindName(pyTestKind, args.Config)
 
 	pythonProjectRoot := cfg.PythonProjectRoot()
 

--- a/gazelle/python/resolve.go
+++ b/gazelle/python/resolve.go
@@ -57,6 +57,11 @@ func (*Resolver) Name() string { return languageName }
 func (py *Resolver) Imports(c *config.Config, r *rule.Rule, f *rule.File) []resolve.ImportSpec {
 	cfgs := c.Exts[languageName].(pythonconfig.Configs)
 	cfg := cfgs[f.Pkg]
+	if !cfg.PerFileGeneration() && GetActualKindName(r.Kind(), c) == pyBinaryKind {
+		// Don't index py_binary in except in file mode, because all non-test Python files
+		// are in py_library already.
+		return nil
+	}
 	srcs := r.AttrStrings("srcs")
 	provides := make([]resolve.ImportSpec, 0, len(srcs)+1)
 	for _, src := range srcs {


### PR DESCRIPTION
This is yet another implementation of #2822. Based on this:

https://github.com/bazel-contrib/rules_python/blob/94e08f7dfe61962fa50508f01ea05c624307d487/gazelle/python/generate.go#L248-L252

The only case when a python file does not exist in `py_library` is in file mode. Stop indexing `py_binary` in other mode to avoid ambiguous dependency resolution.
