### PR TITLE
tests: support whl_from_dir_repo on Windows

### DIFF
--- a/tests/implicit_namespace_packages/BUILD.bazel
+++ b/tests/implicit_namespace_packages/BUILD.bazel
@@ -1,10 +1,10 @@
 load("//python:py_test.bzl", "py_test")
-load("//tests/support:support.bzl", "SUPPORTS_BZLMOD_UNIXY")
+load("//tests/support:support.bzl", "SUPPORTS_BZLMOD")
 
 py_test(
     name = "namespace_packages_test",
     srcs = ["namespace_packages_test.py"],
-    target_compatible_with = SUPPORTS_BZLMOD_UNIXY,
+    target_compatible_with = SUPPORTS_BZLMOD,
     deps = [
         "@implicit_namespace_ns_sub1//:pkg",
         "@implicit_namespace_ns_sub2//:pkg",

--- a/tests/pypi/whl_library/BUILD.bazel
+++ b/tests/pypi/whl_library/BUILD.bazel
@@ -1,10 +1,10 @@
 load("//python:py_test.bzl", "py_test")
-load("//tests/support:support.bzl", "SUPPORTS_BZLMOD_UNIXY")
+load("//tests/support:support.bzl", "SUPPORTS_BZLMOD")
 
 py_test(
     name = "whl_library_extras_test",
     srcs = ["whl_library_extras_test.py"],
-    target_compatible_with = SUPPORTS_BZLMOD_UNIXY,
+    target_compatible_with = SUPPORTS_BZLMOD,
     deps = [
         "@whl_library_extras_direct_dep//:pkg",
     ],

--- a/tests/support/support.bzl
+++ b/tests/support/support.bzl
@@ -35,10 +35,7 @@ SUPPORTS_BOOTSTRAP_SCRIPT = select({
     "//conditions:default": [],
 })
 
-SUPPORTS_BZLMOD_UNIXY = select({
-    "@platforms//os:windows": ["@platforms//:incompatible"],
-    "//conditions:default": [],
-}) if BZLMOD_ENABLED else ["@platforms//:incompatible"]
+SUPPORTS_BZLMOD = [] if BZLMOD_ENABLED else ["@platforms//:incompatible"]
 
 NOT_WINDOWS = select({
     "@platforms//os:windows": ["@platforms//:incompatible"],

--- a/tests/support/whl_from_dir/whl_from_dir_repo.bzl
+++ b/tests/support/whl_from_dir/whl_from_dir_repo.bzl
@@ -11,20 +11,41 @@ def _whl_from_dir_repo(rctx):
     rctx.watch_tree(root)
 
     output = rctx.path(rctx.attr.output)
-    repo_utils.execute_checked(
-        rctx,
-        # cd to root so zip recursively takes everything there.
-        working_directory = str(root),
-        op = "WhlFromDir",
-        arguments = [
-            "zip",
-            "-0",  # Skip compressing
-            "-X",  # Don't store file time or metadata
-            str(output),
-            "-r",
-            ".",
-        ],
-    )
+    if repo_utils.get_platforms_os_name(rctx) == "windows":
+        powershell_exe = rctx.which("powershell.exe") or rctx.which("powershell")
+        if not powershell_exe:
+            fail("powershell not found on PATH")
+
+        zip_script = rctx.path(rctx.attr._zip_script)
+
+        repo_utils.execute_checked(
+            rctx,
+            op = "WhlFromDir",
+            arguments = [
+                powershell_exe,
+                "-NoProfile",
+                "-File",
+                str(zip_script),
+                str(output),
+                str(root),
+            ],
+            # zip.ps1 handles relativizing paths.
+        )
+    else:
+        repo_utils.execute_checked(
+            rctx,
+            # cd to root so zip recursively takes everything there.
+            working_directory = str(root),
+            op = "WhlFromDir",
+            arguments = [
+                "zip",
+                "-0",  # Skip compressing
+                "-X",  # Don't store file time or metadata
+                str(output),
+                "-r",
+                ".",
+            ],
+        )
     rctx.file("BUILD.bazel", 'exports_files(glob(["*"]))')
 
 whl_from_dir_repo = repository_rule(
@@ -45,6 +66,10 @@ https://packaging.python.org/en/latest/specifications/binary-distribution-format
 A file whose directory will be put into the output wheel. All files
 are included verbatim.
             """,
+        ),
+        "_zip_script": attr.label(
+            default = "//tests/support/whl_from_dir:zip.ps1",
+            allow_single_file = True,
         ),
     },
 )

--- a/tests/support/whl_from_dir/zip.ps1
+++ b/tests/support/whl_from_dir/zip.ps1
@@ -1,0 +1,45 @@
+param (
+    [Parameter(Position=0, Mandatory=$true)]
+    [string]$Output,
+
+    [Parameter(Position=1, Mandatory=$true)]
+    [string]$Root
+)
+
+Add-Type -AssemblyName System.IO.Compression
+
+$fixedTime = [datetime]"1980-01-01T00:00:00"
+$RootFull = (Resolve-Path $Root).Path
+
+$stream = [System.IO.File]::Open($Output, [System.IO.FileMode]::Create)
+try {
+    $archive = [System.IO.Compression.ZipArchive]::new($stream, [System.IO.Compression.ZipArchiveMode]::Create)
+    try {
+        $files = Get-ChildItem -Path $RootFull -Recurse -File
+        foreach ($file in $files) {
+            # Relativize path and normalize separators
+            $relPath = $file.FullName.Substring($RootFull.Length).TrimStart('\', '/')
+            $relPath = $relPath -replace '\\', '/'
+
+            $entry = $archive.CreateEntry($relPath, [System.IO.Compression.CompressionLevel]::NoCompression)
+            $entry.LastWriteTime = $fixedTime
+
+            $entryStream = $entry.Open()
+            try {
+                $fileStream = [System.IO.File]::OpenRead($file.FullName)
+                try {
+                    $fileStream.CopyTo($entryStream)
+                } finally {
+                    $fileStream.Dispose()
+                }
+            } finally {
+                $entryStream.Dispose()
+            }
+        }
+    } finally {
+        $archive.Dispose()
+    }
+} finally {
+    $stream.Dispose()
+}
+

--- a/tests/venv_site_packages_libs/app_files_building/app_files_building_tests.bzl
+++ b/tests/venv_site_packages_libs/app_files_building/app_files_building_tests.bzl
@@ -7,7 +7,7 @@ load("//python:py_library.bzl", "py_library")
 load("//python/private:common_labels.bzl", "labels")  # buildifier: disable=bzl-visibility
 load("//python/private:py_info.bzl", "VenvSymlinkEntry", "VenvSymlinkKind")  # buildifier: disable=bzl-visibility
 load("//python/private:venv_runfiles.bzl", "build_link_map", "get_venv_symlinks")  # buildifier: disable=bzl-visibility
-load("//tests/support:support.bzl", "SUPPORTS_BZLMOD_UNIXY")
+load("//tests/support:support.bzl", "SUPPORTS_BZLMOD")
 
 def _empty_files_impl(ctx):
     files = []
@@ -425,7 +425,7 @@ def _test_optimized_grouping_pkgutil_whls(name):
             "@pkgutil_nspkg1//:pkg",
             "@pkgutil_nspkg2//:pkg",
         ],
-        target_compatible_with = SUPPORTS_BZLMOD_UNIXY,
+        target_compatible_with = SUPPORTS_BZLMOD,
     )
     analysis_test(
         name = name,
@@ -435,7 +435,7 @@ def _test_optimized_grouping_pkgutil_whls(name):
             labels.VENVS_SITE_PACKAGES: "yes",
         },
         attr_values = dict(
-            target_compatible_with = SUPPORTS_BZLMOD_UNIXY,
+            target_compatible_with = SUPPORTS_BZLMOD,
         ),
     )
 

--- a/tests/whl_with_build_files/BUILD.bazel
+++ b/tests/whl_with_build_files/BUILD.bazel
@@ -1,9 +1,9 @@
 load("//python:py_test.bzl", "py_test")
-load("//tests/support:support.bzl", "SUPPORTS_BZLMOD_UNIXY")
+load("//tests/support:support.bzl", "SUPPORTS_BZLMOD")
 
 py_test(
     name = "verify_files_test",
     srcs = ["verify_files_test.py"],
-    target_compatible_with = SUPPORTS_BZLMOD_UNIXY,
+    target_compatible_with = SUPPORTS_BZLMOD,
     deps = ["@somepkg_with_build_files//:pkg"],
 )


### PR DESCRIPTION
tests: support whl_from_dir_repo on Windows

The `whl_from_dir_repo` repository rule previously relied on the Unix
`zip` utility to create wheels. Because this command isn't natively
available on Windows, any tests that depended on repositories generated
by this rule had to be explicitly skipped on Windows hosts.

To fix this and expand our test coverage, this adds a native Windows
fallback. When running on Windows, the rule now invokes a helper
PowerShell script that uses .NET compression APIs to create the
archive. This script ensures the resulting wheel remains uncompressed
and uses zeroed-out timestamps to match the deterministic behavior of
the original `zip -0X` command.

With this constraint removed, the Unix-only compatibility flags
(`SUPPORTS_BZLMOD_UNIXY`) have been dropped, enabling several namespace
package and wheel-related integration tests to finally run on Windows.
