### PR TITLE
fix(pip): do not use experimental_index_url for publish_deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ END_UNRELEASED_TEMPLATE
 * (bootstrap) For {obj}`--bootstrap_impl=system_python`, the sys.path order has
   changed from `[app paths, stdlib, runtime site-packages]` to `[stdlib, app
   paths, runtime site-packages]`.
+* (pip) Publishing deps are no longer pulled via `experimental_index_url`.
+  ([#2937](https://github.com/bazel-contrib/rules_python/issues/2937)).
 
 {#v0-0-0-fixed}
 ### Fixed

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -168,12 +168,6 @@ pip = use_extension("//python/extensions:pip.bzl", "pip")
 ]
 
 pip.parse(
-    # NOTE @aignas 2024-10-26: We have an integration test that depends on us
-    # being able to build sdists for this hub, so explicitly set this to False.
-    #
-    # how do we test sdists? Maybe just worth adding a single sdist somewhere?
-    download_only = False,
-    experimental_index_url = "https://pypi.org/simple",
     hub_name = "rules_python_publish_deps",
     python_version = "3.11",
     requirements_by_platform = {


### PR DESCRIPTION
Currently, experimental_index_url will trigger network access (by the bzlmod extension
logic) as it figures out the wheels. This is problematic because this network
access always occurs, even if a user isn't using the publish tool. Additionally,
failed network accesses can get Bazel into stuck state requiring `bazel shutdown`
to fix it.

To fix, don't  use experimental_index_url for the publish tool deps.

Once bazelbuild/bazel#24777 is merged, we can roll it back,
but then we may need to check-in the `MODULE.bazel.lock` file into git.

This should be no-op for most users because the publisher is usually run
from with `host == exec`, but there is a small chance that people will
hit #2241.

Work towards #2937
