### PR TITLE
feat(modules_mapping): add ignore_native_libs parameter for hermetic builds

### DIFF
--- a/examples/build_file_generation/BUILD.bazel
+++ b/examples/build_file_generation/BUILD.bazel
@@ -28,6 +28,9 @@ modules_mapping(
         "^_|(\\._)+",  # This is the default.
         "(\\.tests)+",  # Add a custom one to get rid of the psutil tests.
     ],
+    # Uncomment the next line to enable hermetic builds across platforms
+    # by ignoring platform-specific native libraries (useful for opencv-python-headless, etc.)
+    # ignore_native_libs = True,
     wheels = all_whl_requirements,
 )
 

--- a/gazelle/docs/installation_and_usage.md
+++ b/gazelle/docs/installation_and_usage.md
@@ -96,6 +96,14 @@ modules_mapping(
     # for tools like type checkers and IDEs, improving the development experience and
     # reducing manual overhead in managing separate stub packages.
     include_stub_packages = True,
+
+    # ignore_native_libs: bool (default: False)
+    # If set to True, this flag ignores platform-specific native libraries (.so files)
+    # when generating the modules mapping. This ensures hermetic builds across different
+    # platforms (Linux, macOS, etc.) by producing identical manifests regardless of
+    # platform-specific wheel contents. Useful for packages like opencv-python-headless
+    # that include different native libraries on different platforms.
+    # ignore_native_libs = True,
 )
 
 # Gazelle python extension needs a manifest file mapping from

--- a/gazelle/modules_mapping/def.bzl
+++ b/gazelle/modules_mapping/def.bzl
@@ -38,6 +38,8 @@ def _modules_mapping_impl(ctx):
     args.set_param_file_format(format = "multiline")
     if ctx.attr.include_stub_packages:
         args.add("--include_stub_packages")
+    if ctx.attr.ignore_native_libs:
+        args.add("--ignore_native_libs")
     args.add("--output_file", modules_mapping)
     args.add_all("--exclude_patterns", ctx.attr.exclude_patterns)
     args.add_all("--wheels", all_wheels)
