### PR TITLE
fix(gazelle) Update gazelle to properly process multi-line python imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ END_UNRELEASED_TEMPLATE
 * (toolchain) Python 3.13 now references 3.13.5
 * (gazelle) Switched back to smacker/go-tree-sitter, fixing
   [#2630](https://github.com/bazel-contrib/rules_python/issues/2630)
+* (gazelle) Cleanup multi-line python imports modules
 
 {#v0-0-0-fixed}
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ END_UNRELEASED_TEMPLATE
 * (toolchain) Python 3.13 now references 3.13.5
 * (gazelle) Switched back to smacker/go-tree-sitter, fixing
   [#2630](https://github.com/bazel-contrib/rules_python/issues/2630)
-* (gazelle) Cleanup multi-line python imports modules
 
 {#v0-0-0-fixed}
 ### Fixed
@@ -87,6 +86,7 @@ END_UNRELEASED_TEMPLATE
   ({gh-issue}`3043`).
 * (pypi) The pipstar `defaults` configuration now supports any custom platform
   name.
+* Multi-line python imports (e.g. with escaped newlines) are now correctly processed by Gazelle.
 
 {#v0-0-0-added}
 ### Added

--- a/gazelle/python/file_parser.go
+++ b/gazelle/python/file_parser.go
@@ -146,9 +146,11 @@ func parseImportStatement(node *sitter.Node, code []byte) (Module, bool) {
 
 // cleanImportString removes backslashes and all whitespace from the string.
 func cleanImportString(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "")
 	s = strings.ReplaceAll(s, "\\", "")
 	s = strings.ReplaceAll(s, " ", "")
 	s = strings.ReplaceAll(s, "\n", "")
+	s = strings.ReplaceAll(s, "\t", "")
 	return s
 }
 
@@ -163,6 +165,7 @@ func (p *FileParser) parseImportStatements(node *sitter.Node) bool {
 				continue
 			}
 			m.From = cleanImportString(m.From)
+			m.Name = cleanImportString(m.Name)
 			m.Filepath = p.relFilepath
 			m.TypeCheckingOnly = p.inTypeCheckingBlock
 			if strings.HasPrefix(m.Name, ".") {
@@ -185,6 +188,7 @@ func (p *FileParser) parseImportStatements(node *sitter.Node) bool {
 			}
 			m.Filepath = p.relFilepath
 			m.From = from
+			m.Name = cleanImportString(m.Name)
 			m.Name = fmt.Sprintf("%s.%s", from, m.Name)
 			m.TypeCheckingOnly = p.inTypeCheckingBlock
 			p.output.Modules = append(p.output.Modules, m)

--- a/gazelle/python/file_parser.go
+++ b/gazelle/python/file_parser.go
@@ -144,6 +144,14 @@ func parseImportStatement(node *sitter.Node, code []byte) (Module, bool) {
 	return Module{}, false
 }
 
+// cleanImportString removes backslashes and all whitespace from the string.
+func cleanImportString(s string) string {
+	s = strings.ReplaceAll(s, "\\", "")
+	s = strings.ReplaceAll(s, " ", "")
+	s = strings.ReplaceAll(s, "\n", "")
+	return s
+}
+
 // parseImportStatements parses a node for import statements, returning true if the node is
 // an import statement. It updates FileParser.output.Modules with the `module` that the
 // import represents.
@@ -154,6 +162,7 @@ func (p *FileParser) parseImportStatements(node *sitter.Node) bool {
 			if !ok {
 				continue
 			}
+			m.From = cleanImportString(m.From)
 			m.Filepath = p.relFilepath
 			m.TypeCheckingOnly = p.inTypeCheckingBlock
 			if strings.HasPrefix(m.Name, ".") {
@@ -163,6 +172,7 @@ func (p *FileParser) parseImportStatements(node *sitter.Node) bool {
 		}
 	} else if node.Type() == sitterNodeTypeImportFromStatement {
 		from := node.Child(1).Content(p.code)
+		from = cleanImportString(from)
 		// If the import is from the current package, we don't need to add it to the modules i.e. from . import Class1.
 		// If the import is from a different relative package i.e. from .package1 import foo, we need to add it to the modules.
 		if from == "." {

--- a/gazelle/python/file_parser_test.go
+++ b/gazelle/python/file_parser_test.go
@@ -291,3 +291,32 @@ def example_function():
 		}
 	}
 }
+
+func TestParseImportStatements_MultilineWithBackslashAndWhitespace(t *testing.T) {
+	p := NewFileParser()
+	code := []byte(`from foo.bar.\
+    baz import (
+    Something,
+    AnotherThing
+)
+`)
+	p.SetCodeAndFile(code, "", "test.py")
+	output, err := p.Parse(context.Background())
+	assert.NoError(t, err)
+	// Should parse as: from foo.bar.baz import Something, AnotherThing
+	expected := []Module{
+		{
+			Name:       "foo.bar.baz.Something",
+			LineNumber: 3,
+			Filepath:   "test.py",
+			From:       "foo.bar.baz",
+		},
+		{
+			Name:       "foo.bar.baz.AnotherThing",
+			LineNumber: 4,
+			Filepath:   "test.py",
+			From:       "foo.bar.baz",
+		},
+	}
+	assert.Equal(t, expected, output.Modules)
+}

--- a/gazelle/python/testdata/from_imports/import_nested_var/__init__.py
+++ b/gazelle/python/testdata/from_imports/import_nested_var/__init__.py
@@ -13,4 +13,8 @@
 # limitations under the License.
 
 # baz is a variable in foo/bar/baz.py
-from foo.bar.baz import baz
+from foo\
+    .bar.\
+        baz import (
+            baz
+        )


### PR DESCRIPTION
A python import may be imported as:
```
from foo.bar.application.\
    pipeline.model import (
    Baz
)
```
However, gazelle fails to resolve this import with the error:
`line 30: "foo.bar.application.pipeline.model\\\n     pipeline.mode.Baz" is an invalid dependency:`

Clean up the imports such that whitespace and \n are removed from the import path.