### PR TITLE
fix: normalize stub_path in repl.bzl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,8 @@ END_UNRELEASED_TEMPLATE
   ([#3099](https://github.com/bazel-contrib/rules_python/issues/3099)).
 * (pypi) Expose pypi packages only common to all Python versions in `all_requirements`
   ([#2921](https://github.com/bazel-contrib/rules_python/issues/2921)).
+* (repl) Normalize the path for the `REPL` stub to make it possible to use the
+  default stub template from outside `rules_python` ({gh-issue}`3101`).
 
 {#v0-0-0-added}
 ### Added

--- a/python/private/repl.bzl
+++ b/python/private/repl.bzl
@@ -1,12 +1,10 @@
 """Implementation of the rules to expose a REPL."""
 
 load("//python:py_binary.bzl", _py_binary = "py_binary")
-load("@bazel_skylib//lib:paths.bzl", "paths")
 
 def _generate_repl_main_impl(ctx):
     stub_repo = ctx.attr.stub.label.repo_name or ctx.workspace_name
-    unnormalized_path = "/".join([stub_repo, ctx.file.stub.short_path])
-    stub_path = paths.normalize(unnormalized_path)
+    stub_path = "/".join([stub_repo, ctx.file.stub.short_path])
 
     out = ctx.actions.declare_file(ctx.label.name + ".py")
 

--- a/python/private/repl.bzl
+++ b/python/private/repl.bzl
@@ -1,10 +1,12 @@
 """Implementation of the rules to expose a REPL."""
 
 load("//python:py_binary.bzl", _py_binary = "py_binary")
+load("@bazel_skylib//lib:paths.bzl", "paths")
 
 def _generate_repl_main_impl(ctx):
     stub_repo = ctx.attr.stub.label.repo_name or ctx.workspace_name
-    stub_path = "/".join([stub_repo, ctx.file.stub.short_path])
+    unnormalized_path = "/".join([stub_repo, ctx.file.stub.short_path])
+    stub_path = paths.normalize(unnormalized_path)
 
     out = ctx.actions.declare_file(ctx.label.name + ".py")
 

--- a/python/private/repl_template.py
+++ b/python/private/repl_template.py
@@ -5,7 +5,9 @@ from pathlib import Path
 
 from python.runfiles import runfiles
 
-STUB_PATH = "%stub_path%"
+# runfiles.py will reject paths which aren't normalized, which can happen when the REPL rules are
+# used from a remote module.
+STUB_PATH = os.path.normpath("%stub_path%")
 
 
 def start_repl():


### PR DESCRIPTION
When a REPL target is run from an external Bazel module, the `stub_path` can have path components in it (e.g. "/..") which get rejected by the `Rlocation()` function in `runfiles.py` for not being normalized. This commit normalizes the path before it's passed to `Rlocation()`.

Fixes #3101