### PR TITLE
chore(docs): remove duplicate bzlmod guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,4 @@ For detailed documentation, see <https://rules-python.readthedocs.io>
 
 ## Bzlmod support
 
-- Status: Beta
-- Full Feature Parity: No
-
 See [Bzlmod support](BZLMOD_SUPPORT.md) for more details.


### PR DESCRIPTION
It's out of date with https://github.com/bazel-contrib/rules_python/blob/main/BZLMOD_SUPPORT.md which says the feature is GA now
