### PR TITLE
feat: support per-wheel enable_implicit_namespace_pkgs in whl_mods (WIP)

### DIFF
--- a/python/private/pypi/extension.bzl
+++ b/python/private/pypi/extension.bzl
@@ -49,6 +49,7 @@ def _whl_mods_impl(whl_mods_dict):
                 data = mods.data,
                 data_exclude_glob = mods.data_exclude_glob,
                 srcs_exclude_glob = mods.srcs_exclude_glob,
+                enable_implicit_namespace_pkgs = mods.enable_implicit_namespace_pkgs,
             ))
 
         _whl_mods_repo(
@@ -178,6 +179,7 @@ You cannot use both the additive_build_content and additive_build_content_file a
                 data = whl_mod.data,
                 data_exclude_glob = whl_mod.data_exclude_glob,
                 srcs_exclude_glob = whl_mod.srcs_exclude_glob,
+                enable_implicit_namespace_pkgs = whl_mod.enable_implicit_namespace_pkgs,
             )
 
     config = build_config(module_ctx = module_ctx, enable_pipstar = enable_pipstar)
@@ -740,6 +742,12 @@ cannot have a child module that uses the same `hub_name`.
         "whl_name": attr.string(
             doc = "The whl name that the modifications are used for.",
             mandatory = True,
+        ),
+        "enable_implicit_namespace_pkgs": attr.bool(
+            doc = """\
+(bool, optional): Override the global setting for generating __init__.py
+files for namespace packages. If None, uses the repository-level setting.
+""",
         ),
     }
     return attrs

