### PR TITLE
docs: add config bzlmod extension to docs

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -106,6 +106,7 @@ sphinx_stardocs(
         "//python/cc:py_cc_toolchain_bzl",
         "//python/cc:py_cc_toolchain_info_bzl",
         "//python/entry_points:py_console_script_binary_bzl",
+        "//python/extensions:config_bzl",
         "//python/extensions:python_bzl",
         "//python/local_toolchains:repos_bzl",
         "//python/private:attr_builders_bzl",

--- a/python/private/BUILD.bazel
+++ b/python/private/BUILD.bazel
@@ -197,7 +197,10 @@ bzl_library(
 bzl_library(
     name = "internal_config_repo_bzl",
     srcs = ["internal_config_repo.bzl"],
-    deps = [":bzlmod_enabled_bzl"],
+    deps = [
+        ":repo_utils_bzl",
+        ":text_util_bzl",
+    ],
 )
 
 bzl_library(


### PR DESCRIPTION
The original PR omitted the target from the docs, so it was absent.

Along the way, fix some incorrect deps for its target so docs build.