### PR TITLE
docs: move 1.6.3 related changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,13 +79,6 @@ END_UNRELEASED_TEMPLATE
   length errors due to too long environment variables.
 * (bootstrap) {obj}`--bootstrap_impl=script` now supports the `-S` interpreter
   setting.
-* (pypi) We now use the Minimal Version Selection (MVS) algorithm to select
-  the right wheel when there are multiple wheels for the target platform
-  (e.g. `musllinux_1_1_x86_64` and `musllinux_1_2_x86_64`). If the user
-  wants to set the minimum version for the selection algorithm, use the
-  {attr}`pip.defaults.whl_platform_tags` attribute to configure that. If
-  `musllinux_*_x86_64` is specified, we will chose the lowest available
-  wheel version. Fixes [#3250](https://github.com/bazel-contrib/rules_python/issues/3250).
 * (venvs) {obj}`--vens_site_packages=yes` no longer errors when packages with
   overlapping files or directories are used together.
   ([#3204](https://github.com/bazel-contrib/rules_python/issues/3204)).
@@ -104,6 +97,21 @@ END_UNRELEASED_TEMPLATE
   {ref}`common-deps-with-multiple-pypi-versions` guide on using common
   dependencies with multiple PyPI versions` for an example.
 
+{#v1-6-2}
+## [1.6.2] - 2025-09-21
+
+[1.6.2]: https://github.com/bazel-contrib/rules_python/releases/tag/1.6.2
+
+{#v1-6-2-fixed}
+### Fixed
+
+* (pypi) We now use the Minimal Version Selection (MVS) algorithm to select
+  the right wheel when there are multiple wheels for the target platform
+  (e.g. `musllinux_1_1_x86_64` and `musllinux_1_2_x86_64`). If the user
+  wants to set the minimum version for the selection algorithm, use the
+  {attr}`pip.defaults.whl_platform_tags` attribute to configure that. If
+  `musllinux_*_x86_64` is specified, we will chose the lowest available
+  wheel version. Fixes [#3250](https://github.com/bazel-contrib/rules_python/issues/3250).
 
 {#v1-6-0}
 ## [1.6.0] - 2025-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,12 +97,12 @@ END_UNRELEASED_TEMPLATE
   {ref}`common-deps-with-multiple-pypi-versions` guide on using common
   dependencies with multiple PyPI versions` for an example.
 
-{#v1-6-2}
-## [1.6.2] - 2025-09-21
+{#v1-6-3}
+## [1.6.3] - 2025-09-21
 
-[1.6.2]: https://github.com/bazel-contrib/rules_python/releases/tag/1.6.2
+[1.6.3]: https://github.com/bazel-contrib/rules_python/releases/tag/1.6.3
 
-{#v1-6-2-fixed}
+{#v1-6-3-fixed}
 ### Fixed
 
 * (pypi) We now use the Minimal Version Selection (MVS) algorithm to select

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,7 @@ END_UNRELEASED_TEMPLATE
   (e.g. `musllinux_1_1_x86_64` and `musllinux_1_2_x86_64`). If the user
   wants to set the minimum version for the selection algorithm, use the
   {attr}`pip.defaults.whl_platform_tags` attribute to configure that. If
-  `musllinux_*_x86_64` is specified, we will chose the lowest available
+  `musllinux_*_x86_64` is specified, we will choose the lowest available
   wheel version. Fixes [#3250](https://github.com/bazel-contrib/rules_python/issues/3250).
 
 {#v1-6-0}

--- a/python/private/pypi/extension.bzl
+++ b/python/private/pypi/extension.bzl
@@ -518,7 +518,7 @@ Common patterns:
 :::{seealso}
 See official [docs](https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/#platform-tag) for more information.
 :::
-:::{versionchanged} 1.6.2
+:::{versionchanged} 1.6.3
 The matching of versioned platforms have been switched to MVS (Minimal Version Selection)
 algorithm for easier evaluation logic and fewer surprises. The legacy platform tags are
 supported from this version without extra handling from the user.

--- a/python/private/pypi/extension.bzl
+++ b/python/private/pypi/extension.bzl
@@ -518,7 +518,7 @@ Common patterns:
 :::{seealso}
 See official [docs](https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/#platform-tag) for more information.
 :::
-:::{versionchanged} VERSION_NEXT_FEATURE
+:::{versionchanged} 1.6.2
 The matching of versioned platforms have been switched to MVS (Minimal Version Selection)
 algorithm for easier evaluation logic and fewer surprises. The legacy platform tags are
 supported from this version without extra handling from the user.


### PR DESCRIPTION
This fixes the changelog and manually changes the version updated tag.

The changes have been also cherry-picked to the release branch as I saw
release fail in the [workflow]. Hence this has become a 1.6.3 instead.

[workflow]: https://github.com/bazel-contrib/rules_python/actions/runs/17894155072/job/50878515841

Fixes #3273
