### PR TITLE
chore: enable platform-specific configs and silence C++ warnings in .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -61,12 +61,16 @@ build --lockfile_mode=update
 # Silence spammy C++ compile warnings
 build:linux --copt=-Wno-deprecated-declarations
 build:linux --copt=-Wno-stringop-overread
+build:linux --copt=-Wno-sign-compare
 build:linux --host_copt=-Wno-deprecated-declarations
 build:linux --host_copt=-Wno-stringop-overread
+build:linux --host_copt=-Wno-sign-compare
 build:macos --copt=-Wno-deprecated-declarations
 build:macos --copt=-Wno-stringop-overread
+build:macos --copt=-Wno-sign-compare
 build:macos --host_copt=-Wno-deprecated-declarations
 build:macos --host_copt=-Wno-stringop-overread
+build:macos --host_copt=-Wno-sign-compare
 
 import %workspace%/specialized_configs.bazelrc
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -25,7 +25,7 @@ common --incompatible_disallow_struct_provider_syntax
 # Makes Bazel 7 act more like Bazel 8
 common --incompatible_use_plus_in_repo_names
 
-# Enable platform-specific configurations
+# Implicitly adds --config=linux|macos|windows, depending on the host platform
 common --enable_platform_specific_config
 
 # Needed to make Windows with a py_binary in data deps work. The Bazel launcher

--- a/.bazelrc
+++ b/.bazelrc
@@ -61,8 +61,12 @@ build --lockfile_mode=update
 # Silence spammy C++ compile warnings
 build:linux --copt=-Wno-deprecated-declarations
 build:linux --copt=-Wno-stringop-overread
+build:linux --host_copt=-Wno-deprecated-declarations
+build:linux --host_copt=-Wno-stringop-overread
 build:macos --copt=-Wno-deprecated-declarations
 build:macos --copt=-Wno-stringop-overread
+build:macos --host_copt=-Wno-deprecated-declarations
+build:macos --host_copt=-Wno-stringop-overread
 
 import %workspace%/specialized_configs.bazelrc
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -25,6 +25,9 @@ common --incompatible_disallow_struct_provider_syntax
 # Makes Bazel 7 act more like Bazel 8
 common --incompatible_use_plus_in_repo_names
 
+# Enable platform-specific configurations
+common --enable_platform_specific_config
+
 # Needed to make Windows with a py_binary in data deps work. The Bazel launcher
 # is used, which falls back to finding python.exe on PATH to bootstrap.
 # See https://github.com/bazel-contrib/rules_python/issues/3655
@@ -54,6 +57,12 @@ common --incompatible_python_disallow_native_rules
 common --incompatible_no_implicit_file_export
 
 build --lockfile_mode=update
+
+# Silence spammy C++ compile warnings
+build:linux --copt=-Wno-deprecated-declarations
+build:linux --copt=-Wno-stringop-overread
+build:macos --copt=-Wno-deprecated-declarations
+build:macos --copt=-Wno-stringop-overread
 
 import %workspace%/specialized_configs.bazelrc
 


### PR DESCRIPTION
Silence spammy C++ compile warnings in build logs to make it easier
to identify actual issues. The warnings were primarily deprecation
notices from external dependencies (like protobuf) observed during
both target and tool compilation.

Platform-specific configurations were enabled because C++ compiler flags
(copts) differ significantly for Windows (which typically uses MSVC)
compared to Linux and macOS (which use GCC/Clang). Applying the warning-
silencing flags globally would break Windows builds. This approach
allows us to safely ignore these specific warnings only on platforms
where the flags are supported.
