### PR TITLE
fix: Don't let deprecated test targets get matched by '...'

### DIFF
--- a/python/private/pypi/pip_compile.bzl
+++ b/python/private/pypi/pip_compile.bzl
@@ -196,4 +196,5 @@ def pip_compile(
         name = "{}_test".format(name),
         actual = ":{}.test".format(name),
         deprecation = "Use '{}.test' instead. The '*_test' target will be removed in the next major release.".format(name),
+        tags = ["manual"],
     )


### PR DESCRIPTION
This fixes "target '//foo_test' is deprecated: Use 'foo.test' instead. The '*_test' target will be removed in the next major release." being warned about once per `compile_pip_requirement` call when running `bazel test ...`.