### PR TITLE
fix: don't call Args.add() with an integer

### DIFF
--- a/python/private/precompile.bzl
+++ b/python/private/precompile.bzl
@@ -182,7 +182,7 @@ def _precompile(ctx, src, *, use_pycache):
     # have the repo name, which is likely to contain extraneous info.
     precompile_request_args.add("--src_name", src.short_path)
     precompile_request_args.add("--pyc", pyc)
-    precompile_request_args.add("--optimize", ctx.attr.precompile_optimize_level)
+    precompile_request_args.add("--optimize", str(ctx.attr.precompile_optimize_level))
 
     version_info = target_toolchain.interpreter_version_info
     python_version = "{}.{}".format(version_info.major, version_info.minor)


### PR DESCRIPTION
The documentation for Bazel's Args states that standard conversion rules are only specified for strings, Files, and Labels. For all other types the conversion to a string is done in an unspecified manner, which is why it should be avoided.

Let's stay away from this unspecified behaviour by explicitly converting the precompile optimization level to a string before calling Args.add().
