### PR TITLE
tests: add tests to verify toolchain registration

### DIFF
--- a/python/private/BUILD.bazel
+++ b/python/private/BUILD.bazel
@@ -531,6 +531,7 @@ bzl_library(
         ":py_runtime_info_bzl",
         ":reexports_bzl",
         ":rule_builders_bzl",
+        ":version_bzl",
         "@bazel_skylib//lib:dicts",
         "@bazel_skylib//lib:paths",
         "@bazel_skylib//rules:common_settings",

--- a/python/private/py_runtime_rule.bzl
+++ b/python/private/py_runtime_rule.bzl
@@ -21,6 +21,7 @@ load(":flags.bzl", "FreeThreadedFlag")
 load(":py_internal.bzl", "py_internal")
 load(":py_runtime_info.bzl", "DEFAULT_STUB_SHEBANG", "PyRuntimeInfo")
 load(":reexports.bzl", "BuiltinPyRuntimeInfo")
+load(":version.bzl", "version")
 
 _py_builtins = py_internal
 
@@ -387,11 +388,11 @@ def _is_singleton_depset(files):
     return _py_builtins.is_singleton_depset(files)
 
 def _interpreter_version_info_from_version_str(version_str):
-    parts = version_str.split(".")
+    v = version.parse(version_str)
     version_info = {}
+    parts = list(v.release)
     for key in ("major", "minor", "micro"):
         if not parts:
             break
         version_info[key] = parts.pop(0)
-
     return version_info

--- a/python/private/version.bzl
+++ b/python/private/version.bzl
@@ -622,7 +622,8 @@ def parse(version_str, strict = False, _fail = fail):
         # https://peps.python.org/pep-0440/#public-version-identifiers
         return None
 
-    return struct(
+    # buildifier: disable=uninitialized
+    self = struct(
         epoch = _parse_epoch(parts["epoch"], _fail),
         release = _parse_release(parts["release"]),
         pre = _parse_pre(parts["pre"]),
@@ -631,7 +632,9 @@ def parse(version_str, strict = False, _fail = fail):
         local = _parse_local(parts["local"], _fail),
         string = parts["norm"],
         is_prefix = parts["is_prefix"],
+        key = lambda *a, **k: _version_key(self, *a, **k),
     )
+    return self
 
 def _parse_epoch(value, fail):
     if not value:

--- a/tests/base_rules/py_executable_base_tests.bzl
+++ b/tests/base_rules/py_executable_base_tests.bzl
@@ -23,7 +23,8 @@ load("//python/private:reexports.bzl", "BuiltinPyRuntimeInfo")  # buildifier: di
 load("//tests/base_rules:base_tests.bzl", "create_base_tests")
 load("//tests/base_rules:util.bzl", "WINDOWS_ATTR", pt_util = "util")
 load("//tests/support:py_executable_info_subject.bzl", "PyExecutableInfoSubject")
-load("//tests/support:support.bzl", "CC_TOOLCHAIN", "CROSSTOOL_TOP", "LINUX_X86_64", "WINDOWS_X86_64")
+load("//tests/support:support.bzl", "CC_TOOLCHAIN", "CROSSTOOL_TOP")
+load("//tests/support/platforms:platforms.bzl", "platform_targets")
 
 _tests = []
 
@@ -46,9 +47,9 @@ def _test_basic_windows(name, config):
             "//command_line_option:build_python_zip": "true",
             "//command_line_option:cpu": "windows_x86_64",
             "//command_line_option:crosstool_top": CROSSTOOL_TOP,
-            "//command_line_option:extra_execution_platforms": [WINDOWS_X86_64],
+            "//command_line_option:extra_execution_platforms": [platform_targets.WINDOWS_X86_64],
             "//command_line_option:extra_toolchains": [CC_TOOLCHAIN],
-            "//command_line_option:platforms": [WINDOWS_X86_64],
+            "//command_line_option:platforms": [platform_targets.WINDOWS_X86_64],
         },
         attr_values = {},
     )
@@ -89,9 +90,9 @@ def _test_basic_zip(name, config):
             "//command_line_option:build_python_zip": "true",
             "//command_line_option:cpu": "linux_x86_64",
             "//command_line_option:crosstool_top": CROSSTOOL_TOP,
-            "//command_line_option:extra_execution_platforms": [LINUX_X86_64],
+            "//command_line_option:extra_execution_platforms": [platform_targets.LINUX_X86_64],
             "//command_line_option:extra_toolchains": [CC_TOOLCHAIN],
