### PR TITLE
fix(pypi): add `__init__.py` to site-packages directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ END_UNRELEASED_TEMPLATE
 * (bootstrap) The stage1 bootstrap script now correctly handles nested `RUNFILES_DIR`
   environments, fixing issues where a `py_binary` calls another `py_binary`
   ([#3187](https://github.com/bazel-contrib/rules_python/issues/3187)).
+* (pypi) Now the `site-packages` will also have the `__init__.py` file generated
+  for `namespace` packages to correctly support cases where one package may be a Python
+  file and the other package may be a proper directory module.
+  Fixes ([#3038](https://github.com/bazel-contrib/rules_python/issues/3038)).
 
 {#v0-0-0-added}
 ### Added
@@ -228,7 +232,7 @@ END_UNRELEASED_TEMPLATE
 ### Fixed
 
 * (pypi) Namespace packages work by default (pkgutil shims are generated
-  by default again)
+  by default again).
   ([#3038](https://github.com/bazel-contrib/rules_python/issues/3038)).
 
 {#v1-5-0}

--- a/python/private/pypi/namespace_pkgs.bzl
+++ b/python/private/pypi/namespace_pkgs.bzl
@@ -33,7 +33,9 @@ def get_files(*, srcs, ignored_dirnames = [], root = None):
     ignored = {i: None for i in ignored_dirnames}
 
     if root:
-        _add_all(root, ignored)
+        dirname, _, filename = root.partition("/")
+        if filename:
+            _add_all(dirname, ignored)
 
     for file in srcs:
         dirname, _, filename = file.rpartition("/")

--- a/tests/pypi/namespace_pkgs/namespace_pkgs_tests.bzl
+++ b/tests/pypi/namespace_pkgs/namespace_pkgs_tests.bzl
@@ -32,6 +32,7 @@ def test_find_correct_namespace_packages(env):
 
     got = get_files(srcs = srcs, root = "nested/root")
     expected = [
+        "nested/root",
         "nested/root/foo",
         "nested/root/foo/bar",
         "nested/root/foo/bee",
@@ -148,6 +149,7 @@ def test_skips_ignored_directories(env):
     ]
 
     expected = [
+        "root",
         "root/foo",
         "root/foo/bar",
     ]
@@ -182,16 +184,21 @@ def _test_create_inits(env):
     env.expect.that_collection(copy_file_calls).contains_exactly([
         {
             "name": "_cp_0_namespace",
-            "out": "nested/root/foo/__init__.py",
+            "out": "nested/root/__init__.py",
             "src": template,
         },
         {
             "name": "_cp_1_namespace",
-            "out": "nested/root/foo/bar/__init__.py",
+            "out": "nested/root/foo/__init__.py",
             "src": template,
         },
         {
             "name": "_cp_2_namespace",
+            "out": "nested/root/foo/bar/__init__.py",
+            "src": template,
+        },
+        {
+            "name": "_cp_3_namespace",
             "out": "nested/root/foo/bee/__init__.py",
             "src": template,
         },


### PR DESCRIPTION
Before this change we would be not adding `__init__.py` files for
`site-packages` directories due to an oversight in how the root
directory is handled. As user has reported, we should do this to be
backwards compatible.

Fixes #3038