### PR TITLE
fix(entry_point): ignore type lints on the generated files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ END_UNRELEASED_TEMPLATE
 ### Fixed
 * (gazelle) Fixed handling of auto-included `__init__.py` files when generating `py_binary`
   targets ([#3729](https://github.com/bazel-contrib/rules_python/issues/3729)).
+* (entry_point) From now on `mypy` type checking will be skipped on the generated
+  files ([#3126](https://github.com/bazel-contrib/rules_python/issues/3126)).
 
 {#v0-0-0-added}
 ### Added

--- a/python/private/py_console_script_gen.py
+++ b/python/private/py_console_script_gen.py
@@ -62,6 +62,7 @@ except ImportError:
     raise
 
 if __name__ == "__main__":
+    # type: ignore
     sys.exit({entry_point}())
 """
 

--- a/python/private/py_console_script_gen.py
+++ b/python/private/py_console_script_gen.py
@@ -62,8 +62,7 @@ except ImportError:
     raise
 
 if __name__ == "__main__":
-    # type: ignore
-    sys.exit({entry_point}())
+    sys.exit({entry_point}())  # type: ignore
 """
 
 

--- a/tests/entry_points/py_console_script_gen_test.py
+++ b/tests/entry_points/py_console_script_gen_test.py
@@ -162,7 +162,7 @@ class RunTest(unittest.TestCase):
             raise
 
         if __name__ == "__main__":
-            sys.exit(baz())
+            sys.exit(baz())  # type: ignore
         """
         )
         self.assertEqual(want, got)


### PR DESCRIPTION
Fixes #3126
