### PR TITLE
chore: reject py2 runtimes and remove usages of ctx.fragments.py.disable_py2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@ END_UNRELEASED_TEMPLATE
   paths, runtime site-packages]`.
 * (pip) Publishing deps are no longer pulled via `experimental_index_url`.
   ([#2937](https://github.com/bazel-contrib/rules_python/issues/2937)).
+* (toolchains) `py_runtime` and `PyRuntimeInfo` reject Python 2 settings.
+  Setting `py_runtime.python_version = "PY2"` or non-None
+  `PyRuntimeInfo.py2_runtime` is an error.
 
 {#v0-0-0-fixed}
 ### Fixed

--- a/python/private/flags.bzl
+++ b/python/private/flags.bzl
@@ -39,7 +39,6 @@ load(":enum.bzl", "FlagEnum", "enum")
 _POSSIBLY_NATIVE_FLAGS = {
     "build_python_zip": (lambda ctx: ctx.fragments.py.build_python_zip, "native"),
     "default_to_explicit_init_py": (lambda ctx: ctx.fragments.py.default_to_explicit_init_py, "native"),
-    "disable_py2": (lambda ctx: ctx.fragments.py.disable_py2, "native"),
     "python_import_all_repositories": (lambda ctx: ctx.fragments.bazel_py.python_import_all_repositories, "native"),
     "python_path": (lambda ctx: ctx.fragments.bazel_py.python_path, "native"),
 }

--- a/python/private/py_runtime_pair_rule.bzl
+++ b/python/private/py_runtime_pair_rule.bzl
@@ -17,7 +17,6 @@
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("//python:py_runtime_info.bzl", "PyRuntimeInfo")
 load(":common_labels.bzl", "labels")
-load(":flags.bzl", "read_possibly_native_flag")
 load(":reexports.bzl", "BuiltinPyRuntimeInfo")
 
 def _py_runtime_pair_impl(ctx):
@@ -37,10 +36,9 @@ def _py_runtime_pair_impl(ctx):
     else:
         py3_runtime = None
 
-
     if py2_runtime != None:
         fail("Using Python 2 is not supported and disabled; see " +
-               "https://github.com/bazelbuild/bazel/issues/15684")
+             "https://github.com/bazelbuild/bazel/issues/15684")
 
     extra_kwargs = {}
     if ctx.attr._visible_for_testing[BuildSettingInfo].value:

--- a/python/private/py_runtime_pair_rule.bzl
+++ b/python/private/py_runtime_pair_rule.bzl
@@ -37,10 +37,10 @@ def _py_runtime_pair_impl(ctx):
     else:
         py3_runtime = None
 
-    # TODO: Uncomment this after --incompatible_python_disable_py2 defaults to true
-    # if _is_py2_disabled(ctx) and py2_runtime != None:
-    #     fail("Using Python 2 is not supported and disabled; see " +
-    #          "https://github.com/bazelbuild/bazel/issues/15684")
+
+    if py2_runtime != None:
+        fail("Using Python 2 is not supported and disabled; see " +
+               "https://github.com/bazelbuild/bazel/issues/15684")
 
     extra_kwargs = {}
     if ctx.attr._visible_for_testing[BuildSettingInfo].value:
@@ -61,15 +61,6 @@ def _get_py_runtime_info(target):
         return target[PyRuntimeInfo]
     else:
         return target[BuiltinPyRuntimeInfo]
-
-# buildifier: disable=unused-variable
-def _is_py2_disabled(ctx):
-    # Because this file isn't bundled with Bazel, so we have to conditionally
-    # check for this flag.
-    # TODO: Remove this once all supported Balze versions have this flag.
-    if not hasattr(ctx.fragments.py, "disable_py"):
-        return False
-    return read_possibly_native_flag(ctx, "disable_py2")
 
 _MaybeBuiltinPyRuntimeInfo = [[BuiltinPyRuntimeInfo]] if BuiltinPyRuntimeInfo != None else []
 

--- a/python/private/py_runtime_rule.bzl
+++ b/python/private/py_runtime_rule.bzl
@@ -89,7 +89,7 @@ def _py_runtime_impl(ctx):
 
     if python_version == "PY2":
         fail("Using Python 2 is not supported and disabled; see " +
-               "https://github.com/bazelbuild/bazel/issues/15684")
+             "https://github.com/bazelbuild/bazel/issues/15684")
 
     pyc_tag = ctx.attr.pyc_tag
     if not pyc_tag and (ctx.attr.implementation_name and

--- a/python/private/py_runtime_rule.bzl
+++ b/python/private/py_runtime_rule.bzl
@@ -87,10 +87,9 @@ def _py_runtime_impl(ctx):
         if python_version_flag:
             interpreter_version_info = _interpreter_version_info_from_version_str(python_version_flag)
 
-    # TODO: Uncomment this after --incompatible_python_disable_py2 defaults to true
-    # if ctx.fragments.py.disable_py2 and python_version == "PY2":
-    #     fail("Using Python 2 is not supported and disabled; see " +
-    #          "https://github.com/bazelbuild/bazel/issues/15684")
+    if python_version == "PY2":
+        fail("Using Python 2 is not supported and disabled; see " +
+               "https://github.com/bazelbuild/bazel/issues/15684")
 
     pyc_tag = ctx.attr.pyc_tag
     if not pyc_tag and (ctx.attr.implementation_name and


### PR DESCRIPTION
This removes the usages of the disable_py2 fragment attribute. This also makes py2
runtimes rejected (both when set on py_runtime and PyRuntimeInfo)

Because Python 2 support was dropped long ago and other parts of the code reject,
ignore, or don't work with Python 2 already, this is not considered a breaking change.

Work towards: https://github.com/bazel-contrib/rules_python/issues/3252