### PR TITLE
fix(gazelle): Do not build proto targets with default Gazelle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,8 @@ END_UNRELEASED_TEMPLATE
   dep is not added to the {obj}`py_test` target.
 * (gazelle) New directive `gazelle:python_generate_proto`; when `true`,
   Gazelle generates `py_proto_library` rules for `proto_library`. `false` by default.
+    * Note: Users must manually configure their Gazelle target to support the
+      proto language.
 * (gazelle) New directive `gazelle:python_proto_naming_convention`; controls
   naming of `py_proto_library` rules.
 

--- a/gazelle/docs/directives.md
+++ b/gazelle/docs/directives.md
@@ -636,6 +636,30 @@ the configured name for the `@protobuf` / `@com_google_protobuf` repo in your
 `MODULE.bazel`, and otherwise falling back to `@com_google_protobuf` for
 compatibility with `WORKSPACE`.
 
+:::{note}
+In order to use this, you must manually configure Gazelle to target multiple
+languages. Place this in your root `BUILD.bazel` file:
+
+```
+load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
+
+gazelle_binary(
+    name = "gazelle_multilang",
+    languages = [
+        "@bazel_gazelle//language/proto",
+        # The python gazelle plugin must be listed _after_ the proto language.
+        "@rules_python_gazelle_plugin//python",
+    ],
+)
+
+gazelle(
+    name = "gazelle",
+    gazelle = "//:gazelle_multilang",
+)
+```
+:::
+
+
 For example, in a package with `# gazelle:python_generate_proto true` and a
 `foo.proto`, if you have both the proto extension and the Python extension
 loaded into Gazelle, you'll get something like:

--- a/gazelle/python/BUILD.bazel
+++ b/gazelle/python/BUILD.bazel
@@ -70,8 +70,8 @@ gazelle_test(
     name = "python_test",
     srcs = ["python_test.go"],
     data = [
-        ":gazelle_binary",
         ":_gazelle_binary_with_proto",
+        ":gazelle_binary",
     ],
     test_dirs = glob(
         # Use this so that we don't need to manually maintain the list.

--- a/gazelle/python/BUILD.bazel
+++ b/gazelle/python/BUILD.bazel
@@ -94,6 +94,16 @@ gazelle_binary(
     visibility = ["//visibility:public"],
 )
 
+# Only used by testing
+gazelle_binary(
+    name = "_gazelle_binary_with_proto",
+    languages = [
+        "@bazel_gazelle//language/proto",
+        ":python",
+    ],
+    visibility = ["//visibility:private"],
+)
+
 filegroup(
     name = "distribution",
     srcs = glob(["**"]),

--- a/gazelle/python/BUILD.bazel
+++ b/gazelle/python/BUILD.bazel
@@ -90,10 +90,7 @@ gazelle_test(
 
 gazelle_binary(
     name = "gazelle_binary",
-    languages = [
-        "@bazel_gazelle//language/proto",
-        ":python",
-    ],
+    languages = [":python"],
     visibility = ["//visibility:public"],
 )
 

--- a/gazelle/python/BUILD.bazel
+++ b/gazelle/python/BUILD.bazel
@@ -71,6 +71,7 @@ gazelle_test(
     srcs = ["python_test.go"],
     data = [
         ":gazelle_binary",
+        ":_gazelle_binary_with_proto",
     ],
     test_dirs = glob(
         # Use this so that we don't need to manually maintain the list.

--- a/gazelle/python/python_test.go
+++ b/gazelle/python/python_test.go
@@ -38,7 +38,7 @@ import (
 const (
 	extensionDir      = "python" + string(os.PathSeparator)
 	testDataPath      = extensionDir + "testdata" + string(os.PathSeparator)
-	gazelleBinaryName = "gazelle_binary"
+	gazelleBinaryName = "_gazelle_binary_with_proto"
 )
 
 func TestGazelleBinary(t *testing.T) {


### PR DESCRIPTION
Fixes #3209.

Revert the change to `//:gazelle_binary` so that it once again only generates python code. We then create a new, private target `//:_gazelle_binary_with_proto` that gets used by tests.

Update docs accordingly.

Longer term, I'd like to adjust the `test.yaml` file to include a section:

```yaml
config:
  gazelle_binary: _gazelle_binary_with_proto
```

So that test cases that need to generate `(py_)proto_library` targets can use the multi-lang Gazelle binary and that tests that do _not_ need to generate proto targets can use the single-lang Gazelle binary.

However, there were some minor roadblocks in doing so and thus I'm doing this quick-to-implement method instead.