### PR TITLE
tests: add non-blocking ci config for bazel rolling

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -132,6 +132,19 @@ tasks:
     name: "Default: Ubuntu, upcoming Bazel"
     platform: ubuntu2204
     bazel: last_rc
+  ubuntu_rolling:
+    name: "Default: Ubuntu, rolling Bazel"
+    platform: ubuntu2204
+    bazel: rolling
+    # This is an advisory job; doesn't block merges
+    soft_fail:
+      - exit_status: 1
+    test_targets:
+      - "--"
+      - "//tests/..."
+    test_flags:
+      - "--keep_going"
+      - "--test_tag_filters=-integration-test"
   ubuntu_workspace:
     <<: *reusable_config
     <<: *common_workspace_flags

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -139,6 +139,7 @@ tasks:
     # This is an advisory job; doesn't block merges
     soft_fail:
       - exit_status: 1
+      - exit_status: 3
     test_targets:
       - "--"
       - "//tests/..."


### PR DESCRIPTION
With some core Bazel changes to flags coming that will affect us, and the difficulty it
is to keep the bazel-at-head-and-downstream pipeline green, I figured it'd be a good idea
to add a CI job that uses the weekly Bazel release so we can identify problems sooner
and more obviously.

The CI job only run on Ubuntu to save CI slots and is won't block merges if it has failures.