### PR TITLE
fix(pypi): only generate namespace package shims if implicit namespaces are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,18 @@ END_UNRELEASED_TEMPLATE
 ### Removed
 * Nothing removed.
 
+{#1-5-1}
+## [1.5.1] - 2025-06-XX
+
+[1.5.1]: https://github.com/bazel-contrib/rules_python/releases/tag/1.5.1
+
+{#v1-5-1-fixed}
+### Fixed
+
+* (pypi) Namespace packages work by default (pkgutil shims are generated
+  by default again)
+  ([#3038](https://github.com/bazel-contrib/rules_python/issues/3038)).
+
 {#1-5-0}
 ## [1.5.0] - 2025-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ END_UNRELEASED_TEMPLATE
 * Nothing removed.
 
 {#1-5-1}
-## [1.5.1] - 2025-06-XX
+## [1.5.1] - 2025-07-06
 
 [1.5.1]: https://github.com/bazel-contrib/rules_python/releases/tag/1.5.1
 

--- a/python/private/pypi/whl_library_targets.bzl
+++ b/python/private/pypi/whl_library_targets.bzl
@@ -331,7 +331,7 @@ def whl_library_targets(
             allow_empty = True,
         )
 
-        if enable_implicit_namespace_pkgs:
+        if not enable_implicit_namespace_pkgs:
             srcs = srcs + getattr(native, "select", select)({
                 Label("//python/config_settings:is_venvs_site_packages"): [],
                 "//conditions:default": create_inits(

--- a/tests/pypi/whl_library_targets/whl_library_targets_tests.bzl
+++ b/tests/pypi/whl_library_targets/whl_library_targets_tests.bzl
@@ -16,9 +16,17 @@
 
 load("@rules_testing//lib:test_suite.bzl", "test_suite")
 load("//python/private:glob_excludes.bzl", "glob_excludes")  # buildifier: disable=bzl-visibility
-load("//python/private/pypi:whl_library_targets.bzl", "whl_library_targets", "whl_library_targets_from_requires")  # buildifier: disable=bzl-visibility
+load("//python/private/pypi:whl_library_targets.bzl", _whl_library_targets = "whl_library_targets", _whl_library_targets_from_requires = "whl_library_targets_from_requires")  # buildifier: disable=bzl-visibility
 
 _tests = []
+
+def whl_library_targets(**kwargs):
+    # Let's skip testing this for now
+    _whl_library_targets(enable_implicit_namespace_pkgs = True, **kwargs)
+
+def whl_library_targets_from_requires(**kwargs):
+    # Let's skip testing this for now
+    _whl_library_targets_from_requires(enable_implicit_namespace_pkgs = True, **kwargs)
 
 def _test_filegroups(env):
     calls = []


### PR DESCRIPTION
The refactoring to move the pkgutil shim generation to build phase inverted
the logic for when it should be activated. When
`enable_implicit_namespace_pkgs=True`, it means to not generate the pkgutil shims
("respect the Python definition of the namespace package").

To fix, just invert the logic that activates it.

A test will be added in a subsequent PR because the necessary helper isn't
in the 1.5 branch.

Fixes https://github.com/bazel-contrib/rules_python/issues/3038