### PR TITLE
docs(pypi): clarify when extra_hub_aliases was added to workspace

### DIFF
--- a/python/private/pypi/attrs.bzl
+++ b/python/private/pypi/attrs.bzl
@@ -159,6 +159,13 @@ Extra aliases to make for specific wheels in the hub repo. This is useful when
 paired with the {attr}`whl_modifications`.
 
 :::{versionadded} 0.38.0
+
+For `pip.parse` with bzlmod
+:::
+
+:::{versionadded} 1.0.0
+
+For `pip_parse` with workspace.
 :::
 """,
         mandatory = False,


### PR DESCRIPTION
The `extra_hub_aliases` feature was added for bzlmod and workspace in different versions.

Bzlmod added it in 0.38, while workspace added it in 1.0