### PR TITLE
fix(local-toolchains): don't watch non-existent include directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,9 @@ END_UNRELEASED_TEMPLATE
 * (pypi) Wheels with BUILD.bazel (or other special Bazel files) no longer
   result in missing files at runtime
   ([#2782](https://github.com/bazel-contrib/rules_python/issues/2782)).
+* (toolchains) `local_runtime_repo` now checks if the include directory exists
+  before attempting to watch it, fixing issues on macOS with system Python
+  ({gh-issue}`3043`).
 
 {#v0-0-0-added}
 ### Added

--- a/python/private/local_runtime_repo.bzl
+++ b/python/private/local_runtime_repo.bzl
@@ -100,12 +100,13 @@ def _local_runtime_repo_impl(rctx):
 
     # NOTE: Keep in sync with recursive glob in define_local_runtime_toolchain_impl
     include_path = rctx.path(info["include"])
+
+    # The reported include path may not exist, and watching a non-existant
+    # path is an error. Silently skip, since includes are only necessary
+    # if C extensions are built.
     if include_path.exists and include_path.is_dir:
         repo_utils.watch_tree(rctx, include_path)
     else:
-        # If the path doesn't exist or is not a directory, do not watch it.
-        # This handles the case where the include path specified in Python metadata
-        # is invalid or points to a file.
         pass
 
     # The cc_library.includes values have to be non-absolute paths, otherwise

--- a/python/private/local_runtime_repo.bzl
+++ b/python/private/local_runtime_repo.bzl
@@ -99,7 +99,14 @@ def _local_runtime_repo_impl(rctx):
     interpreter_path = info["base_executable"]
 
     # NOTE: Keep in sync with recursive glob in define_local_runtime_toolchain_impl
-    repo_utils.watch_tree(rctx, rctx.path(info["include"]))
+    include_path = rctx.path(info["include"])
+    if include_path.exists and include_path.is_dir:
+        repo_utils.watch_tree(rctx, include_path)
+    else:
+        # If the path doesn't exist or is not a directory, do not watch it.
+        # This handles the case where the include path specified in Python metadata
+        # is invalid or points to a file.
+        pass
 
     # The cc_library.includes values have to be non-absolute paths, otherwise
     # the toolchain will give an error. Work around this error by making them

--- a/python/private/local_runtime_repo.bzl
+++ b/python/private/local_runtime_repo.bzl
@@ -100,13 +100,12 @@ def _local_runtime_repo_impl(rctx):
 
     # NOTE: Keep in sync with recursive glob in define_local_runtime_toolchain_impl
     include_path = rctx.path(info["include"])
-
-    # The reported include path may not exist, and watching a non-existant
-    # path is an error. Silently skip, since includes are only necessary
-    # if C extensions are built.
     if include_path.exists and include_path.is_dir:
         repo_utils.watch_tree(rctx, include_path)
     else:
+        # If the path doesn't exist or is not a directory, do not watch it.
+        # This handles the case where the include path specified in Python metadata
+        # is invalid or points to a file.
         pass
 
     # The cc_library.includes values have to be non-absolute paths, otherwise


### PR DESCRIPTION
Apparently, Macs can mis-report their include directory.

Since includes are only needed if C extensions are built, skip watching the directory
if it doesn't exist.

Work around for https://github.com/bazel-contrib/rules_python/issues/3043