### PR TITLE
build(gazelle): Update Gazelle, to bring in bzlmod support

### DIFF
--- a/gazelle/MODULE.bazel
+++ b/gazelle/MODULE.bazel
@@ -7,7 +7,7 @@ module(
 bazel_dep(name = "bazel_skylib", version = "1.6.1")
 bazel_dep(name = "rules_python", version = "0.18.0")
 bazel_dep(name = "rules_go", version = "0.41.0", repo_name = "io_bazel_rules_go")
-bazel_dep(name = "gazelle", version = "0.33.0", repo_name = "bazel_gazelle")
+bazel_dep(name = "gazelle", version = "0.44.0", repo_name = "bazel_gazelle")
 bazel_dep(name = "rules_cc", version = "0.0.16")
 
 local_path_override(

--- a/gazelle/python/testdata/respect_kind_mapping/BUILD.out
+++ b/gazelle/python/testdata/respect_kind_mapping/BUILD.out
@@ -1,5 +1,5 @@
-load(":mytest.bzl", "my_test")
 load("@rules_python//python:defs.bzl", "py_library")
+load(":mytest.bzl", "my_test")
 
 # gazelle:map_kind py_test my_test :mytest.bzl
 


### PR DESCRIPTION
This upgrades the version of Gazelle to HEAD. I need this, because I'd like to write tests in https://github.com/bazel-contrib/rules_python/pull/3057 against a setup using bzlmod, but our current version doesn't support that:

```
$ bazel test //...
FAIL: //python:python_test_directive_python_generate_proto_module_protobuf (Exit 1) (see /home/charles/.cache/bazel/_bazel_charles/25da5a3f5a375d8b77b073daf0c17156/execroot/_main/bazel-out/k8-fastbuild/testlogs/python/python_test_directive_python_generate_proto_module_protobuf/test.log)
INFO: From Testing //python:python_test_directive_python_generate_proto_module_protobuf:
==================== Test output for //python:python_test_directive_python_generate_proto_module_protobuf:
--- FAIL: TestGazelleBinary (0.00s)
    --- FAIL: TestGazelleBinary/directive_python_generate_proto_module_protobuf (0.01s)
        python_test.go:169: expected gazelle exit code: 0
            got: 1
        python_test.go:179: expected gazelle stderr: 
            got: gazelle: -repo_root not specified, and WORKSPACE cannot be found: file does not exist
        python_test.go:144: "" exists
        python_test.go:144: "/directive_python_generate_proto_module_protobuf" exists
        python_test.go:144: "/directive_python_generate_proto_module_protobuf/BUILD" exists
        python_test.go:144: "/directive_python_generate_proto_module_protobuf/MODULE.bazel" exists
        python_test.go:144: "/directive_python_generate_proto_module_protobuf/README.md" exists
        python_test.go:144: "/directive_python_generate_proto_module_protobuf/foo.proto" exists
        python_test.go:144: "/directive_python_generate_proto_module_protobuf/test.yaml" exists
FAIL
```

(note the `MODULE.bazel` in the above logs. That's the test I'm adding covering bzlmod support.)

With this change, the test works:
```
$ bazel test //...
# ...
Executed 70 out of 71 tests: 71 tests pass.
```