### PR TITLE
fix(pypi): don't resolve python interpreter when not necessary

### DIFF
--- a/python/private/pypi/whl_library.bzl
+++ b/python/private/pypi/whl_library.bzl
@@ -183,7 +183,8 @@ def _parse_optional_attrs(rctx, args, extra_pip_args = None):
     if rctx.attr.add_libdir_to_library_search_path:
         if "LDFLAGS" in env:
             fail("Can't set both environment LDFLAGS and add_libdir_to_library_search_path")
-        command = [pypi_repo_utils.resolve_python_interpreter(rctx), "-c", "import sys ; sys.stdout.write('{}/lib'.format(sys.exec_prefix))"]
+        command = [
+            pypi_repo_utils.resolve_python_interpreter(rctx), "-c", "import sys ; sys.stdout.write('{}/lib'.format(sys.exec_prefix))"]
         result = rctx.execute(command)
         if result.return_code != 0:
             fail("Failed to get LDFLAGS path: command: {}, exit code: {}, stdout: {}, stderr: {}".format(command, result.return_code, result.stdout, result.stderr))
@@ -292,22 +293,11 @@ def _extract_whl_py(rctx, *, python_interpreter, args, whl_path, environment, lo
 
 def _whl_library_impl(rctx):
     logger = repo_utils.logger(rctx)
-    python_interpreter = pypi_repo_utils.resolve_python_interpreter(
-        rctx,
-        python_interpreter = rctx.attr.python_interpreter,
-        python_interpreter_target = rctx.attr.python_interpreter_target,
-    )
-    args = [
-        "-m",
-        "python.private.pypi.whl_installer.wheel_installer",
-        "--requirement",
-        rctx.attr.requirement,
-    ]
-    extra_pip_args = []
-    extra_pip_args.extend(rctx.attr.extra_pip_args)
 
     whl_path = None
     sdist_filename = None
+    extra_pip_args = []
+    extra_pip_args.extend(rctx.attr.extra_pip_args)
     if rctx.attr.whl_file:
         rctx.watch(rctx.attr.whl_file)
         whl_path = rctx.path(rctx.attr.whl_file)
@@ -352,8 +342,6 @@ def _whl_library_impl(rctx):
             # build deps from PyPI (e.g. `flit_core`) if they are missing.
             extra_pip_args.extend(["--find-links", "."])
 
-    args = _parse_optional_attrs(rctx, args, extra_pip_args)
-
     # also enable pipstar for any whls that are downloaded without `pip`
     enable_pipstar = (rp_config.enable_pipstar or whl_path) and rctx.attr.config_load
     enable_pipstar_extract = enable_pipstar and rp_config.bazel_8_or_later
@@ -362,7 +350,21 @@ def _whl_library_impl(rctx):
     # to setup env vars to run Python, unless we need to build an sdist
     if enable_pipstar_extract and whl_path:
         environment = {}
+        args = []
+        python_interpreter = None
     else:
+        python_interpreter = pypi_repo_utils.resolve_python_interpreter(
+            rctx,
+            python_interpreter = rctx.attr.python_interpreter,
+            python_interpreter_target = rctx.attr.python_interpreter_target,
+        )
+        args = [
+            "-m",
+            "python.private.pypi.whl_installer.wheel_installer",
+            "--requirement",
+            rctx.attr.requirement,
+        ]
+        args = _parse_optional_attrs(rctx, args, extra_pip_args)
         # Manually construct the PYTHONPATH since we cannot use the toolchain here
         environment = _create_repository_execution_environment(rctx, python_interpreter, logger = logger)
 

--- a/python/private/pypi/whl_library.bzl
+++ b/python/private/pypi/whl_library.bzl
@@ -184,7 +184,10 @@ def _parse_optional_attrs(rctx, args, extra_pip_args = None):
         if "LDFLAGS" in env:
             fail("Can't set both environment LDFLAGS and add_libdir_to_library_search_path")
         command = [
-            pypi_repo_utils.resolve_python_interpreter(rctx), "-c", "import sys ; sys.stdout.write('{}/lib'.format(sys.exec_prefix))"]
+            pypi_repo_utils.resolve_python_interpreter(rctx),
+            "-c",
+            "import sys ; sys.stdout.write('{}/lib'.format(sys.exec_prefix))",
+        ]
         result = rctx.execute(command)
         if result.return_code != 0:
             fail("Failed to get LDFLAGS path: command: {}, exit code: {}, stdout: {}, stderr: {}".format(command, result.return_code, result.stdout, result.stderr))
@@ -365,6 +368,7 @@ def _whl_library_impl(rctx):
             rctx.attr.requirement,
         ]
         args = _parse_optional_attrs(rctx, args, extra_pip_args)
+
         # Manually construct the PYTHONPATH since we cannot use the toolchain here
         environment = _create_repository_execution_environment(rctx, python_interpreter, logger = logger)
 

--- a/python/private/pypi/whl_library.bzl
+++ b/python/private/pypi/whl_library.bzl
@@ -351,7 +351,7 @@ def _whl_library_impl(rctx):
 
     # When pipstar is enabled, Python isn't used, so there's no need
     # to setup env vars to run Python, unless we need to build an sdist
-    if enable_pipstar_extract and whl_path:
+    if enable_pipstar_extract and whl_path and not rctx.attr.patches:
         environment = {}
         args = []
         python_interpreter = None

--- a/python/private/pypi/whl_library.bzl
+++ b/python/private/pypi/whl_library.bzl
@@ -351,7 +351,7 @@ def _whl_library_impl(rctx):
 
     # When pipstar is enabled, Python isn't used, so there's no need
     # to setup env vars to run Python, unless we need to build an sdist
-    if enable_pipstar_extract and whl_path and not rctx.attr.patches:
+    if enable_pipstar_extract and whl_path and not rctx.attr.whl_patches:
         environment = {}
         args = []
         python_interpreter = None


### PR DESCRIPTION
Before the PR we would not set the environment for python
interpreter if we would not need the interpreter, but we
still resolve the python interpreter, which works on some
systems that have a minimal Python installation.

With this change we stop resolving the Python interpreter
in cases were we should not need it. To ensure that we are
not accidentally using it, `python_interpreter` is set to
None when we use `pipstar` and do not do any patching, that
still requires the Python interpreter.

Fixes #3712