### PR TITLE
feat(pypi): generate filegroup with all extracted wheel files

### DIFF
--- a/python/private/pypi/labels.bzl
+++ b/python/private/pypi/labels.bzl
@@ -14,6 +14,7 @@
 
 """Constants used by parts of pip_repository for naming libraries and wheels."""
 
+EXTRACTED_WHEEL_FILES = "extracted_whl_files"
 WHEEL_FILE_PUBLIC_LABEL = "whl"
 WHEEL_FILE_IMPL_LABEL = "_whl"
 PY_LIBRARY_PUBLIC_LABEL = "pkg"

--- a/python/private/pypi/whl_library_targets.bzl
+++ b/python/private/pypi/whl_library_targets.bzl
@@ -24,6 +24,7 @@ load(
     ":labels.bzl",
     "DATA_LABEL",
     "DIST_INFO_LABEL",
+    "EXTRACTED_WHEEL_FILES",
     "PY_LIBRARY_IMPL_LABEL",
     "PY_LIBRARY_PUBLIC_LABEL",
     "WHEEL_ENTRY_POINT_PREFIX",
@@ -101,8 +102,16 @@ def whl_library_targets(
         srcs_exclude = [],
         tags = [],
         filegroups = {
-            DIST_INFO_LABEL: ["site-packages/*.dist-info/**"],
-            DATA_LABEL: ["data/**"],
+            EXTRACTED_WHEEL_FILES: dict(
+                include = ["**"],
+                exclude = ["*.whl"],
+            ),
+            DIST_INFO_LABEL: dict(
+                include = ["site-packages/*.dist-info/**"],
+            ),
+            DATA_LABEL: dict(
+                include = ["data/**"],
+            ),
         },
         dependencies = [],
         dependencies_by_platform = {},
@@ -168,10 +177,11 @@ def whl_library_targets(
     tags = sorted(tags)
     data = [] + data
 
-    for filegroup_name, glob in filegroups.items():
+    for filegroup_name, glob_kwargs in filegroups.items():
+        glob_kwargs = {"allow_empty": True} | glob_kwargs
         native.filegroup(
             name = filegroup_name,
-            srcs = native.glob(glob, allow_empty = True),
+            srcs = native.glob(**glob_kwargs),
             visibility = ["//visibility:public"],
         )
 


### PR DESCRIPTION
Adds a filegroup with all the files that came from the extracted wheel.

This has two benefits over using `whl_filegroup`: it avoids copying the wheel
and makes the set of files directly visible to the analysis phase.

Some wheels are multiple gigabytes in size (e.g. torch, cuda, tensorflow), so
avoiding the copy and archive processing saves a decent amount of time.

Knowing the specific files at analysis time is generally beneficial. The
particular case I ran into was the CC rules were unhappy with a TreeArtifact
of header files because they couldn't enforce some check about who was
properly providing headers that were included (layering check?).

Another example is using the unused_inputs_list optimization, which allows
an action to ignore inputs that aren't actually used. e.g. an action could
take all the wheel's files as inputs, only care about the headers, and then
tell bazel all the non-header files aren't relevant, and thus changes to
other files don't re-run the thing that only cares about headers.