### PR TITLE
fix: ensure the stage1 bootstrap is executable

### DIFF
--- a/python/private/py_executable.bzl
+++ b/python/private/py_executable.bzl
@@ -894,6 +894,7 @@ def _create_stage1_bootstrap(
         template = template,
         output = output,
         substitutions = subs,
+        is_executable = True,
     )
 
 def _create_windows_exe_launcher(


### PR DESCRIPTION
Bazel tends to make files executable, even if ctx.actions.write() or ctx.actions.expand_template() is called without is_executable = True. However, in an analysis tool of mine that is a bit more pedantic than Bazel this leads to the issue that py_binary() targets can't be executed due to them not having a +x bit.

Considering that the stage2 bootstrap is marked executable, let's mark is_executable for consistency.