### PR TITLE
fix(bootstrap): handle when runfiles env vars don't point to current binary's runfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@ END_UNRELEASED_TEMPLATE
 
 [1.6.0]: https://github.com/bazel-contrib/rules_python/releases/tag/1.6.0
 
+{#v0-0-0-fixed}
+## Fixed
+* (bootstrap) The stage1 bootstrap script now correctly handles nested `RUNFILES_DIR`
+  environments, fixing issues where a `py_binary` calls another `py_binary`
+  ([#3187](https://github.com/bazel-contrib/rules_python/issues/3187)).
+
 {#1-6-0-changed}
 ### Changed
 * (gazelle) update minimum gazelle version to 0.36.0 - may cause BUILD file changes
@@ -86,9 +92,6 @@ END_UNRELEASED_TEMPLATE
 
 {#1-6-0-fixed}
 ### Fixed
-* (bootstrap) The stage1 bootstrap script now correctly handles nested `RUNFILES_DIR`
-  environments, fixing issues where a `py_binary` calls another `py_binary`
-  ([#3187](https://github.com/bazel-contrib/rules_python/issues/3187)).
 * (toolchains) `local_runtime_repo` now respects changes to the `DEVELOPER_DIR` and `XCODE_VERSION`
   repo env vars, fixing stale cache issues on macOS with system (i.e. Xcode-supplied) Python
   ([#3123](https://github.com/bazel-contrib/rules_python/issues/3123)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,16 +47,33 @@ BEGIN_UNRELEASED_TEMPLATE
 END_UNRELEASED_TEMPLATE
 -->
 
+{#v0-0-0}
+## Unreleased
+
+[0.0.0]: https://github.com/bazel-contrib/rules_python/releases/tag/0.0.0
+
+{#v0-0-0-changed}
+### Changed
+* Nothing changed.
+
+{#v0-0-0-fixed}
+### Fixed
+* (bootstrap) The stage1 bootstrap script now correctly handles nested `RUNFILES_DIR`
+  environments, fixing issues where a `py_binary` calls another `py_binary`
+  ([#3187](https://github.com/bazel-contrib/rules_python/issues/3187)).
+
+{#v0-0-0-added}
+### Added
+* Nothing added.
+
+{#v0-0-0-removed}
+### Removed
+* Nothing removed.
+
 {#1-6-0}
 ## [1.6.0] - 2025-08-23
 
 [1.6.0]: https://github.com/bazel-contrib/rules_python/releases/tag/1.6.0
-
-{#v0-0-0-fixed}
-## Fixed
-* (bootstrap) The stage1 bootstrap script now correctly handles nested `RUNFILES_DIR`
-  environments, fixing issues where a `py_binary` calls another `py_binary`
-  ([#3187](https://github.com/bazel-contrib/rules_python/issues/3187)).
 
 {#1-6-0-changed}
 ### Changed
@@ -108,7 +125,7 @@ END_UNRELEASED_TEMPLATE
   name.
 * (pypi) The selection of the whls has been changed and should no longer result
   in ambiguous select matches ({gh-issue}`2759`) and should be much more efficient
-  when running `bazel query` due to fewer repositories being included 
+  when running `bazel query` due to fewer repositories being included
   ({gh-issue}`2849`).
 * Multi-line python imports (e.g. with escaped newlines) are now correctly processed by Gazelle.
 * (toolchains) `local_runtime_repo` works with multiarch Debian with Python 3.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,9 @@ END_UNRELEASED_TEMPLATE
 
 {#v0-0-0-fixed}
 ### Fixed
+* (bootstrap) The stage1 bootstrap script now correctly handles nested `RUNFILES_DIR`
+  environments, fixing issues where a `py_binary` calls another `py_binary`
+  ([#3187](https://github.com/bazel-contrib/rules_python/issues/3187)).
 * (pypi) Fixes an issue where builds using a `bazel vendor` vendor directory
   would fail if the constraints file contained environment markers. Fixes
   [#2996](https://github.com/bazel-contrib/rules_python/issues/2996).

--- a/python/private/python_bootstrap_template.txt
+++ b/python/private/python_bootstrap_template.txt
@@ -516,7 +516,6 @@ def Main():
   if os.environ.get("RULES_PYTHON_TESTING_TELL_MODULE_SPACE"):
     new_env["RULES_PYTHON_TESTING_MODULE_SPACE"] = module_space
 
-  print(f"===== module space: {module_space}")
   python_imports = '%imports%'
   python_path_entries = CreatePythonPathEntries(python_imports, module_space)
   python_path_entries += GetRepositoriesImports(module_space, %import_all%)
@@ -539,7 +538,6 @@ def Main():
   new_env['PYTHONPATH'] = python_path
   runfiles_envkey, runfiles_envvalue = RunfilesEnvvar(module_space)
   if runfiles_envkey:
-    print(f"===== setting {runfiles_envkey} = {runfiles_envvalue}")
     new_env[runfiles_envkey] = runfiles_envvalue
 
   # Don't prepend a potentially unsafe path to sys.path

--- a/python/private/python_bootstrap_template.txt
+++ b/python/private/python_bootstrap_template.txt
@@ -513,6 +513,10 @@ def Main():
     module_space = FindModuleSpace(main_rel_path)
     delete_module_space = False
 
+  if os.environ.get("RULES_PYTHON_TESTING_TELL_MODULE_SPACE"):
+    new_env["RULES_PYTHON_TESTING_MODULE_SPACE"] = module_space
+
+  print(f"===== module space: {module_space}")
   python_imports = '%imports%'
   python_path_entries = CreatePythonPathEntries(python_imports, module_space)
   python_path_entries += GetRepositoriesImports(module_space, %import_all%)
@@ -535,6 +539,7 @@ def Main():
   new_env['PYTHONPATH'] = python_path
   runfiles_envkey, runfiles_envvalue = RunfilesEnvvar(module_space)
   if runfiles_envkey:
+    print(f"===== setting {runfiles_envkey} = {runfiles_envvalue}")
     new_env[runfiles_envkey] = runfiles_envvalue
 
   # Don't prepend a potentially unsafe path to sys.path

--- a/python/private/stage1_bootstrap_template.sh
+++ b/python/private/stage1_bootstrap_template.sh
@@ -70,6 +70,9 @@ else
       maybe_root="${RUNFILES_MANIFEST_FILE%%.runfiles/MANIFEST}.runfiles"
     fi
 
+    # The RUNFILES_DIR et al variables may misreport the runfiles directory
+    # if an outer binary invokes this binary when it isn't a data dependency.
+    # e.g. a genrule calls `bazel-bin/outer --inner=bazel-bin/inner`
     if [[ -n "$maybe_root" && -e "$maybe_root/$STAGE2_BOOTSTRAP" ]]; then
       echo "$maybe_root"
       return 0
@@ -102,6 +105,9 @@ else
   RUNFILES_DIR=$(find_runfiles_root $0)
 fi
 
+if [[ -n "$RULES_PYTHON_TESTING_TELL_MODULE_SPACE" ]]; then
+  export RULES_PYTHON_TESTING_MODULE_SPACE="$RUNFILES_DIR"
+fi
 
 function find_python_interpreter() {
   runfiles_root="$1"

--- a/python/private/stage1_bootstrap_template.sh
+++ b/python/private/stage1_bootstrap_template.sh
@@ -61,14 +61,17 @@ if [[ "$IS_ZIPFILE" == "1" ]]; then
 
 else
   function find_runfiles_root() {
+    local maybe_root=""
     if [[ -n "${RUNFILES_DIR:-}" ]]; then
-      echo "$RUNFILES_DIR"
-      return 0
+      maybe_root="$RUNFILES_DIR"
     elif [[ "${RUNFILES_MANIFEST_FILE:-}" = *".runfiles_manifest" ]]; then
-      echo "${RUNFILES_MANIFEST_FILE%%.runfiles_manifest}.runfiles"
-      return 0
+      maybe_root="${RUNFILES_MANIFEST_FILE%%.runfiles_manifest}.runfiles"
     elif [[ "${RUNFILES_MANIFEST_FILE:-}" = *".runfiles/MANIFEST" ]]; then
-      echo "${RUNFILES_MANIFEST_FILE%%.runfiles/MANIFEST}.runfiles"
+      maybe_root="${RUNFILES_MANIFEST_FILE%%.runfiles/MANIFEST}.runfiles"
+    fi
+
+    if [[ -n "$maybe_root" && -e "$maybe_root/$STAGE2_BOOTSTRAP" ]]; then
+      echo "$maybe_root"
       return 0
     fi
 

--- a/tests/bootstrap_impls/bin_calls_bin/BUILD.bazel
+++ b/tests/bootstrap_impls/bin_calls_bin/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tests/support:py_reconfig.bzl", "py_reconfig_binary")
-load("//tests/support:support.bzl", "SUPPORTS_BOOTSTRAP_SCRIPT")
+load("//tests/support:support.bzl", "NOT_WINDOWS", "SUPPORTS_BOOTSTRAP_SCRIPT")
 
 # =====
 # bootstrap_impl=system_python testing
@@ -39,6 +39,10 @@ sh_test(
         "verify.sh",
         ":outer_calls_inner_system_python",
     ],
+    # The way verify_system_python.sh loads verify.sh doesn't work
+    # with Windows for some annoying reason. Just skip windows for now;
+    # the logic being test isn't OS-specific, so this should be fine.
+    target_compatible_with = NOT_WINDOWS,
 )
 
 # =====

--- a/tests/bootstrap_impls/bin_calls_bin/BUILD.bazel
+++ b/tests/bootstrap_impls/bin_calls_bin/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tests/support:py_reconfig.bzl", "py_reconfig_binary")
+load("//tests/support:support.bzl", "SUPPORTS_BOOTSTRAP_SCRIPT")
 
 # =====
 # bootstrap_impl=system_python testing
@@ -9,6 +10,7 @@ py_reconfig_binary(
     srcs = ["outer.py"],
     bootstrap_impl = "system_python",
     main = "outer.py",
+    tags = ["manual"],
 )
 
 py_reconfig_binary(
@@ -16,12 +18,14 @@ py_reconfig_binary(
     srcs = ["inner.py"],
     bootstrap_impl = "system_python",
     main = "inner.py",
+    tags = ["manual"],
 )
 
 genrule(
     name = "outer_calls_inner_system_python",
     outs = ["outer_calls_inner_system_python.out"],
     cmd = "RULES_PYTHON_TESTING_TELL_MODULE_SPACE=1 $(location :outer_bootstrap_system_python) $(location :inner_bootstrap_system_python) > $@",
+    tags = ["manual"],
     tools = [
         ":inner_bootstrap_system_python",
         ":outer_bootstrap_system_python",
@@ -45,6 +49,7 @@ py_reconfig_binary(
     srcs = ["inner.py"],
     bootstrap_impl = "script",
     main = "inner.py",
+    tags = ["manual"],
 )
 
 py_reconfig_binary(
@@ -52,12 +57,14 @@ py_reconfig_binary(
     srcs = ["outer.py"],
     bootstrap_impl = "script",
     main = "outer.py",
+    tags = ["manual"],
 )
 
 genrule(
     name = "outer_calls_inner_script_python",
     outs = ["outer_calls_inner_script_python.out"],
     cmd = "RULES_PYTHON_TESTING_TELL_MODULE_SPACE=1 $(location :outer_bootstrap_script) $(location :inner_bootstrap_script) > $@",
+    tags = ["manual"],
     tools = [
         ":inner_bootstrap_script",
         ":outer_bootstrap_script",
@@ -71,4 +78,5 @@ sh_test(
         "verify.sh",
         ":outer_calls_inner_script_python",
     ],
+    target_compatible_with = SUPPORTS_BOOTSTRAP_SCRIPT,
 )

--- a/tests/bootstrap_impls/bin_calls_bin/BUILD.bazel
+++ b/tests/bootstrap_impls/bin_calls_bin/BUILD.bazel
@@ -1,0 +1,74 @@
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//tests/support:py_reconfig.bzl", "py_reconfig_binary")
+
+# =====
+# bootstrap_impl=system_python testing
+# =====
+py_reconfig_binary(
+    name = "outer_bootstrap_system_python",
+    srcs = ["outer.py"],
+    bootstrap_impl = "system_python",
+    main = "outer.py",
+)
+
+py_reconfig_binary(
+    name = "inner_bootstrap_system_python",
+    srcs = ["inner.py"],
+    bootstrap_impl = "system_python",
+    main = "inner.py",
+)
+
+genrule(
+    name = "outer_calls_inner_system_python",
+    outs = ["outer_calls_inner_system_python.out"],
+    cmd = "RULES_PYTHON_TESTING_TELL_MODULE_SPACE=1 $(location :outer_bootstrap_system_python) $(location :inner_bootstrap_system_python) > $@",
+    tools = [
+        ":inner_bootstrap_system_python",
+        ":outer_bootstrap_system_python",
+    ],
+)
+
+sh_test(
+    name = "bootstrap_system_python_test",
+    srcs = ["verify_system_python.sh"],
+    data = [
+        "verify.sh",
+        ":outer_calls_inner_system_python",
+    ],
+)
+
+# =====
+# bootstrap_impl=script testing
+# =====
+py_reconfig_binary(
+    name = "inner_bootstrap_script",
+    srcs = ["inner.py"],
+    bootstrap_impl = "script",
+    main = "inner.py",
+)
+
+py_reconfig_binary(
+    name = "outer_bootstrap_script",
+    srcs = ["outer.py"],
+    bootstrap_impl = "script",
+    main = "outer.py",
+)
+
+genrule(
+    name = "outer_calls_inner_script_python",
+    outs = ["outer_calls_inner_script_python.out"],
+    cmd = "RULES_PYTHON_TESTING_TELL_MODULE_SPACE=1 $(location :outer_bootstrap_script) $(location :inner_bootstrap_script) > $@",
+    tools = [
+        ":inner_bootstrap_script",
+        ":outer_bootstrap_script",
+    ],
+)
+
+sh_test(
+    name = "bootstrap_script_python_test",
+    srcs = ["verify_script_python.sh"],
+    data = [
+        "verify.sh",
+        ":outer_calls_inner_script_python",
+    ],
+)

--- a/tests/bootstrap_impls/bin_calls_bin/inner.py
+++ b/tests/bootstrap_impls/bin_calls_bin/inner.py
@@ -1,0 +1,4 @@
+import os
+
+module_space = os.environ.get("RULES_PYTHON_TESTING_MODULE_SPACE")
+print(f"inner: RULES_PYTHON_TESTING_MODULE_SPACE='{module_space}'")

--- a/tests/bootstrap_impls/bin_calls_bin/outer.py
+++ b/tests/bootstrap_impls/bin_calls_bin/outer.py
@@ -1,0 +1,18 @@
+import subprocess
+import sys
+import os
+
+if __name__ == "__main__":
+    module_space = os.environ.get("RULES_PYTHON_TESTING_MODULE_SPACE")
+    print(f"outer: RULES_PYTHON_TESTING_MODULE_SPACE='{module_space}'")
+
+    inner_binary_path = sys.argv[1]
+    result = subprocess.run(
+        [inner_binary_path],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    print(result.stdout, end="")
+    if result.stderr:
+        print(result.stderr, end="", file=sys.stderr)

--- a/tests/bootstrap_impls/bin_calls_bin/outer.py
+++ b/tests/bootstrap_impls/bin_calls_bin/outer.py
@@ -1,6 +1,6 @@
+import os
 import subprocess
 import sys
-import os
 
 if __name__ == "__main__":
     module_space = os.environ.get("RULES_PYTHON_TESTING_MODULE_SPACE")

--- a/tests/bootstrap_impls/bin_calls_bin/verify.sh
+++ b/tests/bootstrap_impls/bin_calls_bin/verify.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+verify_output() {
+  local OUTPUT_FILE=$1
+
+  # Extract the RULES_PYTHON_TESTING_MODULE_SPACE values
+  local OUTER_MODULE_SPACE=$(grep "outer: RULES_PYTHON_TESTING_MODULE_SPACE" "$OUTPUT_FILE" | sed "s/outer: RULES_PYTHON_TESTING_MODULE_SPACE='\(.*\)'/\1/")
+  local INNER_MODULE_SPACE=$(grep "inner: RULES_PYTHON_TESTING_MODULE_SPACE" "$OUTPUT_FILE" | sed "s/inner: RULES_PYTHON_TESTING_MODULE_SPACE='\(.*\)'/\1/")
+
+  echo "Outer module space: $OUTER_MODULE_SPACE"
+  echo "Inner module space: $INNER_MODULE_SPACE"
+
+  # Check 1: The two values are different
+  if [ "$OUTER_MODULE_SPACE" == "$INNER_MODULE_SPACE" ]; then
+    echo "Error: Outer and Inner module spaces are the same."
+    exit 1
+  fi
+
+  # Check 2: Inner is not a subdirectory of Outer
+  case "$INNER_MODULE_SPACE" in
+    "$OUTER_MODULE_SPACE"/*)
+      echo "Error: Inner module space is a subdirectory of Outer's."
+      exit 1
+      ;;
+    *)
+      # This is the success case
+      ;;
+  esac
+
+  echo "Verification successful."
+}

--- a/tests/bootstrap_impls/bin_calls_bin/verify_script_python.sh
+++ b/tests/bootstrap_impls/bin_calls_bin/verify_script_python.sh
@@ -1,17 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-# rules_python_get_runfiles_path is a helper to correctly look up runfiles.
-# It is needed because on Windows, the path to a runfile can be absolute,
-# which is not something that bash can handle. So we use cygpath to fix it up.
-rules_python_get_runfiles_path() {
-    local path="$1"
-    if [[ -f /bin/cygpath ]]; then
-        cygpath -u "${path}"
-    else
-        echo "${path}"
-    fi
-}
-
-source "$(rules_python_get_runfiles_path "$(dirname "$0")/verify.sh")"
-verify_output "$(rules_python_get_runfiles_path "$(dirname "$0")/outer_calls_inner_script_python.out")"
+source "$(dirname "$0")/verify.sh"
+verify_output "$(dirname "$0")/outer_calls_inner_script_python.out"

--- a/tests/bootstrap_impls/bin_calls_bin/verify_script_python.sh
+++ b/tests/bootstrap_impls/bin_calls_bin/verify_script_python.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
 set -euo pipefail
-source "$(dirname "$0")/verify.sh"
-verify_output "$(dirname "$0")/outer_calls_inner_script_python.out"
+
+# rules_python_get_runfiles_path is a helper to correctly look up runfiles.
+# It is needed because on Windows, the path to a runfile can be absolute,
+# which is not something that bash can handle. So we use cygpath to fix it up.
+rules_python_get_runfiles_path() {
+    local path="$1"
+    if [[ -f /bin/cygpath ]]; then
+        cygpath -u "${path}"
+    else
+        echo "${path}"
+    fi
+}
+
+source "$(rules_python_get_runfiles_path "$(dirname "$0")/verify.sh")"
+verify_output "$(rules_python_get_runfiles_path "$(dirname "$0")/outer_calls_inner_script_python.out")"

--- a/tests/bootstrap_impls/bin_calls_bin/verify_script_python.sh
+++ b/tests/bootstrap_impls/bin_calls_bin/verify_script_python.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/verify.sh"
+verify_output "$(dirname "$0")/outer_calls_inner_script_python.out"

--- a/tests/bootstrap_impls/bin_calls_bin/verify_system_python.sh
+++ b/tests/bootstrap_impls/bin_calls_bin/verify_system_python.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
 set -euo pipefail
-source "$(dirname "$0")/verify.sh"
-verify_output "$(dirname "$0")/outer_calls_inner_system_python.out"
+
+# rules_python_get_runfiles_path is a helper to correctly look up runfiles.
+# It is needed because on Windows, the path to a runfile can be absolute,
+# which is not something that bash can handle. So we use cygpath to fix it up.
+rules_python_get_runfiles_path() {
+    local path="$1"
+    if [[ -f /bin/cygpath ]]; then
+        cygpath -u "${path}"
+    else
+        echo "${path}"
+    fi
+}
+
+source "$(rules_python_get_runfiles_path "$(dirname "$0")/verify.sh")"
+verify_output "$(rules_python_get_runfiles_path "$(dirname "$0")/outer_calls_inner_system_python.out")"

--- a/tests/bootstrap_impls/bin_calls_bin/verify_system_python.sh
+++ b/tests/bootstrap_impls/bin_calls_bin/verify_system_python.sh
@@ -1,17 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-# rules_python_get_runfiles_path is a helper to correctly look up runfiles.
-# It is needed because on Windows, the path to a runfile can be absolute,
-# which is not something that bash can handle. So we use cygpath to fix it up.
-rules_python_get_runfiles_path() {
-    local path="$1"
-    if [[ -f /bin/cygpath ]]; then
-        cygpath -u "${path}"
-    else
-        echo "${path}"
-    fi
-}
-
-source "$(rules_python_get_runfiles_path "$(dirname "$0")/verify.sh")"
-verify_output "$(rules_python_get_runfiles_path "$(dirname "$0")/outer_calls_inner_system_python.out")"
+source "$(dirname "$0")/verify.sh"
+verify_output "$(dirname "$0")/outer_calls_inner_system_python.out"

--- a/tests/bootstrap_impls/bin_calls_bin/verify_system_python.sh
+++ b/tests/bootstrap_impls/bin_calls_bin/verify_system_python.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/verify.sh"
+verify_output "$(dirname "$0")/outer_calls_inner_system_python.out"

--- a/tests/support/support.bzl
+++ b/tests/support/support.bzl
@@ -54,3 +54,8 @@ SUPPORTS_BZLMOD_UNIXY = select({
     "@platforms//os:windows": ["@platforms//:incompatible"],
     "//conditions:default": [],
 }) if BZLMOD_ENABLED else ["@platforms//:incompatible"]
+
+NOT_WINDOWS = select({
+    "@platforms//os:windows": ["@platforms//:incompatible"],
+    "//conditions:default": [],
+})


### PR DESCRIPTION
The stage1 bootstrap script had a bug in the find_runfiles_root
function where it would unconditionally use the RUNFILES_DIR et al
environment variables if they were set.

This failed in a particular nested context: an outer binary
calling an inner binary when the inner binary isn't a data
dependency of the outer binary (i.e. the outer doesn't contain
the inner in runfiles). This would cause the inner binary to
incorrectly resolve its runfiles, leading to failures. Such
a case can occur if a genrule calls the outer binary, which has
the inner binary passed as an arg.

This change adds a check to validate that the script's entry point
exists within the inherited RUNFILES_DIR before using it. If the
entry point is not found, it proceeds with other runfiles discovery
methods. This matches the system_python runfiles discovery logic.

Fixes https://github.com/bazel-contrib/rules_python/issues/3187