### PR TITLE
feat(coverage): add Python 3.14 support and bump coverage.py to 7.10.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@ END_UNRELEASED_TEMPLATE
 * (pypi) Fix `importlib.metadata.files` by ensuring `RECORD` is included in
   installed wheel targets, except when built from sdist
   ([#3024](https://github.com/bazel-contrib/rules_python/issues/3024)).
+* (coverage) Add support for python 3.14 and bump `coverage.py` to 7.10.7.
+  Support for python 3.8 has been dropped, since coverage.py 7.6.2 dropped it.
 
 
 {#v0-0-0-added}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,8 @@ END_UNRELEASED_TEMPLATE
 
 {#v0-0-0-removed}
 ### Removed
-* Nothing removed.
+* (coverage) Support for python 3.8 has been dropped from the bundled
+  `coverage.py` wheel set, since coverage.py 7.6.2 dropped it.
 
 {#v0-0-0-changed}
 ### Changed
@@ -79,8 +80,6 @@ END_UNRELEASED_TEMPLATE
 * (pypi) Fix `importlib.metadata.files` by ensuring `RECORD` is included in
   installed wheel targets, except when built from sdist
   ([#3024](https://github.com/bazel-contrib/rules_python/issues/3024)).
-* (coverage) Add support for python 3.14 and bump `coverage.py` to 7.10.7.
-  Support for python 3.8 has been dropped, since coverage.py 7.6.2 dropped it.
 
 
 {#v0-0-0-added}
@@ -100,6 +99,7 @@ END_UNRELEASED_TEMPLATE
 * Python toolchain from [20260414] release.
 * (pypi) `package_metadata` support, fixes 
   [#2054](https://github.com/bazel-contrib/rules_python/issues/2054).
+* (coverage) Add support for python 3.14 and bump `coverage.py` to 7.10.7.
 
 [20260325]: https://github.com/astral-sh/python-build-standalone/releases/tag/20260325
 [20260414]: https://github.com/astral-sh/python-build-standalone/releases/tag/20260414

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -37,6 +37,13 @@ first in the import path. If you find yourself in this situation, then you'll
 need to manually configure coverage (see below).
 :::
 
+:::{note}
+The bundled `coverage` wheel set covers CPython 3.9 through 3.14 (with
+freethreaded variants for 3.13+). For Python versions outside that range,
+`configure_coverage_tool = True` is a silent no-op and `bazel coverage` will
+produce empty lcov data; manually configure coverage (see below) instead.
+:::
+
 ## Manually configuring coverage
 
 To manually configure coverage support, you'll need to set the

--- a/docs/devguide.md
+++ b/docs/devguide.md
@@ -105,7 +105,7 @@ integration test.
    ```
    bazel run //tools/private/update_deps:update_coverage_deps <VERSION>
    # for example:
-   # bazel run //tools/private/update_deps:update_coverage_deps 7.6.1
+   # bazel run //tools/private/update_deps:update_coverage_deps 7.10.7
    ```
 
 ## Updating tool dependencies

--- a/python/private/coverage.patch
+++ b/python/private/coverage.patch
@@ -8,10 +8,6 @@ diff --git a/coverage/__main__.py b/coverage/__main__.py
 index ce2d8db..7d7d0a0 100644
 --- a/coverage/__main__.py
 +++ b/coverage/__main__.py
-@@ -6,5 +6,6 @@
- from __future__ import annotations
-
+@@ -8,1 +8,2 @@
  import sys
 +sys.path.append(sys.path.pop(0))
- from coverage.cmdline import main
- sys.exit(main())

--- a/python/private/coverage_deps.bzl
+++ b/python/private/coverage_deps.bzl
@@ -23,118 +23,142 @@ load("//python/private:version_label.bzl", "version_label")
 _coverage_deps = {
     "cp310": {
         "aarch64-apple-darwin": (
-            "https://files.pythonhosted.org/packages/7d/73/041928e434442bd3afde5584bdc3f932fb4562b1597629f537387cec6f3d/coverage-7.6.1-cp310-cp310-macosx_11_0_arm64.whl",
-            "cf4b19715bccd7ee27b6b120e7e9dd56037b9c0681dcc1adc9ba9db3d417fa36",
+            "https://files.pythonhosted.org/packages/03/94/952d30f180b1a916c11a56f5c22d3535e943aa22430e9e3322447e520e1c/coverage-7.10.7-cp310-cp310-macosx_11_0_arm64.whl",
+            "e201e015644e207139f7e2351980feb7040e6f4b2c2978892f3e3789d1c125e5",
         ),
         "aarch64-unknown-linux-gnu": (
-            "https://files.pythonhosted.org/packages/c7/c8/6ca52b5147828e45ad0242388477fdb90df2c6cbb9a441701a12b3c71bc8/coverage-7.6.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-            "e61c0abb4c85b095a784ef23fdd4aede7a2628478e7baba7c5e3deba61070a02",
+            "https://files.pythonhosted.org/packages/60/83/5c283cff3d41285f8eab897651585db908a909c572bdc014bcfaf8a8b6ae/coverage-7.10.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl",
+            "6be8ed3039ae7f7ac5ce058c308484787c86e8437e72b30bf5e88b8ea10f3c87",
         ),
         "x86_64-apple-darwin": (
-            "https://files.pythonhosted.org/packages/7e/61/eb7ce5ed62bacf21beca4937a90fe32545c91a3c8a42a30c6616d48fc70d/coverage-7.6.1-cp310-cp310-macosx_10_9_x86_64.whl",
-            "b06079abebbc0e89e6163b8e8f0e16270124c154dc6e4a47b413dd538859af16",
+            "https://files.pythonhosted.org/packages/e5/6c/3a3f7a46888e69d18abe3ccc6fe4cb16cccb1e6a2f99698931dafca489e6/coverage-7.10.7-cp310-cp310-macosx_10_9_x86_64.whl",
+            "fc04cc7a3db33664e0c2d10eb8990ff6b3536f6842c9590ae8da4c614b9ed05a",
         ),
         "x86_64-unknown-linux-gnu": (
-            "https://files.pythonhosted.org/packages/53/23/9e2c114d0178abc42b6d8d5281f651a8e6519abfa0ef460a00a91f80879d/coverage-7.6.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-            "8f59d57baca39b32db42b83b2a7ba6f47ad9c394ec2076b084c3f029b7afca23",
+            "https://files.pythonhosted.org/packages/19/20/d0384ac06a6f908783d9b6aa6135e41b093971499ec488e47279f5b846e6/coverage-7.10.7-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl",
+            "8421e088bc051361b01c4b3a50fd39a4b9133079a2229978d9d30511fd05231b",
         ),
     },
     "cp311": {
         "aarch64-apple-darwin": (
-            "https://files.pythonhosted.org/packages/e1/0e/e52332389e057daa2e03be1fbfef25bb4d626b37d12ed42ae6281d0a274c/coverage-7.6.1-cp311-cp311-macosx_11_0_arm64.whl",
-            "ed37bd3c3b063412f7620464a9ac1314d33100329f39799255fb8d3027da50d3",
+            "https://files.pythonhosted.org/packages/54/f0/514dcf4b4e3698b9a9077f084429681bf3aad2b4a72578f89d7f643eb506/coverage-7.10.7-cp311-cp311-macosx_11_0_arm64.whl",
+            "65646bb0359386e07639c367a22cf9b5bf6304e8630b565d0626e2bdf329227a",
         ),
         "aarch64-unknown-linux-gnu": (
-            "https://files.pythonhosted.org/packages/aa/cd/766b45fb6e090f20f8927d9c7cb34237d41c73a939358bc881883fd3a40d/coverage-7.6.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-            "d85f5e9a5f8b73e2350097c3756ef7e785f55bd71205defa0bfdaf96c31616ff",
+            "https://files.pythonhosted.org/packages/a5/b6/bf054de41ec948b151ae2b79a55c107f5760979538f5fb80c195f2517718/coverage-7.10.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl",
+            "4da86b6d62a496e908ac2898243920c7992499c1712ff7c2b6d837cc69d9467e",
         ),
         "x86_64-apple-darwin": (
-            "https://files.pythonhosted.org/packages/ad/5f/67af7d60d7e8ce61a4e2ddcd1bd5fb787180c8d0ae0fbd073f903b3dd95d/coverage-7.6.1-cp311-cp311-macosx_10_9_x86_64.whl",
-            "7dea0889685db8550f839fa202744652e87c60015029ce3f60e006f8c4462c93",
+            "https://files.pythonhosted.org/packages/d2/5d/c1a17867b0456f2e9ce2d8d4708a4c3a089947d0bec9c66cdf60c9e7739f/coverage-7.10.7-cp311-cp311-macosx_10_9_x86_64.whl",
+            "a609f9c93113be646f44c2a0256d6ea375ad047005d7f57a5c15f614dc1b2f59",
         ),
         "x86_64-unknown-linux-gnu": (
-            "https://files.pythonhosted.org/packages/14/6f/8351b465febb4dbc1ca9929505202db909c5a635c6fdf33e089bbc3d7d85/coverage-7.6.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-            "0c0420b573964c760df9e9e86d1a9a622d0d27f417e1a949a8a66dd7bcee7bc6",
+            "https://files.pythonhosted.org/packages/b0/ef/bd8e719c2f7417ba03239052e099b76ea1130ac0cbb183ee1fcaa58aaff3/coverage-7.10.7-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl",
+            "35f5e3f9e455bb17831876048355dca0f758b6df22f49258cb5a91da23ef437d",
         ),
     },
     "cp312": {
         "aarch64-apple-darwin": (
-            "https://files.pythonhosted.org/packages/e1/ab/6bf00de5327ecb8db205f9ae596885417a31535eeda6e7b99463108782e1/coverage-7.6.1-cp312-cp312-macosx_11_0_arm64.whl",
-            "5621a9175cf9d0b0c84c2ef2b12e9f5f5071357c4d2ea6ca1cf01814f45d2391",
+            "https://files.pythonhosted.org/packages/37/66/593f9be12fc19fb36711f19a5371af79a718537204d16ea1d36f16bd78d2/coverage-7.10.7-cp312-cp312-macosx_11_0_arm64.whl",
+            "18afb24843cbc175687225cab1138c95d262337f5473512010e46831aa0c2973",
         ),
         "aarch64-unknown-linux-gnu": (
-            "https://files.pythonhosted.org/packages/92/8f/2ead05e735022d1a7f3a0a683ac7f737de14850395a826192f0288703472/coverage-7.6.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-            "260933720fdcd75340e7dbe9060655aff3af1f0c5d20f46b57f262ab6c86a5e8",
+            "https://files.pythonhosted.org/packages/98/2e/2dda59afd6103b342e096f246ebc5f87a3363b5412609946c120f4e7750d/coverage-7.10.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl",
+            "c41e71c9cfb854789dee6fc51e46743a6d138b1803fab6cb860af43265b42ea6",
         ),
         "x86_64-apple-darwin": (
-            "https://files.pythonhosted.org/packages/7e/d4/300fc921dff243cd518c7db3a4c614b7e4b2431b0d1145c1e274fd99bd70/coverage-7.6.1-cp312-cp312-macosx_10_9_x86_64.whl",
-            "95cae0efeb032af8458fc27d191f85d1717b1d4e49f7cb226cf526ff28179778",
+            "https://files.pythonhosted.org/packages/13/e4/eb12450f71b542a53972d19117ea5a5cea1cab3ac9e31b0b5d498df1bd5a/coverage-7.10.7-cp312-cp312-macosx_10_13_x86_64.whl",
+            "7bb3b9ddb87ef7725056572368040c32775036472d5a033679d1fa6c8dc08417",
         ),
         "x86_64-unknown-linux-gnu": (
-            "https://files.pythonhosted.org/packages/1f/0f/c890339dd605f3ebc269543247bdd43b703cce6825b5ed42ff5f2d6122c7/coverage-7.6.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-            "c44fee9975f04b33331cb8eb272827111efc8930cfd582e0320613263ca849ca",
+            "https://files.pythonhosted.org/packages/a6/90/a64aaacab3b37a17aaedd83e8000142561a29eb262cede42d94a67f7556b/coverage-7.10.7-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl",
+            "314f2c326ded3f4b09be11bc282eb2fc861184bc95748ae67b360ac962770be7",
         ),
     },
     "cp313": {
         "aarch64-apple-darwin": (
-            "https://files.pythonhosted.org/packages/b9/67/e1413d5a8591622a46dd04ff80873b04c849268831ed5c304c16433e7e30/coverage-7.6.1-cp313-cp313-macosx_11_0_arm64.whl",
-            "a6d3adcf24b624a7b778533480e32434a39ad8fa30c315208f6d3e5542aeb6e9",
+            "https://files.pythonhosted.org/packages/72/4f/732fff31c119bb73b35236dd333030f32c4bfe909f445b423e6c7594f9a2/coverage-7.10.7-cp313-cp313-macosx_11_0_arm64.whl",
+            "73ab1601f84dc804f7812dc297e93cd99381162da39c47040a827d4e8dafe63b",
         ),
         "aarch64-apple-darwin-freethreaded": (
-            "https://files.pythonhosted.org/packages/c4/ae/b5d58dff26cade02ada6ca612a76447acd69dccdbb3a478e9e088eb3d4b9/coverage-7.6.1-cp313-cp313t-macosx_11_0_arm64.whl",
-            "502753043567491d3ff6d08629270127e0c31d4184c4c8d98f92c26f65019962",
+            "https://files.pythonhosted.org/packages/11/0b/91128e099035ece15da3445d9015e4b4153a6059403452d324cbb0a575fa/coverage-7.10.7-cp313-cp313t-macosx_11_0_arm64.whl",
+            "dd5e856ebb7bfb7672b0086846db5afb4567a7b9714b8a0ebafd211ec7ce6a15",
         ),
         "aarch64-unknown-linux-gnu": (
-            "https://files.pythonhosted.org/packages/14/5b/9dec847b305e44a5634d0fb8498d135ab1d88330482b74065fcec0622224/coverage-7.6.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-            "d0c212c49b6c10e6951362f7c6df3329f04c2b1c28499563d4035d964ab8e08c",
+            "https://files.pythonhosted.org/packages/b1/20/b6ea4f69bbb52dac0aebd62157ba6a9dddbfe664f5af8122dac296c3ee15/coverage-7.10.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl",
+            "c79124f70465a150e89340de5963f936ee97097d2ef76c869708c4248c63ca49",
         ),
         "aarch64-unknown-linux-gnu-freethreaded": (
-            "https://files.pythonhosted.org/packages/b8/d7/62095e355ec0613b08dfb19206ce3033a0eedb6f4a67af5ed267a8800642/coverage-7.6.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-            "6a89ecca80709d4076b95f89f308544ec8f7b4727e8a547913a35f16717856cb",
-        ),
-        "x86_64-unknown-linux-gnu": (
-            "https://files.pythonhosted.org/packages/f7/95/d2fd31f1d638df806cae59d7daea5abf2b15b5234016a5ebb502c2f3f7ee/coverage-7.6.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-            "78b260de9790fd81e69401c2dc8b17da47c8038176a79092a89cb2b7d945d060",
-        ),
-        "x86_64-unknown-linux-gnu-freethreaded": (
-            "https://files.pythonhosted.org/packages/8b/61/a7a6a55dd266007ed3b1df7a3386a0d760d014542d72f7c2c6938483b7bd/coverage-7.6.1-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-            "13b0a73a0896988f053e4fbb7de6d93388e6dd292b0d87ee51d106f2c11b465b",
-        ),
-    },
-    "cp38": {
-        "aarch64-apple-darwin": (
-            "https://files.pythonhosted.org/packages/38/ea/cab2dc248d9f45b2b7f9f1f596a4d75a435cb364437c61b51d2eb33ceb0e/coverage-7.6.1-cp38-cp38-macosx_11_0_arm64.whl",
-            "f1adfc8ac319e1a348af294106bc6a8458a0f1633cc62a1446aebc30c5fa186a",
-        ),
-        "aarch64-unknown-linux-gnu": (
-            "https://files.pythonhosted.org/packages/ca/6f/f82f9a500c7c5722368978a5390c418d2a4d083ef955309a8748ecaa8920/coverage-7.6.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-            "a95324a9de9650a729239daea117df21f4b9868ce32e63f8b650ebe6cef5595b",
+            "https://files.pythonhosted.org/packages/f7/08/16bee2c433e60913c610ea200b276e8eeef084b0d200bdcff69920bd5828/coverage-7.10.7-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl",
+            "83082a57783239717ceb0ad584de3c69cf581b2a95ed6bf81ea66034f00401c0",
         ),
         "x86_64-apple-darwin": (
-            "https://files.pythonhosted.org/packages/81/d0/d9e3d554e38beea5a2e22178ddb16587dbcbe9a1ef3211f55733924bf7fa/coverage-7.6.1-cp38-cp38-macosx_10_9_x86_64.whl",
-            "6db04803b6c7291985a761004e9060b2bca08da6d04f26a7f2294b8623a0c1a0",
+            "https://files.pythonhosted.org/packages/9a/94/b765c1abcb613d103b64fcf10395f54d69b0ef8be6a0dd9c524384892cc7/coverage-7.10.7-cp313-cp313-macosx_10_13_x86_64.whl",
+            "981a651f543f2854abd3b5fcb3263aac581b18209be49863ba575de6edf4c14d",
+        ),
+        "x86_64-apple-darwin-freethreaded": (
+            "https://files.pythonhosted.org/packages/bb/22/e04514bf2a735d8b0add31d2b4ab636fc02370730787c576bb995390d2d5/coverage-7.10.7-cp313-cp313t-macosx_10_13_x86_64.whl",
+            "a0ec07fd264d0745ee396b666d47cef20875f4ff2375d7c4f58235886cc1ef0c",
         ),
         "x86_64-unknown-linux-gnu": (
-            "https://files.pythonhosted.org/packages/e4/6e/885bcd787d9dd674de4a7d8ec83faf729534c63d05d51d45d4fa168f7102/coverage-7.6.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-            "8929543a7192c13d177b770008bc4e8119f2e1f881d563fc6b6305d2d0ebe9de",
+            "https://files.pythonhosted.org/packages/a2/77/8c6d22bf61921a59bce5471c2f1f7ac30cd4ac50aadde72b8c48d5727902/coverage-7.10.7-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl",
+            "10b6ba00ab1132a0ce4428ff68cf50a25efd6840a42cdf4239c9b99aad83be8b",
+        ),
+        "x86_64-unknown-linux-gnu-freethreaded": (
+            "https://files.pythonhosted.org/packages/5d/22/9b8d458c2881b22df3db5bb3e7369e63d527d986decb6c11a591ba2364f7/coverage-7.10.7-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl",
+            "1ef2319dd15a0b009667301a3f84452a4dc6fddfd06b0c5c53ea472d3989fbf0",
+        ),
+    },
+    "cp314": {
+        "aarch64-apple-darwin": (
+            "https://files.pythonhosted.org/packages/f0/89/673f6514b0961d1f0e20ddc242e9342f6da21eaba3489901b565c0689f34/coverage-7.10.7-cp314-cp314-macosx_11_0_arm64.whl",
+            "212f8f2e0612778f09c55dd4872cb1f64a1f2b074393d139278ce902064d5b32",
+        ),
+        "aarch64-apple-darwin-freethreaded": (
+            "https://files.pythonhosted.org/packages/f5/6f/f58d46f33db9f2e3647b2d0764704548c184e6f5e014bef528b7f979ef84/coverage-7.10.7-cp314-cp314t-macosx_11_0_arm64.whl",
+            "9fa6e4dd51fe15d8738708a973470f67a855ca50002294852e9571cdbd9433f2",
+        ),
+        "aarch64-unknown-linux-gnu": (
+            "https://files.pythonhosted.org/packages/ff/49/07f00db9ac6478e4358165a08fb41b469a1b053212e8a00cb02f0d27a05f/coverage-7.10.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl",
+            "813922f35bd800dca9994c5971883cbc0d291128a5de6b167c7aa697fcf59360",
+        ),
+        "aarch64-unknown-linux-gnu-freethreaded": (
+            "https://files.pythonhosted.org/packages/84/fd/193a8fb132acfc0a901f72020e54be5e48021e1575bb327d8ee1097a28fd/coverage-7.10.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl",
+            "6e16e07d85ca0cf8bafe5f5d23a0b850064e8e945d5677492b06bbe6f09cc699",
+        ),
+        "x86_64-apple-darwin": (
+            "https://files.pythonhosted.org/packages/23/9c/5844ab4ca6a4dd97a1850e030a15ec7d292b5c5cb93082979225126e35dd/coverage-7.10.7-cp314-cp314-macosx_10_13_x86_64.whl",
+            "b06f260b16ead11643a5a9f955bd4b5fd76c1a4c6796aeade8520095b75de520",
+        ),
+        "x86_64-apple-darwin-freethreaded": (
+            "https://files.pythonhosted.org/packages/62/09/9a5608d319fa3eba7a2019addeacb8c746fb50872b57a724c9f79f146969/coverage-7.10.7-cp314-cp314t-macosx_10_13_x86_64.whl",
+            "a62c6ef0d50e6de320c270ff91d9dd0a05e7250cac2a800b7784bae474506e63",
+        ),
+        "x86_64-unknown-linux-gnu": (
+            "https://files.pythonhosted.org/packages/82/62/14ed6546d0207e6eda876434e3e8475a3e9adbe32110ce896c9e0c06bb9a/coverage-7.10.7-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl",
+            "bb45474711ba385c46a0bfe696c695a929ae69ac636cda8f532be9e8c93d720a",
+        ),
+        "x86_64-unknown-linux-gnu-freethreaded": (
+            "https://files.pythonhosted.org/packages/0f/48/71a8abe9c1ad7e97548835e3cc1adbf361e743e9d60310c5f75c9e7bf847/coverage-7.10.7-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl",
+            "affef7c76a9ef259187ef31599a9260330e0335a3011732c4b9effa01e1cd6e0",
         ),
     },
     "cp39": {
         "aarch64-apple-darwin": (
-            "https://files.pythonhosted.org/packages/a5/fe/137d5dca72e4a258b1bc17bb04f2e0196898fe495843402ce826a7419fe3/coverage-7.6.1-cp39-cp39-macosx_11_0_arm64.whl",
-            "547f45fa1a93154bd82050a7f3cddbc1a7a4dd2a9bf5cb7d06f4ae29fe94eaf8",
+            "https://files.pythonhosted.org/packages/52/2f/b9f9daa39b80ece0b9548bbb723381e29bc664822d9a12c2135f8922c22b/coverage-7.10.7-cp39-cp39-macosx_11_0_arm64.whl",
+            "bc91b314cef27742da486d6839b677b3f2793dfe52b51bbbb7cf736d5c29281c",
         ),
         "aarch64-unknown-linux-gnu": (
-            "https://files.pythonhosted.org/packages/78/5b/a0a796983f3201ff5485323b225d7c8b74ce30c11f456017e23d8e8d1945/coverage-7.6.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-            "645786266c8f18a931b65bfcefdbf6952dd0dea98feee39bd188607a9d307ed2",
+            "https://files.pythonhosted.org/packages/6a/92/1c1c5a9e8677ce56d42b97bdaca337b2d4d9ebe703d8c174ede52dbabd5f/coverage-7.10.7-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl",
+            "c7315339eae3b24c2d2fa1ed7d7a38654cba34a13ef19fbcb9425da46d3dc594",
         ),
         "x86_64-apple-darwin": (
-            "https://files.pythonhosted.org/packages/19/d3/d54c5aa83268779d54c86deb39c1c4566e5d45c155369ca152765f8db413/coverage-7.6.1-cp39-cp39-macosx_10_9_x86_64.whl",
-            "abd5fd0db5f4dc9289408aaf34908072f805ff7792632250dcb36dc591d24255",
+            "https://files.pythonhosted.org/packages/a3/ad/d1c25053764b4c42eb294aae92ab617d2e4f803397f9c7c8295caa77a260/coverage-7.10.7-cp39-cp39-macosx_10_9_x86_64.whl",
+            "fff7b9c3f19957020cac546c70025331113d2e61537f6e2441bc7657913de7d3",
         ),
         "x86_64-unknown-linux-gnu": (
-            "https://files.pythonhosted.org/packages/9a/6f/eef79b779a540326fee9520e5542a8b428cc3bfa8b7c8f1022c1ee4fc66c/coverage-7.6.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-            "609b06f178fe8e9f89ef676532760ec0b4deea15e9969bf754b37f7c40326dbc",
+            "https://files.pythonhosted.org/packages/b0/49/8a070782ce7e6b94ff6a0b6d7c65ba6bc3091d92a92cef4cd4eb0767965c/coverage-7.10.7-cp39-cp39-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl",
+            "2af88deffcc8a4d5974cf2d502251bc3b2db8461f0b66d80a449c33757aa9f40",
         ),
     },
 }

--- a/tools/private/update_deps/update_coverage_deps.py
+++ b/tools/private/update_deps/update_coverage_deps.py
@@ -38,14 +38,18 @@ from tools.private.update_deps.update_file import update_file
 _supported_platforms = {
     # Windows is unsupported right now
     # "win_amd64": "x86_64-pc-windows-msvc",
+    "manylinux1_x86_64": "x86_64-unknown-linux-gnu",
     "manylinux2014_x86_64": "x86_64-unknown-linux-gnu",
     "manylinux2014_aarch64": "aarch64-unknown-linux-gnu",
     "macosx_11_0_arm64": "aarch64-apple-darwin",
     "macosx_10_9_x86_64": "x86_64-apple-darwin",
+    "macosx_10_13_x86_64": "x86_64-apple-darwin",
+    ("t", "manylinux1_x86_64"): "x86_64-unknown-linux-gnu-freethreaded",
     ("t", "manylinux2014_x86_64"): "x86_64-unknown-linux-gnu-freethreaded",
     ("t", "manylinux2014_aarch64"): "aarch64-unknown-linux-gnu-freethreaded",
     ("t", "macosx_11_0_arm64"): "aarch64-apple-darwin-freethreaded",
     ("t", "macosx_10_9_x86_64"): "x86_64-apple-darwin-freethreaded",
+    ("t", "macosx_10_13_x86_64"): "x86_64-apple-darwin-freethreaded",
 }
 
 
@@ -143,7 +147,7 @@ def _parse_args() -> argparse.Namespace:
         "--py",
         nargs="+",
         type=str,
-        default=["cp38", "cp39", "cp310", "cp311", "cp312", "cp313"],
+        default=["cp39", "cp310", "cp311", "cp312", "cp313", "cp314"],
         help="Supported python versions",
     )
     parser.add_argument(


### PR DESCRIPTION
On rules_python 2.0.0, `python.toolchain(configure_coverage_tool = True)` is a silent no-op when `python_version = "3.14"`: the bundled `coverage.py` wheel set in `python/private/coverage_deps.bzl` covers cp310–cp313 only, so `bazel coverage` produces zero-byte per-test lcov files for `py_test` targets. This PR bumps the bundled coverage to 7.10.7 (which ships cp39–cp314 wheels, including freethreaded variants for cp313+) and regenerates the wheel set.

- Regenerate `coverage_deps.bzl` against coverage 7.10.7
- Add cp314 (incl. freethreaded cp314t variants) to the bundled set
- Drop cp38 from the supported set (coverage.py 7.6.2 dropped Python 3.8)
- Extend `update_coverage_deps.py`'s `_supported_platforms` map with the newer wheel platform tags (`manylinux1_x86_64`, `macosx_10_13_x86_64`) used by coverage 7.10.7
- Narrow `coverage.patch` context to apply against the 7.10.7 `coverage/__main__.py` layout
- Document the bundled coverage version range in `docs/coverage.md`

Verification:
- `bazel test //tests/python:python_tests //tests/py_runtime:py_runtime_tests --test_tag_filters=-integration-test` → 37/37 pass (incl. `test_coverage_tool_executable`, `test_coverage_tool_plain_files`)
- E2E: `local_path_override` this branch into a minimal external workspace, set `python_version = "3.14"` with `configure_coverage_tool = True`, run `bazel coverage` on a `py_test` → produces a non-empty per-test lcov with `SF:`, `FNDA:` reflecting actual call counts, and `LH:` non-zero