### PR TITLE
fix: bootstrapping script to not use multiline f-strings

### DIFF
--- a/python/private/python_bootstrap_template.txt
+++ b/python/private/python_bootstrap_template.txt
@@ -436,11 +436,11 @@ def _RunForCoverage(python_program, main_filename, args, env,
   unique_id = uuid.uuid4()
   rcfile_name = os.path.join(os.environ['COVERAGE_DIR'], ".coveragerc_{}".format(unique_id))
   with open(rcfile_name, "w") as rcfile:
-    rcfile.write(f'''[run]
+    rcfile.write('''[run]
 relative_files = True
 source =
 \t{source}
-''')
+'''.format(source=source))
   PrintVerboseCoverage('Coverage entrypoint:', coverage_entrypoint)
   # First run the target Python file via coveragepy to create a .coverage
   # database file, from which we can later export lcov.


### PR DESCRIPTION
With bootstrap_impl=system_python, after
https://github.com/bazel-contrib/rules_python/pull/2607, host Python 3.6 and above is required because of the use of multiline f-strings. For maximum backwards compatibility (because this is a host dependency), do not use multiline f-strings.

This issue naturally does not apply to bootstrap_impl=script because there are no host Python dependency.

Link: https://github.com/bazel-contrib/rules_python/pull/2607