@@ -62,6 +64,11 @@ modules_mapping = rule(
         "include_stub_packages": attr.bool(
             default = False,
             doc = "Whether to include stub packages in the mapping.",
+            mandatory = False,
+        ),
+        "ignore_native_libs": attr.bool(
+            default = False,
+            doc = "Whether to ignore native libraries (*.so files) for platform-independent mappings.",
             mandatory = False,
         ),
         "modules_mapping_name": attr.string(

--- a/gazelle/modules_mapping/def.bzl
+++ b/gazelle/modules_mapping/def.bzl
@@ -68,7 +68,10 @@ modules_mapping = rule(
         ),
         "ignore_native_libs": attr.bool(
             default = False,
-            doc = "Whether to ignore native libraries (*.so files) for platform-independent mappings.",
+            doc = "Whether to ignore platform-specific native libraries (*.so files) when generating mappings. " +
+                  "When True, ensures hermetic builds across different platforms by excluding native library " +
+                  "mappings that vary between Linux, macOS, etc. Useful for packages like opencv-python-headless " +
+                  "that bundle different native libraries on different platforms.",
             mandatory = False,
         ),
         "modules_mapping_name": attr.string(

--- a/gazelle/modules_mapping/test_generator.py
+++ b/gazelle/modules_mapping/test_generator.py
@@ -7,7 +7,7 @@ from generator import Generator
 class GeneratorTest(unittest.TestCase):
     def test_generator(self):
         whl = pathlib.Path(__file__).parent / "pytest-8.3.3-py3-none-any.whl"
-        gen = Generator(None, None, {}, False)
+        gen = Generator(None, None, {}, False, False)
         gen.dig_wheel(whl)
         self.assertLessEqual(
             {
@@ -21,7 +21,7 @@ class GeneratorTest(unittest.TestCase):
 
     def test_stub_generator(self):
         whl = pathlib.Path(__file__).parent / "django_types-0.19.1-py3-none-any.whl"
-        gen = Generator(None, None, {}, True)
+        gen = Generator(None, None, {}, True, False)
         gen.dig_wheel(whl)
         self.assertLessEqual(
             {
@@ -32,12 +32,33 @@ class GeneratorTest(unittest.TestCase):
 
     def test_stub_excluded(self):
         whl = pathlib.Path(__file__).parent / "django_types-0.19.1-py3-none-any.whl"
-        gen = Generator(None, None, {}, False)
+        gen = Generator(None, None, {}, False, False)
         gen.dig_wheel(whl)
         self.assertEqual(
             {}.items(),
             gen.mapping.items(),
         )
+
+    def test_ignore_native_libs(self):
+        # Test the ignore_native_libs functionality with the module_for_path method
+        gen_with_native_libs = Generator(None, None, {}, False, False)
+        gen_without_native_libs = Generator(None, None, {}, False, True)
+
+        # Simulate a Python file - should be included in both cases
+        gen_with_native_libs.module_for_path("cv2/__init__.py", "opencv_python_headless-4.8.1-cp310-cp310-linux_x86_64.whl")
+        gen_without_native_libs.module_for_path("cv2/__init__.py", "opencv_python_headless-4.8.1-cp310-cp310-linux_x86_64.whl")
+
+        # Simulate a native library - should be included only when ignore_native_libs=False
+        gen_with_native_libs.module_for_path("opencv_python_headless.libs/libopenblas-r0-f650aae0.so", "opencv_python_headless-4.8.1-cp310-cp310-linux_x86_64.whl")
+        gen_without_native_libs.module_for_path("opencv_python_headless.libs/libopenblas-r0-f650aae0.so", "opencv_python_headless-4.8.1-cp310-cp310-linux_x86_64.whl")
+
+        # Both should have the Python module mapping
+        self.assertIn("cv2", gen_with_native_libs.mapping)
+        self.assertIn("cv2", gen_without_native_libs.mapping)
+
+        # Only gen_with_native_libs should have the native library mapping
+        self.assertIn("opencv_python_headless.libs.libopenblas-r0-f650aae0", gen_with_native_libs.mapping)
+        self.assertNotIn("opencv_python_headless.libs.libopenblas-r0-f650aae0", gen_without_native_libs.mapping)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds `ignore_native_libs` parameter to `modules_mapping` rule to enable hermetic builds across platforms
- When enabled, excludes platform-specific native libraries (.so files) from modules mapping
- Fixes inconsistent manifest generation between Linux and macOS for packages with platform-specific native libraries

## Problem
The `gazelle_python_manifest` generates different manifest files on different platforms due to platform-specific native libraries in Python wheels. For example, with opencv-python-headless:

**Linux generates entries like:**
```yaml
opencv_python_headless.libs.libopenblas-r0-f650aae0: opencv_python_headless
opencv_python_headless.libs.libgfortran-2e0d59d6: opencv_python_headless
```

**macOS generates no such entries** because the macOS wheel uses Apple's Accelerate framework instead of bundling OpenBLAS libraries.

This happens because Python wheels are platform-specific. The generator scans wheel contents and finds different native libraries:
- **Linux wheel** (`opencv_python_headless-4.x.x-cp310-cp310-linux_x86_64.whl`): Contains `opencv_python_headless/libs/libopenblas-r0-f650aae0.so`
- **macOS wheel** (`opencv_python_headless-4.x.x-cp310-cp310-macosx_11_0_arm64.whl`): Uses system Accelerate framework, no bundled OpenBLAS

These native libraries (.so/.dylib files) are never directly imported by Python code - they exist for underlying C/C++ dependencies but don't correspond to actual Python import statements, making them irrelevant for Gazelle's dependency resolution while breaking build hermiticity.

## Solution
- Added `ignore_native_libs` boolean parameter (default: False) to preserve backward compatibility
- When enabled, skips .so/.dylib files during wheel inspection while preserving all Python module mappings
- Ensures identical manifests across platforms for the same set of dependencies