### PR TITLE
build: remove no-op _native_rules_allowlist

### DIFF
--- a/python/private/attributes.bzl
+++ b/python/private/attributes.bzl
@@ -21,7 +21,6 @@ load(":common_labels.bzl", "labels")
 load(":enum.bzl", "enum")
 load(":flags.bzl", "PrecompileFlag", "PrecompileSourceRetentionFlag")
 load(":py_info.bzl", "PyInfo")
-load(":py_internal.bzl", "py_internal")
 load(":reexports.bzl", "BuiltinPyInfo")
 load(":rule_builders.bzl", "ruleb")
 

--- a/python/private/attributes.bzl
+++ b/python/private/attributes.bzl
@@ -174,33 +174,9 @@ This is because Python has a concept of runtime resources.
     ),
 }
 
-def _create_native_rules_allowlist_attrs():
-    if py_internal:
-        # The fragment and name are validated when configuration_field is called
-        default = configuration_field(
-            fragment = "py",
-            name = "native_rules_allowlist",
-        )
-
-        # A None provider isn't allowed
-        providers = [_PackageSpecificationInfo]
-    else:
-        default = None
-        providers = []
-
-    return {
-        "_native_rules_allowlist": lambda: attrb.Label(
-            default = default,
-            providers = providers,
-        ),
-    }
-
-NATIVE_RULES_ALLOWLIST_ATTRS = _create_native_rules_allowlist_attrs()
-
 # Attributes common to all rules.
 COMMON_ATTRS = dicts.add(
     DATA_ATTRS,
-    NATIVE_RULES_ALLOWLIST_ATTRS,
     # buildifier: disable=attr-licenses
     {
         # NOTE: This attribute is deprecated and slated for removal.

--- a/python/private/attributes.bzl
+++ b/python/private/attributes.bzl
@@ -25,8 +25,6 @@ load(":py_internal.bzl", "py_internal")
 load(":reexports.bzl", "BuiltinPyInfo")
 load(":rule_builders.bzl", "ruleb")
 
-_PackageSpecificationInfo = getattr(py_internal, "PackageSpecificationInfo", None)
-
 # Due to how the common exec_properties attribute works, rules must add exec
 # groups even if they don't actually use them. This is due to two interactions:
 # 1. Rules give an error if users pass an unsupported exec group.

--- a/python/private/py_runtime_rule.bzl
+++ b/python/private/py_runtime_rule.bzl
@@ -16,7 +16,6 @@
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
-load(":attributes.bzl", "NATIVE_RULES_ALLOWLIST_ATTRS")
 load(":common_labels.bzl", "labels")
 load(":flags.bzl", "FreeThreadedFlag")
 load(":py_internal.bzl", "py_internal")
@@ -191,7 +190,6 @@ py_runtime(
 """,
     fragments = ["py"],
     attrs = dicts.add(
-        {k: v().build() for k, v in NATIVE_RULES_ALLOWLIST_ATTRS.items()},
         {
             "abi_flags": attr.string(
                 default = "<AUTO>",


### PR DESCRIPTION
Remove `_native_rules_allowlist` attribute as it is no-op

This is needed to allow removing the deprecated flag `--native_rules_allowlist` from bazel.

Work towards: https://github.com/bazel-contrib/rules_python/issues/3252