### PR TITLE
fix(toolchains): correctly register musl/freethreaded toolchains for workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,10 @@ END_UNRELEASED_TEMPLATE
   ([#3204](https://github.com/bazel-contrib/rules_python/issues/3204)).
 * (uv) {obj}`//python/uv:lock.bzl%lock` now works with a local platform
   runtime.
+* (toolchains) WORKSPACE builds now correctly register musl and freethreaded
+  variants. Setting {obj}`--py_linux_libc=musl` and `--py_freethreaded=yes` now
+  activate them, respectively.
+  ([#3262](https://github.com/bazel-contrib/rules_python/issues/3262)).
 
 {#v0-0-0-added}
 ### Added

--- a/python/private/toolchains_repo.bzl
+++ b/python/private/toolchains_repo.bzl
@@ -214,7 +214,7 @@ def python_toolchain_build_file_content(
             user_repository_name = "{}_{}".format(user_repository_name, platform),
             python_version = python_version,
             set_python_version_constraint = set_python_version_constraint,
-            target_settings = [],
+            target_settings = meta.target_settings,
         ))
     return "\n\n".join(entries)
 

--- a/tests/toolchains/multi_platform_resolution/resolution_tests.bzl
+++ b/tests/toolchains/multi_platform_resolution/resolution_tests.bzl
@@ -141,13 +141,6 @@ def _test_toolchains(name):
         if runtime.libc:
             config_settings[labels.PY_LINUX_LIBC] = runtime.libc
 
-        # TODO: Workspace isn't correctly registering musl and freethreaded
-        # toolchains, so skip them for now.
-        target_compatible_with = []
-        if not BZLMOD_ENABLED and (runtime.libc == "musl" or
-                                   runtime.freethreaded == "yes"):
-            target_compatible_with = ["@platforms//:incompatible"]
-
         analysis_test(
             name = test_name,
             target = name + "_current_toolchain",

--- a/tests/toolchains/multi_platform_resolution/resolution_tests.bzl
+++ b/tests/toolchains/multi_platform_resolution/resolution_tests.bzl
@@ -10,7 +10,6 @@ load("@bazel_skylib//lib:structs.bzl", "structs")
 load("@rules_testing//lib:analysis_test.bzl", "analysis_test")
 load("@rules_testing//lib:test_suite.bzl", "test_suite")
 load("//python:versions.bzl", "TOOL_VERSIONS")
-load("//python/private:bzlmod_enabled.bzl", "BZLMOD_ENABLED")  # buildifier: disable=bzl-visibility
 load("//python/private:common_labels.bzl", "labels")  # buildifier: disable=bzl-visibility
 load("//python/private:toolchain_types.bzl", "TARGET_TOOLCHAIN_TYPE")  # buildifier: disable=bzl-visibility
 load("//python/private:version.bzl", "version")  # buildifier: disable=bzl-visibility
@@ -158,7 +157,6 @@ def _test_toolchains(name):
                     "os={}".format(runtime.os),
                     "arch={}".format(runtime.arch),
                 ],
-                "target_compatible_with": target_compatible_with,
             },
         )
 


### PR DESCRIPTION
The musl/freethreaded runtimes weren't being activated when the flags were set. This was
because the toolchains weren't having `target_settings` set, which means extra settings,
such as musl/freethreaded-ness were ignored when matching. The net result is the regular
toolchain, because it's registered earlier, would always match earlier.

To fix, set the target_settings in the toolchain() call. This matches the bzlmod behavior.

Also update the toolchain resolution tests to verify resolution.

Fixes https://github.com/bazel-contrib/rules_python/issues/3262