### PR TITLE
fix(pip): Pass --abi flag when downloading wheel for freethreaded python

### DIFF
--- a/python/private/pypi/hub_builder.bzl
+++ b/python/private/pypi/hub_builder.bzl
@@ -510,6 +510,8 @@ def _create_whl_repos(
         extra_pip_args = pip_attr.extra_pip_args,
         get_index_urls = self._get_index_urls.get(pip_attr.python_version),
         evaluate_markers = _evaluate_markers(self, pip_attr),
+        download_only = pip_attr.download_only,
+        python_version = pip_attr.python_version,
         logger = logger,
     )
 

--- a/python/private/pypi/parse_requirements.bzl
+++ b/python/private/pypi/parse_requirements.bzl
@@ -43,6 +43,8 @@ def parse_requirements(
         get_index_urls = None,
         evaluate_markers = None,
         extract_url_srcs = True,
+        download_only = False,
+        python_version = None,
         logger):
     """Get the requirements with platforms that the requirements apply to.
 
@@ -114,7 +116,14 @@ def parse_requirements(
                 # output all of the requirement lines that have a marker
                 if ";" in requirement_line:
                     reqs_with_env_markers.setdefault(requirement_line, []).append(plat)
-            options[plat] = pip_args
+            plat_args = list(pip_args)
+            if download_only and plat.endswith("freethreaded") and python_version:
+                if not any([a.startswith("--abi") for a in plat_args]):
+                    major, _, tail = python_version.partition(".")
+                    minor, _, _ = tail.partition(".")
+                    if major and minor:
+                        plat_args.append("--abi=cp{}{}t".format(major, minor))
+            options[plat] = plat_args
 
             # Parse the index URL from the requirement files
             index_url = argparse.index_url(pip_args, index_url)


### PR DESCRIPTION
When `pip download` is used for fetching pip dependency, we need to pass `--abi` flag to fetch the correct wheel file for freethreaded python.

Essentially making https://github.com/google-ml-infra/rules_ml_toolchain/blob/1c2352bde159ee14cc5050a871c437622fe25e1f/py/python_init_pip.bzl#L69-L71 unnecessary.