### PR TITLE
fix(toolchains): add releases.astral.sh mirror for python-build-standalone

### DIFF
--- a/python/versions.bzl
+++ b/python/versions.bzl
@@ -28,6 +28,10 @@ INSTALL_ONLY = "install_only"
 
 DEFAULT_RELEASE_BASE_URL = "https://github.com/astral-sh/python-build-standalone/releases/download"
 
+_GITHUB_PREFIX = "https://github.com/astral-sh/python-build-standalone/releases/download"
+_LEGACY_GITHUB_PREFIX = "https://github.com/indygreg/python-build-standalone/releases/download"
+_ASTRAL_PREFIX = "https://releases.astral.sh/github/python-build-standalone/releases/download"
+
 # When updating the versions and releases, run the following command to get
 # the hashes:
 #   bazel run //python/private:print_toolchains_checksums --//python/config_settings:python_version={major}.{minor}.{patch}
@@ -1435,6 +1439,14 @@ def get_release_info(platform, python_version, base_url = DEFAULT_RELEASE_BASE_U
         A tuple of (filename, url, archive strip prefix, patches, patch_strip)
     """
 
+    base_urls = [base_url]
+    if base_url == DEFAULT_RELEASE_BASE_URL or base_url.startswith(_GITHUB_PREFIX):
+        suffix = base_url[len(_GITHUB_PREFIX):]
+        base_urls.append(_ASTRAL_PREFIX + suffix)
+    elif base_url.startswith(_LEGACY_GITHUB_PREFIX):
+        suffix = base_url[len(_LEGACY_GITHUB_PREFIX):]
+        base_urls.append(_ASTRAL_PREFIX + suffix)
+
     url = tool_versions[python_version]["url"]
 
     if type(url) == type({}):
@@ -1490,7 +1502,8 @@ def get_release_info(platform, python_version, base_url = DEFAULT_RELEASE_BASE_U
         if "://" in release_filename:  # is absolute url?
             rendered_urls.append(release_filename)
         else:
-            rendered_urls.append("/".join([base_url, release_filename]))
+            for b_url in base_urls:
+                rendered_urls.append("/".join([b_url, release_filename]))
 
     if release_filename == None:
         fail("release_filename should be set by now; were any download URLs given?")

--- a/tests/get_release_info/get_release_info_tests.bzl
+++ b/tests/get_release_info/get_release_info_tests.bzl
@@ -48,6 +48,61 @@ def _test_file_url(env):
 
 _tests.append(_test_file_url)
 
+def _test_astral_mirror(env):
+    """Tests that the releases.astral.sh mirror is added as a secondary URL."""
+    tool_versions = {
+        "3.11.5": {
+            "sha256": {
+                "x86_64-unknown-linux-gnu": "fbed6f7694b2faae5d7c401a856219c945397f772eea5ca50c6eb825cbc9d1e1",
+            },
+            "strip_prefix": "python",
+            "url": "20230826/cpython-{python_version}+20230826-{platform}-{build}.tar.gz",
+        },
+    }
+
+    expected_urls = [
+        "https://github.com/astral-sh/python-build-standalone/releases/download/20230826/cpython-3.11.5+20230826-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "https://releases.astral.sh/github/python-build-standalone/releases/download/20230826/cpython-3.11.5+20230826-x86_64-unknown-linux-gnu-install_only.tar.gz",
+    ]
+
+    _, urls, _, _, _ = get_release_info(
+        platform = "x86_64-unknown-linux-gnu",
+        python_version = "3.11.5",
+        tool_versions = tool_versions,
+    )
+
+    env.expect.that_collection(urls).contains_exactly(expected_urls)
+
+_tests.append(_test_astral_mirror)
+
+def _test_astral_mirror_legacy(env):
+    """Tests that the releases.astral.sh mirror is added for legacy indygreg URLs."""
+    tool_versions = {
+        "3.11.5": {
+            "sha256": {
+                "x86_64-unknown-linux-gnu": "fbed6f7694b2faae5d7c401a856219c945397f772eea5ca50c6eb825cbc9d1e1",
+            },
+            "strip_prefix": "python",
+            "url": "20230826/cpython-{python_version}+20230826-{platform}-{build}.tar.gz",
+        },
+    }
+
+    expected_urls = [
+        "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5+20230826-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "https://releases.astral.sh/github/python-build-standalone/releases/download/20230826/cpython-3.11.5+20230826-x86_64-unknown-linux-gnu-install_only.tar.gz",
+    ]
+
+    _, urls, _, _, _ = get_release_info(
+        platform = "x86_64-unknown-linux-gnu",
+        python_version = "3.11.5",
+        base_url = "https://github.com/indygreg/python-build-standalone/releases/download",
+        tool_versions = tool_versions,
+    )
+
+    env.expect.that_collection(urls).contains_exactly(expected_urls)
+
+_tests.append(_test_astral_mirror_legacy)
+
 def get_release_info_test_suite(name):
     """Defines the test suite for get_release_info."""
     test_suite(


### PR DESCRIPTION
Currently, python-build-standalone runtimes are only downloaded from
github.com. If github.com is down or experiencing 5xx errors, builds
will fail because the runtimes cannot be fetched.

To fix this, add releases.astral.sh as a secondary fallback mirror URL.
If the requested base_url starts with the standard or legacy github.com
release prefix, we append the equivalent releases.astral.sh URL to
rendered_urls.
