### PR TITLE
fix(pypi): select the lowest available libc version by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,10 @@ END_UNRELEASED_TEMPLATE
   length errors due to too long environment variables.
 * (bootstrap) {obj}`--bootstrap_impl=script` now supports the `-S` interpreter
   setting.
+* (pypi) We now by default select the highest closest match wheel version if the user is
+  specifying a particular version via the `whl_platform_tags` or if any version is matched via
+  the `*` token, then we select the lowest available version.
+  Fixes [#3250](https://github.com/bazel-contrib/rules_python/issues/3250).
 
 {#v0-0-0-added}
 ### Added

--- a/python/private/pypi/select_whl.bzl
+++ b/python/private/pypi/select_whl.bzl
@@ -46,6 +46,8 @@ def _platform_tag_priority(*, tag, values):
         arch = tail
     version = (int(major), int(minor))
 
+    select_highest = True
+
     keys = []
     for priority, wp in enumerate(values):
         want_os, sep, tail = wp.partition("_")
@@ -65,6 +67,7 @@ def _platform_tag_priority(*, tag, values):
             want_major = ""
             want_minor = ""
             want_arch = tail
+            select_highest = False
         elif os.startswith(_ANDROID):
             # we set it to `0` above, so setting the `want_minor` her to `0` will make things
             # consistent.
@@ -81,7 +84,7 @@ def _platform_tag_priority(*, tag, values):
         # if want_major is defined, then we know that we don't have a `*` in the matcher.
         want_version = (int(want_major), int(want_minor)) if want_major else None
         if not want_version or version <= want_version:
-            keys.append((priority, version))
+            keys.append((priority, version if select_highest else (-version[0], -version[1])))
 
     return max(keys) if keys else None
 

--- a/tests/pypi/select_whl/select_whl_tests.bzl
+++ b/tests/pypi/select_whl/select_whl_tests.bzl
@@ -406,9 +406,10 @@ def _test_multiple_musllinux(env):
     _match(
         env,
         got,
-        # select the one with the highest version that is matching
-        "pkg-0.0.1-py3-none-musllinux_1_1_x86_64.whl",
+        # select the one with the lowest version that is matching because we want to
+        # increase the compatibility
         "pkg-0.0.1-py3-none-musllinux_1_2_x86_64.whl",
+        "pkg-0.0.1-py3-none-musllinux_1_1_x86_64.whl",
     )
 
 _tests.append(_test_multiple_musllinux)
@@ -433,6 +434,28 @@ def _test_multiple_musllinux_exact_params(env):
     )
 
 _tests.append(_test_multiple_musllinux_exact_params)
+
+def _test_multiple_highest_closest_match(env):
+    got = _select_whl(
+        whls = [
+            "pkg-0.0.1-py3-none-musllinux_1_4_x86_64.whl",
+            "pkg-0.0.1-py3-none-musllinux_1_2_x86_64.whl",
+            "pkg-0.0.1-py3-none-musllinux_1_1_x86_64.whl",
+        ],
+        whl_platform_tags = ["musllinux_1_3_x86_64"],
+        whl_abi_tags = ["none"],
+        python_version = "3.12",
+        limit = 2,
+    )
+    _match(
+        env,
+        got,
+        # select the one with the lowest version, because of the input to the function
+        "pkg-0.0.1-py3-none-musllinux_1_1_x86_64.whl",
+        "pkg-0.0.1-py3-none-musllinux_1_2_x86_64.whl",
+    )
+
+_tests.append(_test_multiple_highest_closest_match)
 
 def _test_android(env):
     got = _select_whl(


### PR DESCRIPTION
The #3058 PR has subtly changed the default behaviour of
`experimental_index_url` code path and I think in order to make things
easier by default for our users we should go back to that behaviour.

The selection of the wheels happens in two ways:
1. If the user specifies `whl_platform_tags` value like
   `manylinux_*_x86_64` then we we should just get the lowest available
   versioned wheel. I.e. if `manylinux_2_28_x86_64` and
   `manylinux_2_32_x86_64` are available, we should prefer the former.
2. If the user specifies `whl_platform_tags` value like
   `manylinux_2_32_x86_64` then we we should get the highest version
   that is lower or equal than the specified one. I.e. if
   `manylinux_2_21_x86_64`, `manylinux_2_28_x86_64` and
   `manylinux_2_36_x86_64` are available, we should prefer the
   `manylinux_2_28_x86_64` one.

Fixes #3250
