### PR TITLE
refactor(runtime setup): Add separate ABI3 Python headers target

### DIFF
--- a/python/private/hermetic_runtime_repo_setup.bzl
+++ b/python/private/hermetic_runtime_repo_setup.bzl
@@ -109,7 +109,26 @@ def define_hermetic_runtime_toolchain_impl(
     cc_library(
         name = "python_headers",
         deps = select({
-            "@bazel_tools//src/conditions:windows": [":interface", ":abi3_interface"],
+            "@bazel_tools//src/conditions:windows": [":interface"],
+            "//conditions:default": None,
+        }),
+        hdrs = [":includes"],
+        includes = [
+            "include",
+        ] + select({
+            _IS_FREETHREADED_YES: [
+                "include/python{major}.{minor}t".format(**version_dict),
+            ],
+            _IS_FREETHREADED_NO: [
+                "include/python{major}.{minor}".format(**version_dict),
+                "include/python{major}.{minor}m".format(**version_dict),
+            ],
+        }),
+    )
+    cc_library(
+        name = "python_headers_abi3",
+        deps = select({
+            "@bazel_tools//src/conditions:windows": [":abi3_interface"],
             "//conditions:default": None,
         }),
         hdrs = [":includes"],


### PR DESCRIPTION
Until now, we silently link extensions with both stable and unstable ABI libs, with the latter taking precedence in symbol resolution, because it appears first in the linker command AND, crucially, contains all CPython symbols present in the stable ABI library, thus overriding them.

This has the effect that stable ABI extensions on Windows are useable only with the Python distribution that they were built on. The now introduced separate ABI3 header target fixes this, and should be used for C++ extensions on Windows if stable ABI builds are requested.

Idea as formulated by `@dgrunwald-qt` in https://github.com/nicholasjng/nanobind-bazel/issues/72#issuecomment-3249959583.

-----------------------

This is motivated by https://github.com/nicholasjng/nanobind-bazel/issues/72, which I admittedly have procrastinated on, sorry about that.

This change shifts stable ABI selection on Windows to the extension developer, where it has arguably always been (they had to set the `Py_LIMITED_API` macro). I hope this isn't too much of an issue.  
An upside of this approach, though, is that with a separate target, the question "stable ABI or not" can be decided on an extension-by-extension basis, giving maximum flexibility to developers. This should not influence the wheel platform target, because a wheel is marked ABI3 if and only if all of its extensions are marked as ABI3.

Happy for comments.