### PR TITLE
docs: doc expectations of ai-assisted contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -320,13 +320,22 @@ Not breaking changes:
 
 ## AI-assisted Contributions
 
-Contributions assisted by AI tools are welcome. However, the human author submitting the Pull Request (PR) bears full responsibility for the contributed code. This means:
+Contributions assisted by AI tools are allowed. However, the human author
+submitting the pull request is responsible for the contributed code as if they
+had written it entirely themselves. This means:
 
-*   **Understanding the Code:** You must be able to explain what the code does and why it's implemented that way.
-*   **Vetting for Correctness and Functionality:** You are responsible for thoroughly testing and verifying that the code is correct, functional, and meets all project requirements and standards.
-*   **Cogent Discussion:** You must be able to discuss the code, its implications, and any trade-offs made during its development, just as if you had written it entirely yourself.
+*   **Understanding the code:** You must be able to explain what the code does
+    and why it's implemented that way. This includes discussing its
+    implications, and any trade-offs made during its development, just as if you
+    had written it entirely yourself.
+*   **Vetting the correctness and functionality:** You are responsible for
+    thoroughly testing and verifying that the code is correct, functional, and
+    meets all project requirements and standards.
 
-If the human PR author cannot fulfill these responsibilities, the `rules_python` maintainers will not spend time reviewing or merging the PR. The goal is to ensure that all contributions, regardless of their origin, maintain the quality and integrity of the project and do not place an undue burden on maintainers.
+If the human PR author cannot fulfill these responsibilities, the `rules_python`
+maintainers will not spend time reviewing or merging the PR. The goal is to
+ensure that all contributions, regardless of their origin, maintain the quality
+and integrity of the project and do not place an undue burden on maintainers.
 
 ## FAQ
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -318,6 +318,16 @@ Not breaking changes:
   * Changing internal details, such as renaming an internal file.
   * Changing a rule to a macro.
 
+## AI-assisted Contributions
+
+Contributions assisted by AI tools are welcome. However, the human author submitting the Pull Request (PR) bears full responsibility for the contributed code. This means:
+
+*   **Understanding the Code:** You must be able to explain what the code does and why it's implemented that way.
+*   **Vetting for Correctness and Functionality:** You are responsible for thoroughly testing and verifying that the code is correct, functional, and meets all project requirements and standards.
+*   **Cogent Discussion:** You must be able to discuss the code, its implications, and any trade-offs made during its development, just as if you had written it entirely yourself.
+
+If the human PR author cannot fulfill these responsibilities, the `rules_python` maintainers will not spend time reviewing or merging the PR. The goal is to ensure that all contributions, regardless of their origin, maintain the quality and integrity of the project and do not place an undue burden on maintainers.
+
 ## FAQ
 
 ### Installation errors when during `git commit`


### PR DESCRIPTION
A lot of this should go without saying, but I want to have a written reference we
can refer to and so it's clear to potential contributors.

The two basic points it makes is that AI-assisted contributions are allowed, but
they're treated no different than regular contributions, so all the usual expectations
apply.