### PR TITLE
chore: use python.defaults to set rules_python default python version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -37,13 +37,15 @@ use_repo(
 # We need to do another use_extension call to expose the "pythons_hub"
 # repo.
 python = use_extension("//python/extensions:python.bzl", "python")
+python.defaults(
+    python_version = "3.11",
+)
 
 # The default toolchain to use if nobody configures a toolchain.
 # NOTE: This is not a stable version. It is provided for convenience, but will
 # change frequently to track the most recent Python version.
 # NOTE: The root module can override this.
 python.toolchain(
-    is_default = True,
     python_version = "3.11",
 )
 use_repo(


### PR DESCRIPTION
python.defaults is the modern way to set the default.

Setting it this way also helps avoid a bug where if a root module has a single `python.toolchain()` call (which are implicitly treated as `is_default=True`) and also sets the default using `python.defaults()`, some validation logic gives an error about using both ways to set a default.