-            "//command_line_option:platforms": [LINUX_X86_64],
+            "//command_line_option:platforms": [platform_targets.LINUX_X86_64],
         },
         attr_values = {"target_compatible_with": target_compatible_with},
     )
@@ -326,8 +327,8 @@ def _test_main_module_bootstrap_system_python(name, config):
         target = name + "_subject",
         config_settings = {
             labels.BOOTSTRAP_IMPL: "system_python",
-            "//command_line_option:extra_execution_platforms": ["@bazel_tools//tools:host_platform", LINUX_X86_64],
-            "//command_line_option:platforms": [LINUX_X86_64],
+            "//command_line_option:extra_execution_platforms": ["@bazel_tools//tools:host_platform", platform_targets.LINUX_X86_64],
+            "//command_line_option:platforms": [platform_targets.LINUX_X86_64],
         },
     )
 
@@ -350,8 +351,8 @@ def _test_main_module_bootstrap_script(name, config):
         target = name + "_subject",
         config_settings = {
             labels.BOOTSTRAP_IMPL: "script",
-            "//command_line_option:extra_execution_platforms": ["@bazel_tools//tools:host_platform", LINUX_X86_64],
-            "//command_line_option:platforms": [LINUX_X86_64],
+            "//command_line_option:extra_execution_platforms": ["@bazel_tools//tools:host_platform", platform_targets.LINUX_X86_64],
+            "//command_line_option:platforms": [platform_targets.LINUX_X86_64],
         },
     )
 

--- a/tests/base_rules/py_test/py_test_tests.bzl
+++ b/tests/base_rules/py_test/py_test_tests.bzl
@@ -21,7 +21,8 @@ load(
     "create_executable_tests",
 )
 load("//tests/base_rules:util.bzl", pt_util = "util")
-load("//tests/support:support.bzl", "CC_TOOLCHAIN", "CROSSTOOL_TOP", "LINUX_X86_64", "MAC_X86_64")
+load("//tests/support:support.bzl", "CC_TOOLCHAIN", "CROSSTOOL_TOP")
+load("//tests/support/platforms:platforms.bzl", "platform_targets")
 
 # The Windows CI currently runs as root, which breaks when
 # the analysis tests try to install (but not use, because
@@ -51,9 +52,9 @@ def _test_mac_requires_darwin_for_execution(name, config):
         config_settings = {
             "//command_line_option:cpu": "darwin_x86_64",
             "//command_line_option:crosstool_top": CROSSTOOL_TOP,
-            "//command_line_option:extra_execution_platforms": [MAC_X86_64],
+            "//command_line_option:extra_execution_platforms": [platform_targets.MAC_X86_64],
             "//command_line_option:extra_toolchains": [CC_TOOLCHAIN],
-            "//command_line_option:platforms": [MAC_X86_64],
+            "//command_line_option:platforms": [platform_targets.MAC_X86_64],
         },
         attr_values = _SKIP_WINDOWS,
     )
@@ -78,9 +79,9 @@ def _test_non_mac_doesnt_require_darwin_for_execution(name, config):
         config_settings = {
             "//command_line_option:cpu": "k8",
             "//command_line_option:crosstool_top": CROSSTOOL_TOP,
-            "//command_line_option:extra_execution_platforms": [LINUX_X86_64],
+            "//command_line_option:extra_execution_platforms": [platform_targets.LINUX_X86_64],
             "//command_line_option:extra_toolchains": [CC_TOOLCHAIN],
-            "//command_line_option:platforms": [LINUX_X86_64],
+            "//command_line_option:platforms": [platform_targets.LINUX_X86_64],
         },
         attr_values = _SKIP_WINDOWS,
     )

--- a/tests/config_settings/transition/multi_version_tests.bzl
+++ b/tests/config_settings/transition/multi_version_tests.bzl
@@ -22,6 +22,7 @@ load("//python:py_info.bzl", "PyInfo")
 load("//python:py_test.bzl", "py_test")
 load("//python/private:reexports.bzl", "BuiltinPyInfo")  # buildifier: disable=bzl-visibility
 load("//tests/support:support.bzl", "CC_TOOLCHAIN")
+load("//tests/support/platforms:platforms.bzl", "platform_targets")
 
 # NOTE @aignas 2024-06-04: we are using here something that is registered in the MODULE.Bazel
 # and if you find tests failing, it could be because of the toolchain resolution issues here.
