### PR TITLE
refactor(gazelle_manifest): print the wrong hash when encountered

### DIFF
--- a/gazelle/manifest/manifest.go
+++ b/gazelle/manifest/manifest.go
@@ -70,6 +70,9 @@ func (f *File) VerifyIntegrity(manifestGeneratorHashFile, requirements io.Reader
 		return false, fmt.Errorf("failed to verify integrity: %w", err)
 	}
 	valid := (f.Integrity == fmt.Sprintf("%x", integrityBytes))
+	if (!valid) {
+		fmt.Printf("WARN: Integrity hash was %v but expected %x\n", f.Integrity, integrityBytes)
+	}
 	return valid, nil
 }
 


### PR DESCRIPTION
Ideally developers should always re-run the manifest generator, which will update the hash for them.

However I've got clients where the CI system is the only place that all the dependencies can resolve, either because of credentials needed to access the wheelhouse/PyPI, or because of disk exhaustion from massive wheels.

Printing the difference allows a red PR to be greened up just by reading the CI log.
