### PR TITLE
fix: add py.typed to runfiles py_wheel so it gets packaged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ END_UNRELEASED_TEMPLATE
 * (pypi) Wheels with BUILD.bazel (or other special Bazel files) no longer
   result in missing files at runtime
   ([#2782](https://github.com/bazel-contrib/rules_python/issues/2782)).
+* (runfiles) The pypi runfiles package now includes `py.typed` to indicate it
+  supports type checking.
 
 {#v0-0-0-added}
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,8 @@ END_UNRELEASED_TEMPLATE
   result in missing files at runtime
   ([#2782](https://github.com/bazel-contrib/rules_python/issues/2782)).
 * (runfiles) The pypi runfiles package now includes `py.typed` to indicate it
-  supports type checking.
+  supports type checking
+  ([#2503](https://github.com/bazel-contrib/rules_python/issues/2503)).
 
 {#v0-0-0-added}
 ### Added

--- a/python/runfiles/BUILD.bazel
+++ b/python/runfiles/BUILD.bazel
@@ -24,6 +24,7 @@ filegroup(
 
 filegroup(
     name = "py_typed",
+    # See PEP 561: py.typed is a special file that indicates the code supports type checking
     srcs = ["py.typed"],
 )
 

--- a/python/runfiles/BUILD.bazel
+++ b/python/runfiles/BUILD.bazel
@@ -22,13 +22,18 @@ filegroup(
     visibility = ["//python:__pkg__"],
 )
 
+filegroup(
+    name = "py_typed",
+    srcs = ["py.typed"],
+)
+
 py_library(
     name = "runfiles",
     srcs = [
         "__init__.py",
         "runfiles.py",
     ],
-    data = ["py.typed"],
+    data = [":py_typed"],
     imports = [
         # Add the repo root so `import python.runfiles.runfiles` works. This makes it agnostic
         # to the --experimental_python_import_all_repositories setting.
@@ -57,5 +62,8 @@ py_wheel(
     # this can be replaced by building with --stamp --embed_label=1.2.3
     version = "{BUILD_EMBED_LABEL}",
     visibility = ["//visibility:public"],
-    deps = [":runfiles"],
+    deps = [
+        ":py_typed",
+        ":runfiles",
+    ],
 )


### PR DESCRIPTION
Per the guidance in #2503, this is a quick fix just to restore type-checking for the runfiles package. It does not address or investigate further whether py.typed data dependencies in direct `py_library` dependencies of `py_wheel` should be automatically included as inputs to the wheel. 

Fixes #2503