### PR TITLE
fix(py_wheel): add directories in deterministic order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@ END_UNRELEASED_TEMPLATE
 * (pypi) Support `requirements.txt` files that use different versions of the same
   package targeting different target platforms.
   ([#2797](https://github.com/bazel-contrib/rules_python/issues/2797)).
+* (py_wheel) Add directories in deterministic order.
 
 {#v0-0-0-added}
 ### Added

--- a/tools/wheelmaker.py
+++ b/tools/wheelmaker.py
@@ -152,7 +152,7 @@ class _WhlFile(zipfile.ZipFile):
         """Add given file to the distribution."""
 
         if os.path.isdir(real_filename):
-            directory_contents = os.listdir(real_filename)
+            directory_contents = sorted(os.listdir(real_filename))
             for file_ in directory_contents:
                 self.add_file(
                     "{}/{}".format(package_filename, file_),


### PR DESCRIPTION
A call to `os.listdir` does not return a deterministic result from one run to the next.  So for example if the output of a skylib [copy_directory](https://github.com/bazelbuild/bazel-skylib/blob/main/docs/copy_directory_doc.md) is added to a wheel, the files will be in a random order.