### PR TITLE
fix: handle urls without release id format

### DIFF
--- a/python/versions.bzl
+++ b/python/versions.bzl
@@ -1045,7 +1045,13 @@ def get_release_info(platform, python_version, base_url = DEFAULT_RELEASE_BASE_U
     for u in url:
         p, _, _ = platform.partition(FREETHREADED)
 
-        release_id = int(u.split("/")[-2])
+        # Assume an unknown release_id is a newer url format
+        release_id = 99999999
+        url_parts = u.split("/")
+        if len(url_parts) >= 2:
+            maybe_release_id = url_parts[-2]
+            if maybe_release_id.isdigit():
+                release_id = int(maybe_release_id)
 
         if FREETHREADED.lstrip("-") in platform:
             build = "{}+{}-full".format(


### PR DESCRIPTION
Sometimes when users customize the URLs for release, they use urls that don't have
the same format the python-build-standalone URLs. Namely, they may not have
the release_id component of the url. This would result in an error parsing such
urls.

To fix, refine the url parsing to check if a component is a valid numeric release id.

Fixes https://github.com/bazel-contrib/rules_python/issues/3285