### PR TITLE
docs: link to PyRuntimeInfo and mention it has more than example shows

### DIFF
--- a/docs/howto/get-python-version.md
+++ b/docs/howto/get-python-version.md
@@ -35,6 +35,10 @@ my_rule = rule(
 )
 ```
 
+The `info` variable above is a {obj}`PyRuntimeInfo` object, which contains
+information about the Python runtime. It contains more than just the version;
+see the {obj}`PyRuntimeInfo` docs for its API documentation.
+
 ## Using the rule
 
 In your `BUILD.bazel` file, you can use the rule like this:


### PR DESCRIPTION
Have the example that gets the python version also link to the provider. Also mention
that more than just the version is available.