@@ -92,7 +93,7 @@ def _setup_py_binary_windows(name, *, impl, build_python_zip):
         config_settings = {
             "//command_line_option:build_python_zip": build_python_zip,
             "//command_line_option:extra_toolchains": CC_TOOLCHAIN,
-            "//command_line_option:platforms": str(Label("//tests/support:windows_x86_64")),
+            "//command_line_option:platforms": str(platform_targets.WINDOWS_X86_64),
         },
     )
 

--- a/tests/exec_toolchain_matching/exec_toolchain_matching_tests.bzl
+++ b/tests/exec_toolchain_matching/exec_toolchain_matching_tests.bzl
@@ -20,7 +20,7 @@ load("//python:py_runtime.bzl", "py_runtime")
 load("//python:py_runtime_pair.bzl", "py_runtime_pair")
 load("//python/private:common_labels.bzl", "labels")  # buildifier: disable=bzl-visibility
 load("//python/private:toolchain_types.bzl", "EXEC_TOOLS_TOOLCHAIN_TYPE", "TARGET_TOOLCHAIN_TYPE")  # buildifier: disable=bzl-visibility
-load("//tests/support:support.bzl", "LINUX", "MAC")
+load("//tests/support/platforms:platforms.bzl", "platform_targets")
 
 _LookupInfo = provider()  # buildifier: disable=provider-params
 
@@ -126,9 +126,9 @@ def _test_exec_matches_target_python_version(name):
         target = name + "_subject",
         impl = _test_exec_matches_target_python_version_impl,
         config_settings = {
-            "//command_line_option:extra_execution_platforms": [str(MAC)],
+            "//command_line_option:extra_execution_platforms": [str(platform_targets.MAC)],
             "//command_line_option:extra_toolchains": ["//tests/exec_toolchain_matching:all"],
-            "//command_line_option:platforms": [str(LINUX)],
+            "//command_line_option:platforms": [str(platform_targets.LINUX)],
             labels.PYTHON_VERSION: "3.12",
         },
     )

--- a/tests/pypi/config_settings/config_settings_tests.bzl
+++ b/tests/pypi/config_settings/config_settings_tests.bzl
@@ -31,7 +31,7 @@ _subject = rule(
 )
 
 _flag = struct(
-    platform = lambda x: ("//command_line_option:platforms", str(Label("//tests/support:" + x))),
+    platform = lambda x: ("//command_line_option:platforms", str(Label("//tests/support/platforms:" + x))),
     pip_whl = lambda x: (str(Label("//python/config_settings:pip_whl")), str(x)),
     pip_whl_glibc_version = lambda x: (str(Label("//python/config_settings:pip_whl_glibc_version")), str(x)),
     pip_whl_muslc_version = lambda x: (str(Label("//python/config_settings:pip_whl_muslc_version")), str(x)),

--- a/tests/support/BUILD.bazel
+++ b/tests/support/BUILD.bazel
@@ -12,80 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# ====================
-# NOTE: You probably want to use the constants in test_platforms.bzl
-# Otherwise, you'll probably have to manually call Label() on these targets
-# to force them to resolve in the proper context.
-# ====================
-
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load(":sh_py_run_test.bzl", "current_build_settings")
 
 package(
     default_visibility = ["//:__subpackages__"],
-)
-
-platform(
-    name = "mac",
-    constraint_values = [
-        "@platforms//os:macos",
-    ],
-)
-
-platform(
-    name = "linux",
-    constraint_values = [
-        "@platforms//os:linux",
-    ],
-)
-
-platform(
-    name = "windows",
-    constraint_values = [
-        "@platforms//os:windows",
-    ],
-)
-
-# Used when testing downloading of toolchains for a different platform
-
-platform(
-    name = "linux_x86_64",
-    constraint_values = [
-        "@platforms//cpu:x86_64",
-        "@platforms//os:linux",
-    ],
-)
-
-platform(
-    name = "linux_aarch64",
-    constraint_values = [
-        "@platforms//cpu:aarch64",
-        "@platforms//os:linux",
-    ],
-)
-
-platform(
-    name = "mac_x86_64",
-    constraint_values = [
-        "@platforms//cpu:x86_64",
-        "@platforms//os:macos",
-    ],
-)
-
-platform(
-    name = "windows_x86_64",
-    constraint_values = [
-        "@platforms//cpu:x86_64",
-        "@platforms//os:windows",
-    ],
-)
-
-platform(
-    name = "win_aarch64",
-    constraint_values = [
-        "@platforms//os:windows",
-        "@platforms//cpu:aarch64",
-    ],
 )
 
 current_build_settings(

--- a/tests/support/platforms/BUILD.bazel
+++ b/tests/support/platforms/BUILD.bazel
@@ -1,0 +1,77 @@
+package(
+    default_visibility = ["//:__subpackages__"],
+)
+
+# ====================
+# NOTE: You probably want to use the constants in test_platforms.bzl
+# Otherwise, you'll probably have to manually call Label() on these targets
+# to force them to resolve in the proper context.
+# ====================
+platform(
+    name = "mac",
+    constraint_values = [
+        "@platforms//os:macos",
+    ],
+)
+
+platform(
+    name = "linux",
+    constraint_values = [
+        "@platforms//os:linux",
+    ],
+)
+
+platform(
+    name = "windows",
+    constraint_values = [
+        "@platforms//os:windows",
+    ],
+)
+
+platform(
+    name = "linux_x86_64",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+)
+
+platform(
+    name = "linux_aarch64",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+)
+
+platform(
+    name = "mac_x86_64",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:macos",
+    ],
+)
+
+platform(
+    name = "mac_aarch64",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:macos",
+    ],
+)
+
+platform(
+    name = "windows_x86_64",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:windows",
+    ],
+)
+
+platform(
+    name = "windows_aarch64",
+    constraint_values = [
+        "@platforms//os:windows",
+        "@platforms//cpu:aarch64",
+    ],
+)