--- a/python/private/pypi/generate_whl_library_build_bazel.bzl
+++ b/python/private/pypi/generate_whl_library_build_bazel.bzl
@@ -109,7 +109,7 @@ def generate_whl_library_build_bazel(
         kwargs["copy_executables"] = annotation.copy_executables
         kwargs["data_exclude"] = kwargs.get("data_exclude", []) + annotation.data_exclude_glob
         kwargs["srcs_exclude"] = annotation.srcs_exclude_glob
-        if annotation.enable_implicit_namespace_pkgs != None:
+        if hasattr(annotation, "enable_implicit_namespace_pkgs") and annotation.enable_implicit_namespace_pkgs != None:
             kwargs["enable_implicit_namespace_pkgs"] = annotation.enable_implicit_namespace_pkgs
         if annotation.additive_build_content:
             additional_content.append(annotation.additive_build_content)

--- a/python/private/pypi/generate_whl_library_build_bazel.bzl
+++ b/python/private/pypi/generate_whl_library_build_bazel.bzl
@@ -109,6 +109,8 @@ def generate_whl_library_build_bazel(
         kwargs["copy_executables"] = annotation.copy_executables
         kwargs["data_exclude"] = kwargs.get("data_exclude", []) + annotation.data_exclude_glob
         kwargs["srcs_exclude"] = annotation.srcs_exclude_glob
+        if annotation.enable_implicit_namespace_pkgs != None:
+            kwargs["enable_implicit_namespace_pkgs"] = annotation.enable_implicit_namespace_pkgs
         if annotation.additive_build_content:
             additional_content.append(annotation.additive_build_content)
     if default_python_version:

--- a/python/private/pypi/package_annotation.bzl
+++ b/python/private/pypi/package_annotation.bzl
@@ -20,7 +20,8 @@ def package_annotation(
         copy_executables = {},
         data = [],
         data_exclude_glob = [],
-        srcs_exclude_glob = []):
+        srcs_exclude_glob = [],
+        enable_implicit_namespace_pkgs = None):
     """Annotations to apply to the BUILD file content from package generated from a `pip_repository` rule.
 
     [cf]: https://github.com/bazelbuild/bazel-skylib/blob/main/docs/copy_file_doc.md
@@ -35,6 +36,8 @@ def package_annotation(
         data_exclude_glob (list, optional): A list of exclude glob patterns to add as `data` to the generated
             `py_library` target.
         srcs_exclude_glob (list, optional): A list of labels to add as `srcs` to the generated `py_library` target.
+        enable_implicit_namespace_pkgs (bool, optional): Override the global setting for generating __init__.py
+            files for namespace packages. If None, uses the repository-level setting.
 
     Returns:
         str: A json encoded string of the provided content.
@@ -46,4 +49,5 @@ def package_annotation(
         data = data,
         data_exclude_glob = data_exclude_glob,
         srcs_exclude_glob = srcs_exclude_glob,
+        enable_implicit_namespace_pkgs = enable_implicit_namespace_pkgs,
     ))

--- a/tests/pypi/generate_whl_library_build_bazel/generate_whl_library_build_bazel_tests.bzl
+++ b/tests/pypi/generate_whl_library_build_bazel/generate_whl_library_build_bazel_tests.bzl
@@ -215,17 +215,25 @@ def _test_enable_implicit_namespace_pkgs_annotation(env):
     want = """\
 load("@rules_python//python/private/pypi:whl_library_targets.bzl", "whl_library_targets")
 
+package(default_visibility = ["//visibility:public"])
+
 whl_library_targets(
     dep_template = "@pypi//{name}:{target}",
-    enable_implicit_namespace_pkgs = True,
-    name = "foo.whl",
     dependencies = ["foo"],
-    dependencies_by_platform = {"baz": ["bar"]},
+    dependencies_by_platform = {
+        "baz": ["bar"],
+    },
+    enable_implicit_namespace_pkgs = True,
     entry_points = {
         "foo": "bar.py",
     },
-    group_deps = ["foo", "fox", "qux"],
+    group_deps = [
+        "foo",
+        "fox",
+        "qux",
+    ],
     group_name = "qux",
+    name = "foo.whl",
     tags = ["tag1"],
 )
 """
@@ -252,17 +260,25 @@ def _test_enable_implicit_namespace_pkgs_annotation_false(env):
     want = """\
 load("@rules_python//python/private/pypi:whl_library_targets.bzl", "whl_library_targets")
 
+package(default_visibility = ["//visibility:public"])
+
 whl_library_targets(
     dep_template = "@pypi//{name}:{target}",
-    enable_implicit_namespace_pkgs = False,
-    name = "foo.whl",
     dependencies = ["foo"],
-    dependencies_by_platform = {"baz": ["bar"]},
+    dependencies_by_platform = {
+        "baz": ["bar"],
+    },
+    enable_implicit_namespace_pkgs = False,
     entry_points = {
         "foo": "bar.py",
     },
-    group_deps = ["foo", "fox", "qux"],
+    group_deps = [
+        "foo",
+        "fox",
+        "qux",
+    ],
     group_name = "qux",
+    name = "foo.whl",
     tags = ["tag1"],
 )
 """

--- a/tests/pypi/generate_whl_library_build_bazel/generate_whl_library_build_bazel_tests.bzl
+++ b/tests/pypi/generate_whl_library_build_bazel/generate_whl_library_build_bazel_tests.bzl
@@ -211,6 +211,80 @@ whl_library_targets_from_requires(
 
 _tests.append(_test_all_with_loads)
 
+def _test_enable_implicit_namespace_pkgs_annotation(env):
+    want = """\
+load("@rules_python//python/private/pypi:whl_library_targets.bzl", "whl_library_targets")
+
+whl_library_targets(
+    dep_template = "@pypi//{name}:{target}",
+    enable_implicit_namespace_pkgs = True,
+    name = "foo.whl",
+    dependencies = ["foo"],
+    dependencies_by_platform = {"baz": ["bar"]},
+    entry_points = {
+        "foo": "bar.py",
+    },
+    group_deps = ["foo", "fox", "qux"],
+    group_name = "qux",
+    tags = ["tag1"],
+)
+"""
+    actual = generate_whl_library_build_bazel(
+        dep_template = "@pypi//{name}:{target}",
+        name = "foo.whl",
+        dependencies = ["foo"],
+        dependencies_by_platform = {"baz": ["bar"]},
+        entry_points = {
+            "foo": "bar.py",
+        },
+        annotation = struct(
+            enable_implicit_namespace_pkgs = True,
+        ),
+        group_name = "qux",
+        group_deps = ["foo", "fox", "qux"],
+        tags = ["tag1"],
+    )
+    env.expect.that_str(actual.replace("@@", "@")).equals(want)
+
+_tests.append(_test_enable_implicit_namespace_pkgs_annotation)
+
+def _test_enable_implicit_namespace_pkgs_annotation_false(env):
+    want = """\
+load("@rules_python//python/private/pypi:whl_library_targets.bzl", "whl_library_targets")
+
+whl_library_targets(
+    dep_template = "@pypi//{name}:{target}",
+    enable_implicit_namespace_pkgs = False,
+    name = "foo.whl",
+    dependencies = ["foo"],
+    dependencies_by_platform = {"baz": ["bar"]},
+    entry_points = {
+        "foo": "bar.py",
+    },
+    group_deps = ["foo", "fox", "qux"],
+    group_name = "qux",
+    tags = ["tag1"],
+)
+"""
+    actual = generate_whl_library_build_bazel(
+        dep_template = "@pypi//{name}:{target}",
+        name = "foo.whl",
+        dependencies = ["foo"],
+        dependencies_by_platform = {"baz": ["bar"]},
+        entry_points = {
+            "foo": "bar.py",
+        },
+        annotation = struct(
+            enable_implicit_namespace_pkgs = False,
+        ),
+        group_name = "qux",
+        group_deps = ["foo", "fox", "qux"],
+        tags = ["tag1"],
+    )
+    env.expect.that_str(actual.replace("@@", "@")).equals(want)
+
+_tests.append(_test_enable_implicit_namespace_pkgs_annotation_false)
+
 def generate_whl_library_build_bazel_test_suite(name):
     """Create the test suite.
 

--- a/tests/pypi/generate_whl_library_build_bazel/generate_whl_library_build_bazel_tests.bzl
+++ b/tests/pypi/generate_whl_library_build_bazel/generate_whl_library_build_bazel_tests.bzl
@@ -103,6 +103,7 @@ whl_library_targets_from_requires(
         "data_exclude_all",
     ],
     dep_template = "@pypi//{name}:{target}",
+    enable_implicit_namespace_pkgs = True,
     entry_points = {
         "foo": "bar.py",
     },
@@ -139,6 +140,7 @@ whl_library_targets_from_requires(
             data_exclude_glob = ["data_exclude_all"],
             srcs_exclude_glob = ["srcs_exclude_all"],
             additive_build_content = """# SOMETHING SPECIAL AT THE END""",
+            enable_implicit_namespace_pkgs = True,
         ),
         group_name = "qux",
         group_deps = ["foo", "fox", "qux"],
@@ -211,95 +213,6 @@ whl_library_targets_from_requires(
 
 _tests.append(_test_all_with_loads)
 
-def _test_enable_implicit_namespace_pkgs_annotation(env):
-    want = """\
-load("@rules_python//python/private/pypi:whl_library_targets.bzl", "whl_library_targets")
-
-package(default_visibility = ["//visibility:public"])
-
-whl_library_targets(
-    dep_template = "@pypi//{name}:{target}",
-    dependencies = ["foo"],
-    dependencies_by_platform = {
-        "baz": ["bar"],
-    },
-    enable_implicit_namespace_pkgs = True,
-    entry_points = {
-        "foo": "bar.py",
-    },
-    group_deps = [
-        "foo",
-        "fox",
-        "qux",
-    ],
-    group_name = "qux",
-    name = "foo.whl",
-    tags = ["tag1"],
-)
-"""
-    actual = generate_whl_library_build_bazel(
-        dep_template = "@pypi//{name}:{target}",
-        name = "foo.whl",
-        dependencies = ["foo"],
-        dependencies_by_platform = {"baz": ["bar"]},
-        entry_points = {
-            "foo": "bar.py",
-        },
-        annotation = struct(
-            enable_implicit_namespace_pkgs = True,
-        ),
-        group_name = "qux",
-        group_deps = ["foo", "fox", "qux"],
-        tags = ["tag1"],
-    )
-    env.expect.that_str(actual.replace("@@", "@")).equals(want)
-
-_tests.append(_test_enable_implicit_namespace_pkgs_annotation)
-
-def _test_enable_implicit_namespace_pkgs_annotation_false(env):
-    want = """\
-load("@rules_python//python/private/pypi:whl_library_targets.bzl", "whl_library_targets")
-
-package(default_visibility = ["//visibility:public"])
-
-whl_library_targets(
-    dep_template = "@pypi//{name}:{target}",
-    dependencies = ["foo"],
-    dependencies_by_platform = {
-        "baz": ["bar"],
-    },
-    enable_implicit_namespace_pkgs = False,
-    entry_points = {
-        "foo": "bar.py",
-    },
-    group_deps = [
-        "foo",
-        "fox",
-        "qux",
-    ],
-    group_name = "qux",
-    name = "foo.whl",
-    tags = ["tag1"],
-)
-"""
-    actual = generate_whl_library_build_bazel(
-        dep_template = "@pypi//{name}:{target}",
-        name = "foo.whl",
-        dependencies = ["foo"],
-        dependencies_by_platform = {"baz": ["bar"]},
-        entry_points = {
-            "foo": "bar.py",
-        },
-        annotation = struct(
-            enable_implicit_namespace_pkgs = False,
-        ),
-        group_name = "qux",
-        group_deps = ["foo", "fox", "qux"],
-        tags = ["tag1"],
-    )
-    env.expect.that_str(actual.replace("@@", "@")).equals(want)
-
-_tests.append(_test_enable_implicit_namespace_pkgs_annotation_false)
 
 def generate_whl_library_build_bazel_test_suite(name):
     """Create the test suite.


### PR DESCRIPTION
Update: I was [reading a thread](https://bazelbuild.slack.com/archives/CA306CEV6/p1751471945163239) in `#python` and saw that this set to True when setting `--incompatible_default_to_explicit_init_py` is actually desirable and forward-looking.

So perhaps this PR is unnecessary for my use case, unless somebody runs into issues and needs to toggle it for some packages/wheels.

Other note: perhaps the `enable_implicit_namespace_pkgs` documentation can be further clarified.

---

As part of investigating https://github.com/aspect-build/rules_py/issues/611 which requires `enable_implicit_namespace_pkgs = True` as a workaround to unblock PEX creation, I looked into how to only toggle on this flag per wheel, as per https://github.com/aspect-build/rules_py/issues/611#issuecomment-3305979729 .

The goal of this is to reduce reliance on this flag where it's not necessary.

This PR is a proof-of-concept to gather if there's any interest in this feature. The commits aren't cleaned up yet.

Not yet done:
- [ ] Update CHANGELOG.md
- [ ] Update documentation for whl_mods
