### PR TITLE
fix: use platform_info.target_settings in toolchain aliases

### DIFF
--- a/python/config_settings/BUILD.bazel
+++ b/python/config_settings/BUILD.bazel
@@ -125,15 +125,19 @@ string_flag(
     visibility = ["//visibility:public"],
 )
 
-config_setting(
+alias(
     name = "is_py_freethreaded",
-    flag_values = {":py_freethreaded": FreeThreadedFlag.YES},
+    actual = ":_is_py_freethreaded_yes",
+    deprecation = "not actually public, please create your own config_setting using the flag that rules_python exposes",
+    tags = ["manual"],
     visibility = ["//visibility:public"],
 )
 
-config_setting(
+alias(
     name = "is_py_non_freethreaded",
-    flag_values = {":py_freethreaded": FreeThreadedFlag.NO},
+    actual = ":_is_py_freethreaded_no",
+    deprecation = "not actually public, please create your own config_setting using the flag that rules_python exposes",
+    tags = ["manual"],
     visibility = ["//visibility:public"],
 )
 

--- a/python/private/config_settings.bzl
+++ b/python/private/config_settings.bzl
@@ -143,7 +143,7 @@ def construct_config_settings(*, name, default_version, versions, minor_mapping,
     )
     native.config_setting(
         name = "_is_py_linux_libc_musl",
-        flag_values = {libc: "glibc"},
+        flag_values = {libc: "musl"},
         visibility = _NOT_ACTUALLY_PUBLIC,
     )
     freethreaded = Label("//python/config_settings:py_freethreaded")

--- a/python/private/hermetic_runtime_repo_setup.bzl
+++ b/python/private/hermetic_runtime_repo_setup.bzl
@@ -22,7 +22,8 @@ load(":glob_excludes.bzl", "glob_excludes")
 load(":py_exec_tools_toolchain.bzl", "py_exec_tools_toolchain")
 load(":version.bzl", "version")
 
-_IS_FREETHREADED = Label("//python/config_settings:is_py_freethreaded")
+_IS_FREETHREADED_YES = Label("//python/config_settings:_is_py_freethreaded_yes")
+_IS_FREETHREADED_NO = Label("//python/config_settings:_is_py_freethreaded_no")
 
 def define_hermetic_runtime_toolchain_impl(
         *,
@@ -87,16 +88,16 @@ def define_hermetic_runtime_toolchain_impl(
     cc_import(
         name = "interface",
         interface_library = select({
-            _IS_FREETHREADED: "libs/python{major}{minor}t.lib".format(**version_dict),
-            "//conditions:default": "libs/python{major}{minor}.lib".format(**version_dict),
+            _IS_FREETHREADED_YES: "libs/python{major}{minor}t.lib".format(**version_dict),
+            _IS_FREETHREADED_NO: "libs/python{major}{minor}.lib".format(**version_dict),
         }),
         system_provided = True,
     )
     cc_import(
         name = "abi3_interface",
         interface_library = select({
-            _IS_FREETHREADED: "libs/python3t.lib",
-            "//conditions:default": "libs/python3.lib",
+            _IS_FREETHREADED_YES: "libs/python3t.lib",
+            _IS_FREETHREADED_NO: "libs/python3.lib",
         }),
         system_provided = True,
     )
@@ -115,10 +116,10 @@ def define_hermetic_runtime_toolchain_impl(
         includes = [
             "include",
         ] + select({
-            _IS_FREETHREADED: [
+            _IS_FREETHREADED_YES: [
                 "include/python{major}.{minor}t".format(**version_dict),
             ],
-            "//conditions:default": [
+            _IS_FREETHREADED_NO: [
                 "include/python{major}.{minor}".format(**version_dict),
                 "include/python{major}.{minor}m".format(**version_dict),
             ],
@@ -224,8 +225,8 @@ def define_hermetic_runtime_toolchain_impl(
         implementation_name = "cpython",
         # See https://peps.python.org/pep-3147/ for pyc tag infix format
         pyc_tag = select({
-            _IS_FREETHREADED: "cpython-{major}{minor}t".format(**version_dict),
-            "//conditions:default": "cpython-{major}{minor}".format(**version_dict),
+            _IS_FREETHREADED_YES: "cpython-{major}{minor}t".format(**version_dict),
+            _IS_FREETHREADED_NO: "cpython-{major}{minor}".format(**version_dict),
         }),
     )
 

--- a/python/private/pypi/config_settings.bzl
+++ b/python/private/pypi/config_settings.bzl
@@ -80,8 +80,8 @@ FLAGS = struct(
             "is_pip_whl_auto",
             "is_pip_whl_no",
             "is_pip_whl_only",
-            "is_py_freethreaded",
-            "is_py_non_freethreaded",
+            "_is_py_freethreaded_yes",
+            "_is_py_freethreaded_no",
             "pip_whl_glibc_version",
             "pip_whl_muslc_version",
             "pip_whl_osx_arch",
@@ -205,12 +205,12 @@ def _dist_config_settings(*, suffix, plat_flag_values, python_version, **kwargs)
     for name, f, compatible_with in [
         ("py_none", _flags.whl, None),
         ("py3_none", _flags.whl_py3, None),
-        ("py3_abi3", _flags.whl_py3_abi3, (FLAGS.is_py_non_freethreaded,)),
+        ("py3_abi3", _flags.whl_py3_abi3, (FLAGS._is_py_freethreaded_no,)),
         ("none", _flags.whl_pycp3x, None),
-        ("abi3", _flags.whl_pycp3x_abi3, (FLAGS.is_py_non_freethreaded,)),
+        ("abi3", _flags.whl_pycp3x_abi3, (FLAGS._is_py_freethreaded_no,)),
         # The below are not specializations of one another, they are variants
-        (cpv, _flags.whl_pycp3x_abicp, (FLAGS.is_py_non_freethreaded,)),
-        (cpv + "t", _flags.whl_pycp3x_abicp, (FLAGS.is_py_freethreaded,)),
+        (cpv, _flags.whl_pycp3x_abicp, (FLAGS._is_py_freethreaded_no,)),
+        (cpv + "t", _flags.whl_pycp3x_abicp, (FLAGS._is_py_freethreaded_yes,)),
     ]:
         if (f, compatible_with) in used_flags:
             # This should never happen as all of the different whls should have
@@ -237,12 +237,12 @@ def _dist_config_settings(*, suffix, plat_flag_values, python_version, **kwargs)
         for name, f, compatible_with in [
             ("py_none", _flags.whl_plat, None),
             ("py3_none", _flags.whl_plat_py3, None),
-            ("py3_abi3", _flags.whl_plat_py3_abi3, (FLAGS.is_py_non_freethreaded,)),
+            ("py3_abi3", _flags.whl_plat_py3_abi3, (FLAGS._is_py_freethreaded_no,)),
             ("none", _flags.whl_plat_pycp3x, None),
-            ("abi3", _flags.whl_plat_pycp3x_abi3, (FLAGS.is_py_non_freethreaded,)),
+            ("abi3", _flags.whl_plat_pycp3x_abi3, (FLAGS._is_py_freethreaded_no,)),
             # The below are not specializations of one another, they are variants
-            (cpv, _flags.whl_plat_pycp3x_abicp, (FLAGS.is_py_non_freethreaded,)),
-            (cpv + "t", _flags.whl_plat_pycp3x_abicp, (FLAGS.is_py_freethreaded,)),
+            (cpv, _flags.whl_plat_pycp3x_abicp, (FLAGS._is_py_freethreaded_no,)),
+            (cpv + "t", _flags.whl_plat_pycp3x_abicp, (FLAGS._is_py_freethreaded_yes,)),
         ]:
             if (f, compatible_with) in used_flags:
                 # This should never happen as all of the different whls should have
@@ -329,7 +329,7 @@ def _dist_config_setting(*, name, compatible_with = None, native = native, **kwa
         compatible_with: {type}`tuple[Label]` A collection of config settings that are
             compatible with the given dist config setting. For example, if only
             non-freethreaded python builds are allowed, add
-            FLAGS.is_py_non_freethreaded here.
+            FLAGS._is_py_freethreaded_no here.
         native (struct): The struct containing alias and config_setting rules
             to use for creating the objects. Can be overridden for unit tests
             reasons.

--- a/python/private/toolchain_aliases.bzl
+++ b/python/private/toolchain_aliases.bzl
@@ -14,7 +14,8 @@
 
 """Create toolchain alias targets."""
 
-load("@rules_python//python:versions.bzl", "PLATFORMS")
+load("@bazel_skylib//lib:selects.bzl", "selects")
+load("//python:versions.bzl", "PLATFORMS")
 
 def toolchain_aliases(*, name, platforms, visibility = None, native = native):
     """Create toolchain aliases for the python toolchains.
@@ -30,10 +31,15 @@ def toolchain_aliases(*, name, platforms, visibility = None, native = native):
         if platform not in platforms:
             continue
 
+        _platform = "_" + platform
         native.config_setting(
-            name = platform,
-            flag_values = PLATFORMS[platform].flag_values,
+            name = _platform,
             constraint_values = PLATFORMS[platform].compatible_with,
+            visibility = ["//visibility:private"],
+        )
+        selects.config_setting_group(
+            name = platform,
+            match_all = PLATFORMS[platform].target_settings + [_platform],
             visibility = ["//visibility:private"],
         )
 

--- a/tests/toolchains/BUILD.bazel
+++ b/tests/toolchains/BUILD.bazel
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("//python/private:bzlmod_enabled.bzl", "BZLMOD_ENABLED")  # buildifier: disable=bzl-visibility
 load("//tests/support:sh_py_run_test.bzl", "py_reconfig_test")
 load(":defs.bzl", "define_toolchain_tests")
@@ -29,4 +30,11 @@ py_reconfig_test(
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
     ] if BZLMOD_ENABLED else ["@platforms//:incompatible"],
+)
+
+build_test(
+    name = "build_test",
+    targets = [
+        "@python_3_11//:python_headers",
+    ],
 )


### PR DESCRIPTION
During the refactor we forgot one more place where the `flag_values` on
the platform information was used. They were no longer populated and
broke.

The solution is to use `selects.config_setting_group` to maintain
behaviour and in order to smoke test I have added a target to verify
that the aliases work.

Related to #2875
Fixes #2993