--- a/tests/support/platforms/platforms.bzl
+++ b/tests/support/platforms/platforms.bzl
@@ -1,0 +1,13 @@
+"""Constants and utilities for platforms used for testing."""
+
+platform_targets = struct(
+    LINUX = Label("//tests/support/platforms:linux"),
+    LINUX_AARCH64 = Label("//tests/support/platforms:linux_aarch64"),
+    LINUX_X86_64 = Label("//tests/support/platforms:linux_x86_64"),
+    MAC = Label("//tests/support/platforms:mac"),
+    MAC_X86_64 = Label("//tests/support/platforms:mac_x86_64"),
+    MAC_AARCH64 = Label("//tests/support/platforms:mac_aarch64"),
+    WINDOWS = Label("//tests/support/platforms:windows"),
+    WINDOWS_AARCH64 = Label("//tests/support/platforms:windows_aarch64"),
+    WINDOWS_X86_64 = Label("//tests/support/platforms:windows_x86_64"),
+)

--- a/tests/support/support.bzl
+++ b/tests/support/support.bzl
@@ -21,13 +21,6 @@
 
 load("//python/private:bzlmod_enabled.bzl", "BZLMOD_ENABLED")  # buildifier: disable=bzl-visibility
 
-MAC = Label("//tests/support:mac")
-MAC_X86_64 = Label("//tests/support:mac_x86_64")
-LINUX = Label("//tests/support:linux")
-LINUX_X86_64 = Label("//tests/support:linux_x86_64")
-WINDOWS = Label("//tests/support:windows")
-WINDOWS_X86_64 = Label("//tests/support:windows_x86_64")
-
 PY_TOOLCHAINS = str(Label("//tests/support/py_toolchains:all"))
 CC_TOOLCHAIN = str(Label("//tests/support/cc_toolchains:all"))
 CROSSTOOL_TOP = Label("//tests/support/cc_toolchains:cc_toolchain_suite")

--- a/tests/toolchains/multi_platform_resolution/BUILD.bazel
+++ b/tests/toolchains/multi_platform_resolution/BUILD.bazel
@@ -1,0 +1,3 @@
+load(":resolution_tests.bzl", "resolution_test_suite")
+
+resolution_test_suite(name = "resolution_tests")

