### PR TITLE
fix: parsing local version with digit followed by non-digits

### DIFF
--- a/python/private/version.bzl
+++ b/python/private/version.bzl
@@ -297,10 +297,9 @@ def accept_separator_alnum(parser):
     Returns:
       whether a separator and an alphanumeric string were accepted.
     """
-
-    # Input is "0.1.0+brt.9e"
     ctx = parser.open_context()
 
+    # PEP 440: Local version segments
     if not accept(parser, _in([".", "-", "_"]), "."):
         return parser.discard()
 
@@ -312,15 +311,6 @@ def accept_separator_alnum(parser):
         if value.isdigit():
             value = str(int(value))
             ctx["norm"] = ctx["norm"][0] + value
-        return parser.accept()
-
-    return parser.discard()
-
-    # PEP 440: Local version segments
-    if (
-        accept(parser, _in([".", "-", "_"]), ".") and
-        (accept_digits(parser) or accept_alnum(parser))
-    ):
         return parser.accept()
 
     return parser.discard()

--- a/tests/version/version_test.bzl
+++ b/tests/version/version_test.bzl
@@ -105,6 +105,14 @@ def _test_normalization(env):
 
 _tests.append(_test_normalization)
 
+def _test_normalize_local(env):
+    # Verify a local with a [digit][non-digit] sequence parses ok
+    in_str = "0.1.0+brt.9e"
+    actual = version.normalize(in_str)
+    env.expect.that_str(actual).equals("xxx")
+
+_tests.append(_test_normalize_local)
+
 def _test_ordering(env):
     want = [
         # Taken from https://peps.python.org/pep-0440/#summary-of-permitted-suffixes-and-relative-ordering

--- a/tests/version/version_test.bzl
+++ b/tests/version/version_test.bzl
@@ -109,7 +109,7 @@ def _test_normalize_local(env):
     # Verify a local with a [digit][non-digit] sequence parses ok
     in_str = "0.1.0+brt.9e"
     actual = version.normalize(in_str)
-    env.expect.that_str(actual).equals("xxx")
+    env.expect.that_str(actual).equals(in_str)
 
 _tests.append(_test_normalize_local)
 


### PR DESCRIPTION
When parsing the local identifier segment of `<digit><letter>` the parser would
give an error saying the letter was unexpected.

What was happening was `accept_digits()` consumed up to the first non-digit, and
considered this success, which prevented calling `accept_alnum()` to finish
the parsing.

To fix, only call `accept_alnum()`, then post-process the value to normalize
an all-digit segment.

I'm guessing `accept_digits()` stopping at the first non-digit is WAI because
it expects to parse e.g. "3.14b", where the caller handles subsequent
characters.

Along the way, some minor doc improvements to the parser code.

Fixes https://github.com/bazel-contrib/rules_python/issues/3030