### PR TITLE
fix(toolchains): Add Xcode repo env vars to local_runtime_repo for better cache invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,9 @@ END_UNRELEASED_TEMPLATE
 
 {#v0-0-0-fixed}
 ### Fixed
+* (toolchains) `local_runtime_repo` now respects changes to the `DEVELOPER_DIR` and `XCODE_VERSION`
+  repo env vars, fixing stale cache issues on macOS with system (i.e. Xcode-supplied) Python
+  ([#3123](https://github.com/bazel-contrib/rules_python/issues/3123)).
 * (pypi) Fixes an issue where builds using a `bazel vendor` vendor directory
   would fail if the constraints file contained environment markers. Fixes
   [#2996](https://github.com/bazel-contrib/rules_python/issues/2996).

--- a/python/private/local_runtime_repo.bzl
+++ b/python/private/local_runtime_repo.bzl
@@ -232,7 +232,7 @@ How to handle errors when trying to automatically determine settings.
         ),
         "_rule_name": attr.string(default = "local_runtime_repo"),
     },
-    environ = ["PATH", REPO_DEBUG_ENV_VAR],
+    environ = ["PATH", REPO_DEBUG_ENV_VAR, "DEVELOPER_DIR", "XCODE_VERSION"],
 )
 
 def _expand_incompatible_template():


### PR DESCRIPTION
Fixes #3123. On macOS, if one writes a `local_runtime_repo` with `interpreter_path = "/usr/bin/python3"`, the path to python3 inside the selected _Xcode.app/Contents/Developer_ directory gets cached. If a developer changes that directory with `xcode-select --switch` that cached file with the old directory remains. 

Making the local_runtime_repo rule sensitive to DEVELOPER_DIR and XCODE_VERSION (two conventionally adopted env vars among the Bazel + Apple ecosystem) will ensure that if Xcode changes, so will the resolved python3 path.