### PR TITLE
fix(uv): use astral urls for uv primary source, github as secondary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,10 +71,9 @@ END_UNRELEASED_TEMPLATE
   files ([#3126](https://github.com/bazel-contrib/rules_python/issues/3126)).
 * (pypi) Support `--experimental_isolated_extension_usages`
   ([#3668](https://github.com/bazel-contrib/rules_python/issues/3668)).
-* (uv) Improve download availability: for official releases, use the astral.sh
-  mirror as the preferred url for binary downloads, with github.com as a
-  fallback; for uv >= 0.11.0, read the checksums directly from the dist-manifest
-  contents.
+* (uv) use the astral.sh mirror as the preferred url for binary downloads,
+  with github.com as a fallback; for uv >= 0.11.0, read the checksums directly
+  from the dist-manifest contents.
 
 {#v0-0-0-added}
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,10 @@ END_UNRELEASED_TEMPLATE
   files ([#3126](https://github.com/bazel-contrib/rules_python/issues/3126)).
 * (pypi) Support `--experimental_isolated_extension_usages`
   ([#3668](https://github.com/bazel-contrib/rules_python/issues/3668)).
+* (uv) Improve download availability: for official releases, use the astral.sh
+  mirror as the preferred url for binary downloads, with github.com as a
+  fallback; for uv >= 0.11.0, read the checksums directly from the dist-manifest
+  contents.
 
 {#v0-0-0-added}
 ### Added

--- a/python/uv/private/uv.bzl
+++ b/python/uv/private/uv.bzl
@@ -380,6 +380,10 @@ def _overlap(first_collection, second_collection):
 
     return False
 
+# See https://github.com/astral-sh/setup-uv/pull/809.
+GITHUB_RELEASES_PREFIX = "https://github.com/astral-sh/uv/releases/download/"
+ASTRAL_MIRROR_PREFIX = "https://releases.astral.sh/github/uv/releases/download/"
+
 def _get_tool_urls_from_dist_manifest(module_ctx, *, base_url, manifest_filename, platforms, get_auth = get_auth, **auth_attrs):
     """Download the results about remote tool sources.
 
@@ -452,6 +456,8 @@ def _get_tool_urls_from_dist_manifest(module_ctx, *, base_url, manifest_filename
                     }
                 ]
                 checksum	"uv-aarch64-apple-darwin.tar.gz.sha256"
+                checksums
+                    sha256	"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
             uv-aarch64-apple-darwin.tar.gz.sha256	
                 name	"uv-aarch64-apple-darwin.tar.gz.sha256"
                 kind	"checksum"
@@ -471,7 +477,8 @@ def _get_tool_urls_from_dist_manifest(module_ctx, *, base_url, manifest_filename
         fail(result)
     dist_manifest = json.decode(module_ctx.read(dist_manifest))
 
-    base_url = (
+    # Use the simple download_url from the manifest, when available.
+    dist_base_url = (
         dist_manifest
             .get("releases", [{}])[0]
             .get("hosting", {})
@@ -479,21 +486,46 @@ def _get_tool_urls_from_dist_manifest(module_ctx, *, base_url, manifest_filename
             .get("download_url", base_url)
     )
 
+    # For official releases, add the astral mirror to improve availability.
+    # See https://github.com/astral-sh/setup-uv/pull/809.
+    if dist_base_url.startswith(GITHUB_RELEASES_PREFIX):
+        astral_base_url = ASTRAL_MIRROR_PREFIX + dist_base_url[len(GITHUB_RELEASES_PREFIX):]
+        base_urls = [
+            astral_base_url,
+            dist_base_url,
+        ]
+    else:
+        base_urls = [dist_base_url]
+
     artifacts = dist_manifest["artifacts"]
     tool_sources = {}
     downloads = {}
     for fname, artifact in artifacts.items():
         if artifact.get("kind") != "executable-zip":
             continue
-
-        checksum = artifacts[artifact["checksum"]]
-        if not _overlap(checksum["target_triples"], platforms):
-            # we are not interested in this platform, so skip
+        target_triples = artifact["target_triples"]
+        if not _overlap(target_triples, platforms):
+            # We are not interested in this platform, so skip.
             continue
 
+        # Releases of uv >= 0.11.0 have the sha256 directly inline.
+        sha256 = artifact.get("checksums", {}).get("sha256", "")
+        if len(sha256) > 0:
+            for platform in target_triples:
+                tool_sources[platform] = struct(
+                    urls = [
+                        "{}/{}".format(base, fname)
+                        for base in base_urls
+                    ],
+                    sha256 = sha256,
+                )
+            continue
+
+        # For uv < 0.11.0, we'll need to fetch the individual sha256 files.
+        checksum = artifacts[artifact["checksum"]]
         checksum_fname = checksum["name"]
         checksum_path = module_ctx.path(checksum_fname)
-        urls = ["{}/{}".format(base_url, checksum_fname)]
+        urls = ["{}/{}".format(dist_base_url, checksum_fname)]
         downloads[checksum_path] = struct(
             download = module_ctx.download(
                 url = urls,
@@ -502,7 +534,7 @@ def _get_tool_urls_from_dist_manifest(module_ctx, *, base_url, manifest_filename
                 auth = get_auth(module_ctx, urls, ctx_attr = auth_attr),
             ),
             archive_fname = fname,
-            platforms = checksum["target_triples"],
+            platforms = target_triples,
         )
 
     for checksum_path, download in downloads.items():
@@ -522,7 +554,10 @@ def _get_tool_urls_from_dist_manifest(module_ctx, *, base_url, manifest_filename
 
         for platform in download.platforms:
             tool_sources[platform] = struct(
-                urls = ["{}/{}".format(base_url, archive_fname)],
+                urls = [
+                    "{}/{}".format(base, archive_fname)
+                    for base in base_urls
+                ],
                 sha256 = sha256,
             )
 

--- a/tests/uv/uv/uv_tests.bzl
+++ b/tests/uv/uv/uv_tests.bzl
@@ -34,6 +34,7 @@ def _uv_mock_mctx(*modules, download = None):
             x: {
                 "checksum": x + ".sha256",
                 "kind": "executable-zip",
+                "target_triples": [x],
             }
             for x in ["linux", "osx"]
         } | {
@@ -47,6 +48,7 @@ def _uv_mock_mctx(*modules, download = None):
             x: {
                 "checksum": x + ".sha256",
                 "kind": "executable-zip",
+                "target_triples": [x],
             }
             for x in ["linux", "os", "osx", "something_extra"]
         } | {


### PR DESCRIPTION
For official releases, use the astral.sh mirror as the preferred url for binary downloads, with github.com as a fallback.

For uv >= 0.11.0, read the checksums directly from the dist-manifest contents, so the only github.com SPOF is fetching the dist-manifest itself.

---

It is not infrequent for `github.com` to give a 5xx error on one of the uv sha256 downloads, leading to a failed build.  (The sha256 downloads cannot be cached by Bazel's repository cache, since we request them without a checksum.)  See https://github.com/RobotLocomotion/drake/issues/24140 for some examples, as well as https://github.com/bazelbuild/bazel-central-registry/pull/8591#issuecomment-4332125830 ([log](https://buildkite.com/bazel/bcr-presubmit/builds/33406/canvas?jid=019dd214-ce96-4eeb-b6e8-a720932ed816&tab=output)).

This change limits github as a single point of failure.