### PR TITLE
fix: wrong value of `has_py3_only_sources` in the PyInfo constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ END_UNRELEASED_TEMPLATE
 
 {#v0-0-0-fixed}
 ### Fixed
+* (rules) The `PyInfo` constructor was setting the wrong value for
+  `has_py3_only_sources` - this is now fixed.
 * (bootstrap) The stage1 bootstrap script now correctly handles nested `RUNFILES_DIR`
   environments, fixing issues where a `py_binary` calls another `py_binary`
   ([#3187](https://github.com/bazel-contrib/rules_python/issues/3187)).

--- a/python/private/py_info.bzl
+++ b/python/private/py_info.bzl
@@ -146,7 +146,7 @@ def _PyInfo_init(
         "direct_pyc_files": direct_pyc_files,
         "direct_pyi_files": direct_pyi_files,
         "has_py2_only_sources": has_py2_only_sources,
-        "has_py3_only_sources": has_py2_only_sources,
+        "has_py3_only_sources": has_py3_only_sources,
         "imports": imports,
         "transitive_implicit_pyc_files": transitive_implicit_pyc_files,
         "transitive_implicit_pyc_source_files": transitive_implicit_pyc_source_files,

--- a/tests/base_rules/py_info/py_info_tests.bzl
+++ b/tests/base_rules/py_info/py_info_tests.bzl
@@ -35,7 +35,7 @@ def _provide_py_info_impl(ctx):
     if ctx.attr.has_py2_only_sources != -1:
         kwargs["has_py2_only_sources"] = bool(ctx.attr.has_py2_only_sources)
     if ctx.attr.has_py3_only_sources != -1:
-        kwargs["has_py2_only_sources"] = bool(ctx.attr.has_py2_only_sources)
+        kwargs["has_py3_only_sources"] = bool(ctx.attr.has_py3_only_sources)
 
     providers = []
     providers.append(PyInfo(**kwargs))


### PR DESCRIPTION
The has_py3_only_sources field was being set to the has_py2_only_sources variable