### PR TITLE
fix(pypi): namespace_pkgs should pass correct arguments

### DIFF
--- a/python/private/pypi/namespace_pkgs.bzl
+++ b/python/private/pypi/namespace_pkgs.bzl
@@ -59,25 +59,32 @@ def get_files(*, srcs, ignored_dirnames = [], root = None):
 
     return sorted([d for d in dirs if d not in ignored])
 
-def create_inits(**kwargs):
+def create_inits(*, srcs, ignored_dirnames = [], root = None, copy_file = copy_file, **kwargs):
     """Create init files and return the list to be included `py_library` srcs.
 
     Args:
-        **kwargs: passed to {obj}`get_files`.
+        srcs: {type}`src` a list of files to be passed to {bzl:obj}`py_library`
+            as `srcs` and `data`. This is usually a result of a {obj}`glob`.
+        ignored_dirnames: {type}`str` a list of patterns to ignore.
+        root: {type}`str` the prefix to use as the root.
+        copy_file: the `copy_file` rule to copy files in build context.
+        **kwargs: passed to {obj}`copy_file`.
 
     Returns:
         {type}`list[str]` to be included as part of `py_library`.
     """
-    srcs = []
-    for out in get_files(**kwargs):
+    ret = []
+    for i, out in enumerate(get_files(srcs = srcs, ignored_dirnames = ignored_dirnames, root = root)):
         src = "{}/__init__.py".format(out)
-        srcs.append(srcs)
+        ret.append(src)
 
         copy_file(
-            name = "_cp_{}_namespace".format(out),
+            # For the target name, use a number instead of trying to convert an output
+            # path into a valid label.
+            name = "_cp_{}_namespace".format(i),
             src = _TEMPLATE,
             out = src,
             **kwargs
         )
 
-    return srcs
+    return ret


### PR DESCRIPTION
It seems that the only function that did not have unit tests have bugs and the integration tests did not catch it because we weren't creating namespacepkg `__init__.py` files.

This change fixes the bug, adds a unit test for the remaining untested function.

Fixes #3023