### PR TITLE
doc: changelog cherry-picks for 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,9 +54,6 @@ END_UNRELEASED_TEMPLATE
 
 {#v0-0-0-changed}
 ### Changed
-* (deps) (bzlmod) Upgraded to `bazel-skylib` version
-  [1.8.1](https://github.com/bazelbuild/bazel-skylib/releases/tag/1.8.1)
-  to remove deprecation warnings.
 * (gazelle) For package mode, resolve dependencies when imports are relative
   to the package path. This is enabled via the
   `# gazelle:python_experimental_allow_relative_imports` true directive ({gh-issue}`2203`).
@@ -112,10 +109,6 @@ END_UNRELEASED_TEMPLATE
 * (toolchains) use "command -v" to find interpreter in `$PATH`
   ([#3150](https://github.com/bazel-contrib/rules_python/pull/3150)).
 * (pypi) `bazel vendor` now works in `bzlmod` ({gh-issue}`3079`).
-* (pypi) Correctly pull `sdist` distributions using `pip`
-  ([#3131](https://github.com/bazel-contrib/rules_python/pull/3131)).
-* (core) builds work again on `7.x` `WORKSPACE` configurations
-  ([#3119](https://github.com/bazel-contrib/rules_python/issues/3119)).
 
 {#v0-0-0-added}
 ### Added
@@ -150,6 +143,24 @@ END_UNRELEASED_TEMPLATE
 {#v0-0-0-removed}
 ### Removed
 * Nothing removed.
+
+{#1-5-2}
+## [1.5.2] - 2025-08-11
+
+[1.5.2]: https://github.com/bazel-contrib/rules_python/releases/tag/1.5.2
+
+{#v1-5-2-changed}
+### Changed
+* (deps) (bzlmod) Upgraded to `bazel-skylib` version
+  [1.8.1](https://github.com/bazelbuild/bazel-skylib/releases/tag/1.8.1)
+  to remove deprecation warnings.
+
+{#v1-5-2-fixed}
+### Fixed
+* (pypi) Correctly pull `sdist` distributions using `pip`
+  ([#3131](https://github.com/bazel-contrib/rules_python/pull/3131)).
+* (core) builds work again on `7.x` `WORKSPACE` configurations
+  ([#3119](https://github.com/bazel-contrib/rules_python/issues/3119)).
 
 {#1-5-1}
 ## [1.5.1] - 2025-07-06


### PR DESCRIPTION
Fixes #3135

The cherry-picks in the release/1.5 branch already include the fixes
to the changelog, so this PR won't need to be cherry-picked itself.