### PR TITLE
refactor: rename symbols in re-exports

### DIFF
--- a/python/py_binary.bzl
+++ b/python/py_binary.bzl
@@ -14,11 +14,8 @@
 
 """Public entry point for py_binary."""
 
-load("//python/private:py_binary_macro.bzl", _starlark_py_binary = "py_binary")
+load("//python/private:py_binary_macro.bzl", _py_binary = "py_binary")
 load("//python/private:register_extension_info.bzl", "register_extension_info")
-
-# buildifier: disable=native-python
-_py_binary_impl = _starlark_py_binary
 
 def py_binary(**attrs):
     """Creates an executable Python program.
@@ -40,7 +37,7 @@ def py_binary(**attrs):
     if attrs.get("srcs_version") in ("PY2", "PY2ONLY"):
         fail("Python 2 is no longer supported: https://github.com/bazel-contrib/rules_python/issues/886")
 
-    _py_binary_impl(**attrs)
+    _py_binary(**attrs)
 
 register_extension_info(
     extension = py_binary,

--- a/python/py_cc_link_params_info.bzl
+++ b/python/py_cc_link_params_info.bzl
@@ -1,5 +1,5 @@
 """Public entry point for PyCcLinkParamsInfo."""
 
-load("//python/private:py_cc_link_params_info.bzl", _starlark_PyCcLinkParamsInfo = "PyCcLinkParamsInfo")
+load("//python/private:py_cc_link_params_info.bzl", _PyCcLinkParamsInfo = "PyCcLinkParamsInfo")
 
-PyCcLinkParamsInfo = _starlark_PyCcLinkParamsInfo
+PyCcLinkParamsInfo = _PyCcLinkParamsInfo

--- a/python/py_info.bzl
+++ b/python/py_info.bzl
@@ -14,6 +14,6 @@
 
 """Public entry point for PyInfo."""
 
-load("//python/private:py_info.bzl", _starlark_PyInfo = "PyInfo")
+load("//python/private:py_info.bzl", _PyInfo = "PyInfo")
 
-PyInfo = _starlark_PyInfo
+PyInfo = _PyInfo

--- a/python/py_library.bzl
+++ b/python/py_library.bzl
@@ -14,11 +14,8 @@
 
 """Public entry point for py_library."""
 
-load("//python/private:py_library_macro.bzl", _starlark_py_library = "py_library")
+load("//python/private:py_library_macro.bzl", _py_library = "py_library")
 load("//python/private:register_extension_info.bzl", "register_extension_info")
-
-# buildifier: disable=native-python
-_py_library_impl = _starlark_py_library
 
 def py_library(**attrs):
     """Creates an executable Python program.
@@ -37,7 +34,7 @@ def py_library(**attrs):
     if attrs.get("srcs_version") in ("PY2", "PY2ONLY"):
         fail("Python 2 is no longer supported: https://github.com/bazel-contrib/rules_python/issues/886")
 
-    _py_library_impl(**attrs)
+    _py_library(**attrs)
 
 register_extension_info(
     extension = py_library,

--- a/python/py_runtime.bzl
+++ b/python/py_runtime.bzl
@@ -14,10 +14,7 @@
 
 """Public entry point for py_runtime."""
 
-load("//python/private:py_runtime_macro.bzl", _starlark_py_runtime = "py_runtime")
-
-# buildifier: disable=native-python
-_py_runtime_impl = _starlark_py_runtime
+load("//python/private:py_runtime_macro.bzl", _py_runtime = "py_runtime")
 
 def py_runtime(**attrs):
     """Creates an executable Python program.
@@ -38,4 +35,4 @@ def py_runtime(**attrs):
     if attrs.get("python_version") == "PY2":
         fail("Python 2 is no longer supported: see https://github.com/bazel-contrib/rules_python/issues/886")
 
-    _py_runtime_impl(**attrs)
+    _py_runtime(**attrs)

--- a/python/py_runtime_info.bzl
+++ b/python/py_runtime_info.bzl
@@ -14,6 +14,6 @@
 
 """Public entry point for PyRuntimeInfo."""
 
-load("//python/private:py_runtime_info.bzl", _starlark_PyRuntimeInfo = "PyRuntimeInfo")
+load("//python/private:py_runtime_info.bzl", _PyRuntimeInfo = "PyRuntimeInfo")
 
-PyRuntimeInfo = _starlark_PyRuntimeInfo
+PyRuntimeInfo = _PyRuntimeInfo

--- a/python/py_runtime_pair.bzl
+++ b/python/py_runtime_pair.bzl
@@ -14,9 +14,7 @@
 
 """Public entry point for py_runtime_pair."""
 
-load("//python/private:py_runtime_pair_macro.bzl", _starlark_impl = "py_runtime_pair")
-
-_py_runtime_pair = _starlark_impl
+load("//python/private:py_runtime_pair_macro.bzl", _py_runtime_pair = "py_runtime_pair")
 
 # NOTE: This doc is copy/pasted from the builtin py_runtime_pair rule so our
 # doc generator gives useful API docs.

--- a/python/py_test.bzl
+++ b/python/py_test.bzl
@@ -14,11 +14,8 @@
 
 """Public entry point for py_test."""
 
-load("//python/private:py_test_macro.bzl", _starlark_py_test = "py_test")
+load("//python/private:py_test_macro.bzl", _py_test = "py_test")
 load("//python/private:register_extension_info.bzl", "register_extension_info")
-
-# buildifier: disable=native-python
-_py_test_impl = _starlark_py_test
 
 def py_test(**attrs):
     """Creates an executable Python program.
@@ -41,7 +38,7 @@ def py_test(**attrs):
         fail("Python 2 is no longer supported: https://github.com/bazel-contrib/rules_python/issues/886")
 
     # buildifier: disable=native-python
-    _py_test_impl(**attrs)
+    _py_test(**attrs)
 
 register_extension_info(
     extension = py_test,


### PR DESCRIPTION
A followup to #3282 to finish up the cleanup and remove the unnecessary
`starlark` usage in naming.