--- a/tests/toolchains/multi_platform_resolution/resolution_tests.bzl
+++ b/tests/toolchains/multi_platform_resolution/resolution_tests.bzl
@@ -1,0 +1,186 @@
+"""Tests to verify toolchain resolution of different config variants.
+
+NOTE: This test relies on the project toolchain configuration. This is
+intentional because it wants to verify that, using the toolchains as
+rules_python configures them, the different implementations can be used
+by setting the appropriate flags.
+"""
+
+load("@bazel_skylib//lib:structs.bzl", "structs")
+load("@rules_testing//lib:analysis_test.bzl", "analysis_test")
+load("@rules_testing//lib:test_suite.bzl", "test_suite")
+load("//python:versions.bzl", "TOOL_VERSIONS")
+load("//python/private:bzlmod_enabled.bzl", "BZLMOD_ENABLED")  # buildifier: disable=bzl-visibility
+load("//python/private:common_labels.bzl", "labels")  # buildifier: disable=bzl-visibility
+load("//python/private:toolchain_types.bzl", "TARGET_TOOLCHAIN_TYPE")  # buildifier: disable=bzl-visibility
+load("//python/private:version.bzl", "version")  # buildifier: disable=bzl-visibility
+load("//tests/support/platforms:platforms.bzl", "platform_targets")
+
+_PLATFORM_TARGET_MAP = {
+    "linux": {
+        "aarch64": platform_targets.LINUX_AARCH64,
+        "x86_64": platform_targets.LINUX_X86_64,
+    },
+    "osx": {
+        "aarch64": platform_targets.MAC_AARCH64,
+        "x86_64": platform_targets.MAC_X86_64,
+    },
+    "windows": {
+        "aarch64": platform_targets.WINDOWS_AARCH64,
+        "x86_64": platform_targets.WINDOWS_X86_64,
+    },
+}
+_PLATFORM_TRIPLES = {
+    ("linux", "glibc"): "unknown_linux_gnu",
+    ("linux", "musl"): "unknown_linux_musl",
+    "osx": "apple_darwin",
+    "windows": "pc_windows_msvc",
+}
+
+_ResolvedToolchainsInfo = provider(
+    doc = "Tell what toolchain was found",
+    fields = {
+        "target": "ToolchainInfo for //python:toolchain_type",
+    },
+)
+
+def _current_toolchain_impl(ctx):
+    # todo: also return current settings for various config flags
+    # to help identify state
+    return [_ResolvedToolchainsInfo(
+        target = ctx.toolchains[TARGET_TOOLCHAIN_TYPE],
+    )]
+
+_current_toolchain = rule(
+    implementation = _current_toolchain_impl,
+    toolchains = [
+        TARGET_TOOLCHAIN_TYPE,
+    ],
+)
+
+def _platform(os, arch, libc, *, ft):
+    if os == "linux":
+        platform_triple = _PLATFORM_TRIPLES[os, libc]
+    else:
+        platform_triple = _PLATFORM_TRIPLES[os]
+    return struct(
+        arch = arch,
+        freethreaded = ft,
+        libc = libc,
+        os = os,
+        platform_triple = platform_triple,
+        platform_target = _PLATFORM_TARGET_MAP[os][arch],
+    )
+
+# There's many exceptions to the full `os x arch x libc x threading` matrix,
+# so just list the specific combinations that are supported.
+# We also omit some more esoteric archs to reduce the matrix size (and
+# thus how many runtimes get downloaded).
+# The important quality is to have at least 2 for every dimension
+_PLATFORMS = [
+    _platform("linux", "aarch64", "glibc", ft = "no"),
+    _platform("linux", "aarch64", "glibc", ft = "yes"),
+    _platform("linux", "x86_64", "glibc", ft = "no"),
+    _platform("linux", "x86_64", "glibc", ft = "yes"),
+    _platform("linux", "x86_64", "musl", ft = "no"),
+    _platform("osx", "aarch64", None, ft = "no"),
+    _platform("osx", "aarch64", None, ft = "yes"),
+    _platform("osx", "x86_64", None, ft = "no"),
+    _platform("osx", "x86_64", None, ft = "yes"),
+    _platform("windows", "aarch64", None, ft = "no"),
+    _platform("windows", "aarch64", None, ft = "yes"),
+    _platform("windows", "x86_64", None, ft = "no"),
+    _platform("windows", "x86_64", None, ft = "yes"),
+]
+
+def _compute_runtimes():
+    runtimes = []
+
+    # Limit to the two most recent versions. This helps ensure that multiple
+    # versions are matching correctly. Limit to two because the disk/download
+    # isn't worth the marginal coverage improvment.
+    selected_versions = sorted(
+        TOOL_VERSIONS.keys(),
+        key = lambda v: version.parse(v).key(),
+    )[-2::1]
+
+    for python_version in selected_versions:
+        for platform in _PLATFORMS:
+            runtimes.append(struct(
+                name = "{python_version}_{arch}_{triple}{threading}".format(
+                    python_version = python_version.replace(".", "_"),
+                    arch = platform.arch,
+                    triple = platform.platform_triple,
+                    threading = "_freethreaded" if platform.freethreaded == "yes" else "",
+                ),
+                python_version = python_version,
+                **structs.to_dict(platform)
+            ))
+
+    return sorted(runtimes, key = lambda v: v.name)
+
+def _test_toolchains_impl(env, target):
+    target_tc = target[_ResolvedToolchainsInfo].target
+    toolchain_str = str(target_tc.toolchain_label).replace("-", "_")
+    env.expect.that_str(toolchain_str).contains(env.ctx.attr.expected_toolchain_name)
+
+def _test_toolchains(name):
+    _current_toolchain(
+        name = name + "_current_toolchain",
+    )
+    test_names = []
+    for runtime in _compute_runtimes():
+        test_name = "test_{}".format(runtime.name)
+        test_names.append(test_name)
+        config_settings = {
+            "//command_line_option:platforms": [runtime.platform_target],
+            labels.VISIBLE_FOR_TESTING: True,
+            labels.PY_FREETHREADED: runtime.freethreaded,
+            labels.PYTHON_VERSION: runtime.python_version,
+        }
+        if runtime.libc:
+            config_settings[labels.PY_LINUX_LIBC] = runtime.libc
+
+        # TODO: Workspace isn't correctly registering musl and freethreaded
+        # toolchains, so skip them for now.
+        target_compatible_with = []
+        if not BZLMOD_ENABLED and (runtime.libc == "musl" or
+                                   runtime.freethreaded == "yes"):
+            target_compatible_with = ["@platforms//:incompatible"]
+
+        analysis_test(
+            name = test_name,
+            target = name + "_current_toolchain",
+            impl = _test_toolchains_impl,
+            config_settings = config_settings,
+            attrs = {"expected_toolchain_name": attr.string()},
+            attr_values = {
+                "expected_toolchain_name": runtime.name,
+                # A lot of tests are generated, so set tags to make selecting
+                # subsets easier
+                "tags": [
+                    "python-version={}".format(runtime.python_version),
+                    "libc={}".format(runtime.libc),
+                    "freethreaded={}".format(runtime.freethreaded),
+                    "os={}".format(runtime.os),
+                    "arch={}".format(runtime.arch),
+                ],
+                "target_compatible_with": target_compatible_with,
+            },
+        )
+
+    # We have to return a target for `name`.
+    native.test_suite(
+        name = name,
+        tests = test_names,
+    )
+
+_tests = [
+    _test_toolchains,
+]
+
+def resolution_test_suite(name):
+    test_suite(
+        name = name,
+        tests = _tests,
+    )

