### PR TITLE
fix(gazelle): Rename experimental_allow_relative_imports directive to follow convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ END_UNRELEASED_TEMPLATE
 ### Changed
 * (gazelle) For package mode, resolve dependencies when imports are relative
   to the package path. This is enabled via the
-  `# gazelle:experimental_allow_relative_imports` true directive ({gh-issue}`2203`).
+  `# gazelle:python_experimental_allow_relative_imports` true directive ({gh-issue}`2203`).
 * (gazelle) Types for exposed members of `python.ParserOutput` are now all public.
 * (gazelle) Removed the requirement for `__init__.py`, `__main__.py`, or `__test__.py` files to be
   present in a directory to generate a `BUILD.bazel` file.

--- a/gazelle/README.md
+++ b/gazelle/README.md
@@ -222,7 +222,7 @@ Python-specific directives are as follows:
 | Defines the format of the distribution name in labels to third-party deps. Useful for using Gazelle plugin with other rules with different repository conventions (e.g. `rules_pycross`). Full label is always prepended with (pip) repository name, e.g. `@pip//numpy`.                        |
 | `# gazelle:python_label_normalization`                                                                                                                                                                                                                                                          | `snake_case` |
 | Controls how distribution names in labels to third-party deps are normalized. Useful for using Gazelle plugin with other rules with different label conventions (e.g. `rules_pycross` uses PEP-503). Can be "snake_case", "none", or "pep503".                                                  |
-| `# gazelle:experimental_allow_relative_imports`          | `false` |
+| `# gazelle:python_experimental_allow_relative_imports`          | `false` |
 | Controls whether Gazelle resolves dependencies for import statements that use paths relative to the current package. Can be "true" or "false".|
 | `# gazelle:python_generate_pyi_deps`                                                                                                                                                                                                                                                            | `false` |
 | Controls whether to generate a separate `pyi_deps` attribute for type-checking dependencies or merge them into the regular `deps` attribute. When `false` (default), type-checking dependencies are merged into `deps` for backward compatibility. When `true`, generates separate `pyi_deps`. Imports in blocks with the format `if typing.TYPE_CHECKING:`/`if TYPE_CHECKING:` and type-only stub packages (eg. boto3-stubs) are recognized as type-checking dependencies. |
