### PR TITLE
backport: PR#3178 to 1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ END_UNRELEASED_TEMPLATE
 * (core) builds work again on `7.x` `WORKSPACE` configurations
   ([#3119](https://github.com/bazel-contrib/rules_python/issues/3119)).
 
+
 {#1-5-1}
 ## [1.5.1] - 2025-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ END_UNRELEASED_TEMPLATE
 ### Fixed
 
 * fix(local_runtime): Search for libs in sys._base_executable when available. #3178
-gg=======
+
 {#1-5-3}
 ## [1.5.3] - 2025-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,8 @@ END_UNRELEASED_TEMPLATE
 {#v1-5-4-fixed}
 ### Fixed
 
-* fix(local_runtime): Search for libs in sys._base_executable when available. #3178
+* (local toolchains) Search for libs in sys._base_executable when available
+  ([#3178](https://github.com/bazel-contrib/rules_python/issues/3178)).
 
 {#1-5-3}
 ## [1.5.3] - 2025-08-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,16 @@ BEGIN_UNRELEASED_TEMPLATE
 END_UNRELEASED_TEMPLATE
 -->
 
+{#1-5-4}
+## [1.5.4] - 2025-08-26
+
+[1.5.4]: https://github.com/bazel-contrib/rules_python/releases/tag/1.5.4
+
+{#v1-5-4-fixed}
+### Fixed
+
+* fix(local_runtime): Search for libs in sys._base_executable when available. #3178
+
 {#1-5-1}
 ## [1.5.1] - 2025-07-06
 

--- a/python/private/get_local_runtime_info.py
+++ b/python/private/get_local_runtime_info.py
@@ -16,10 +16,6 @@ import json
 import sys
 import sysconfig
 
-_IS_WINDOWS = sys.platform == "win32"
-_IS_DARWIN = sys.platform == "darwin"
-
-
 def _get_base_executable():
     """Returns the base executable path."""
     try:

--- a/python/private/get_local_runtime_info.py
+++ b/python/private/get_local_runtime_info.py
@@ -16,13 +16,31 @@ import json
 import sys
 import sysconfig
 
+_IS_WINDOWS = sys.platform == "win32"
+_IS_DARWIN = sys.platform == "darwin"
+
+
+def _get_base_executable():
+    """Returns the base executable path."""
+    try:
+        if sys._base_executable:  # pylint: disable=protected-access
+            return sys._base_executable  # pylint: disable=protected-access
+    except AttributeError:
+        # Bug reports indicate sys._base_executable  doesn't exist in some cases,
+        # but it's not clear why.
+        # See https://github.com/bazel-contrib/rules_python/issues/3172
+        pass
+    # The normal sys.executable is the next-best guess if sys._base_executable
+    # is missing.
+    return sys.executable
+
 data = {
     "major": sys.version_info.major,
     "minor": sys.version_info.minor,
     "micro": sys.version_info.micro,
     "include": sysconfig.get_path("include"),
     "implementation_name": sys.implementation.name,
-    "base_executable": sys._base_executable,
+    "base_executable": _get_base_executable(),
 }
 
 config_vars = [


### PR DESCRIPTION
fix(local_runtime): Search for libs in sys._base_executable when available. (#3178)
    
Search directory for libraries should look in the same directory as
sys._base_executable. Since sys._base_executable may be unset, fallback
to sys.executable
    
Found this when trying to build using a venv for
[tensorstore](https://github.com/google/tensorstore) on Windows:
    * Github CI uses nuget to download Python.
    * Build sets up a Python venv.
    
The venv does not include all the lib directories required to link an
extension.
    
Fixes https://github.com/bazel-contrib/rules_python/issues/3172
    
---------
    
Co-authored-by: Richard Levasseur <richardlev@gmail.com>