--- a/tests/toolchains/multi_platform_resolution/resolution_tests.bzl
+++ b/tests/toolchains/multi_platform_resolution/resolution_tests.bzl
@@ -102,7 +102,7 @@ def _compute_runtimes():
     selected_versions = sorted(
         TOOL_VERSIONS.keys(),
         key = lambda v: version.parse(v).key(),
-    )[-2::1]
+    )[-2:]
 
     for python_version in selected_versions:
         for platform in _PLATFORMS:

--- a/tests/uv/uv/uv_tests.bzl
+++ b/tests/uv/uv/uv_tests.bzl
@@ -21,6 +21,7 @@ load("//python/private:common_labels.bzl", "labels")  # buildifier: disable=bzl-
 load("//python/uv:uv_toolchain_info.bzl", "UvToolchainInfo")
 load("//python/uv/private:uv.bzl", "process_modules")  # buildifier: disable=bzl-visibility
 load("//python/uv/private:uv_toolchain.bzl", "uv_toolchain")  # buildifier: disable=bzl-visibility
+load("//tests/support/platforms:platforms.bzl", "platform_targets")
 
 _tests = []
 
@@ -575,7 +576,7 @@ def _test_toolchain_precedence(name):
             "//command_line_option:extra_toolchains": [
                 str(Label("//tests/uv/uv_toolchains:all")),
             ],
-            "//command_line_option:platforms": str(Label("//tests/support:linux_aarch64")),
+            "//command_line_option:platforms": str(platform_targets.LINUX_AARCH64),
         },
     )
 


### PR DESCRIPTION
This adds tests that verify toolchains are registered and resolving correctly for
the different variants and platforms for the runtimes.

This also shows that workspace mode isn't registering musl or freethreaded builds
correctly, so use them isn't as easy as simply setting the build flags. For now,
the tests skip those in workspace mode.

Along the way, fix a bug where py_runtime would crash if it got the python version
from the flag, and the version contained more than micro (e.g. "3.14.0rc0")