### PR TITLE
chore: allow release workflow to be manually run and skip pypi upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,13 @@ on:
   push:
     tags:
       - "*.*.*"
+  workflow_dispatch:
+    inputs:
+      publish_to_pypi:
+        description: 'Publish to PyPI'
+        required: true
+        type: boolean
+        default: true
 
 jobs:
   build:
@@ -29,6 +36,7 @@ jobs:
       - name: Create release archive and notes
         run: .github/workflows/create_archive_and_notes.sh
       - name: Publish wheel dist
+        if: github.event_name == 'push' || github.event.inputs.publish_to_pypi
         env:
           # This special value tells pypi that the user identity is supplied within the token
           TWINE_USERNAME: __token__

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -45,6 +45,25 @@ final release (`X.Y.Z`).
 
 Release automation will create a GitHub release and BCR pull request.
 
+### Manually triggering the release workflow
+
+The release workflow can be manually triggered using the GitHub CLI (`gh`).
+This is useful for re-running a release or for creating a release from a
+specific commit.
+
+To trigger the workflow, use the `gh workflow run` command:
+
+```shell
+gh workflow run release.yml --ref <TAG>
+```
+
+By default, the workflow will publish the wheel to PyPI. To skip this step,
+you can set the `publish_to_pypi` input to `false`:
+
+```shell
+gh workflow run release.yml --ref <TAG> -f publish_to_pypi=false
+```
+
 ### Determining Semantic Version
 
 **rules_python** uses [semantic version](https://semver.org), so releases with


### PR DESCRIPTION
This makes it possible to manually invoke the release workflow and skip the pypi upload. This is useful if the release workflow was cancelled (or failed) after the pypi upload step.

Work towards https://github.com/bazel-contrib/rules_python/issues/3188