### PR TITLE
fix(uv): make uv lock rule work with platform python runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ END_UNRELEASED_TEMPLATE
 * (venvs) {obj}`--vens_site_packages=yes` no longer errors when packages with
   overlapping files or directories are used together.
   ([#3204](https://github.com/bazel-contrib/rules_python/issues/3204)).
+* (uv) {obj}`//python/uv:lock.bzl%lock` now works with a local platform
+  runtime.
 
 {#v0-0-0-added}
 ### Added

--- a/python/uv/private/lock.bzl
+++ b/python/uv/private/lock.bzl
@@ -106,7 +106,7 @@ def _lock_impl(ctx):
     exec_tools = ctx.toolchains[EXEC_TOOLS_TOOLCHAIN_TYPE].exec_tools
     runtime = exec_tools.exec_interpreter[platform_common.ToolchainInfo].py3_runtime
     python = runtime.interpreter or runtime.interpreter_path
-    python_files = runtime.files
+    python_files = runtime.files or depset()
     args.add("--python", python)
     args.add_all(srcs)
 


### PR DESCRIPTION
A platform runtime is when the interpreter is provided as an absolute path to Python
instead of bundled in the runfiles. The uv lock rule almost worked, it just didn't
handle the runtime files being empty in such a case.

To fix, use an empty depset to satisfy the subsequent APIs that use it.