@@ -736,7 +736,7 @@ See [Issue #3076][gh3076] for more information.
 [gh3076]: https://github.com/bazel-contrib/rules_python/issues/3076
 
 
-#### Directive: `experimental_allow_relative_imports`
+#### Directive: `python_experimental_allow_relative_imports`
 Enables experimental support for resolving relative imports in
 `python_generation_mode package`.
 

--- a/gazelle/python/testdata/relative_imports_package_mode/BUILD.in
+++ b/gazelle/python/testdata/relative_imports_package_mode/BUILD.in
@@ -1,2 +1,2 @@
 # gazelle:python_generation_mode package
-# gazelle:experimental_allow_relative_imports true
+# gazelle:python_experimental_allow_relative_imports true

--- a/gazelle/python/testdata/relative_imports_package_mode/BUILD.out
+++ b/gazelle/python/testdata/relative_imports_package_mode/BUILD.out
@@ -1,7 +1,7 @@
 load("@rules_python//python:defs.bzl", "py_binary")
 
 # gazelle:python_generation_mode package
-# gazelle:experimental_allow_relative_imports true
+# gazelle:python_experimental_allow_relative_imports true
 
 py_binary(
     name = "relative_imports_package_mode_bin",

--- a/gazelle/python/testdata/sibling_imports_disabled/BUILD.in
+++ b/gazelle/python/testdata/sibling_imports_disabled/BUILD.in
@@ -1,2 +1,2 @@
 # gazelle:python_resolve_sibling_imports false
-# gazelle:experimental_allow_relative_imports true
+# gazelle:python_experimental_allow_relative_imports true

--- a/gazelle/python/testdata/sibling_imports_disabled/BUILD.out
+++ b/gazelle/python/testdata/sibling_imports_disabled/BUILD.out
@@ -1,7 +1,7 @@
 load("@rules_python//python:defs.bzl", "py_library", "py_test")
 
 # gazelle:python_resolve_sibling_imports false
-# gazelle:experimental_allow_relative_imports true
+# gazelle:python_experimental_allow_relative_imports true
 
 py_library(
     name = "sibling_imports_disabled",

--- a/gazelle/python/testdata/sibling_imports_disabled/README.md
+++ b/gazelle/python/testdata/sibling_imports_disabled/README.md
@@ -10,7 +10,7 @@ disabled. It covers different types of imports in `pkg/unit_test.py`:
   (not the sibling `typing.py`).
 - `from .b import run` / `from .typing import A` - resolves to the sibling
   `pkg/b.py` / `pkg/typing.py` (with
-  `gazelle:experimental_allow_relative_imports` enabled)
+  `gazelle:python_experimental_allow_relative_imports` enabled)
 - `import test_util` - resolves to the root-level `test_util.py` instead of
   the sibling `pkg/test_util.py`
 - `from b import run` - resolves to the root-level `b.py` instead of the

--- a/gazelle/python/testdata/sibling_imports_disabled_file_mode/BUILD.in
+++ b/gazelle/python/testdata/sibling_imports_disabled_file_mode/BUILD.in
@@ -1,3 +1,3 @@
 # gazelle:python_generation_mode file
 # gazelle:python_resolve_sibling_imports false
-# gazelle:experimental_allow_relative_imports true
+# gazelle:python_experimental_allow_relative_imports true

--- a/gazelle/python/testdata/sibling_imports_disabled_file_mode/BUILD.out
+++ b/gazelle/python/testdata/sibling_imports_disabled_file_mode/BUILD.out
@@ -2,7 +2,7 @@ load("@rules_python//python:defs.bzl", "py_library", "py_test")
 
 # gazelle:python_generation_mode file
 # gazelle:python_resolve_sibling_imports false
-# gazelle:experimental_allow_relative_imports true
+# gazelle:python_experimental_allow_relative_imports true
 
 py_library(
     name = "a",

--- a/gazelle/python/testdata/sibling_imports_disabled_file_mode/README.md
+++ b/gazelle/python/testdata/sibling_imports_disabled_file_mode/README.md
@@ -10,7 +10,7 @@ disabled. It covers different types of imports in `pkg/unit_test.py`:
   (not the sibling `typing.py`).
 - `from .b import run` / `from .typing import A` - resolves to the sibling
   `pkg/b.py` / `pkg/typing.py` (with
-  `gazelle:experimental_allow_relative_imports` enabled)
+  `gazelle:python_experimental_allow_relative_imports` enabled)
 - `import test_util` - resolves to the root-level `test_util.py` instead of
   the sibling `pkg/test_util.py`
 - `from b import run` - resolves to the root-level `b.py` instead of the

--- a/gazelle/pythonconfig/pythonconfig.go
+++ b/gazelle/pythonconfig/pythonconfig.go
@@ -99,7 +99,7 @@ const (
 	LabelNormalization = "python_label_normalization"
 	// ExperimentalAllowRelativeImports represents the directive that controls
 	// whether relative imports are allowed.
-	ExperimentalAllowRelativeImports = "experimental_allow_relative_imports"
+	ExperimentalAllowRelativeImports = "python_experimental_allow_relative_imports"
 	// GeneratePyiDeps represents the directive that controls whether to generate
 	// separate pyi_deps attribute or merge type-checking dependencies into deps.
 	// Defaults to false for backward compatibility.


### PR DESCRIPTION
Prefix `experimental_allow_relative_imports` with `python_` to match the rest of the directives.

1.6.0 hasn't been released yet, so this is a non-breaking change.