### PR TITLE
refactor(gazelle): report missing BUILD_WORKSPACE_DIRECTORY key more directly

### DIFF
--- a/gazelle/manifest/copy_to_source.py
+++ b/gazelle/manifest/copy_to_source.py
@@ -20,7 +20,7 @@ def copy_to_source(generated_relative_path: Path, target_relative_path: Path) ->
     generated_absolute_path = Path.cwd() / generated_relative_path
 
     # Similarly, the target is relative to the source directory.
-    target_absolute_path = os.getenv("BUILD_WORKSPACE_DIRECTORY") / target_relative_path
+    target_absolute_path = os.environ["BUILD_WORKSPACE_DIRECTORY"] / target_relative_path
 
     print(f"Copying {generated_absolute_path} to {target_absolute_path}")
     target_absolute_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Replace `os.environ.get("BUILD_WORKSPACE_DIRECTORY")` with `os.environ["BUILD_WORKSPACE_DIRECTORY"]`.

The former may return None if the environment variable is not set, in which case the code will crash with a TypeError when the line is run since the result is concatenated with a `pathlib.Path` object, and is therefore making it impossible to use rules_python_gazelle_plugin along with rules_mypy:

These changes allow rules_mypy users to also use rules_python_gazelle_plugin without having to work around the type error.

Now if the environment variable is not set, the code will still crash, but now with an error that better indicates the failed precondition, namely `KeyError("BUILD_WORKSPACE_DIRECTORY")` rather than `TypeError("unsupported operand type(s) for /: 'PosixPath' and 'NoneType')`.