### PR TITLE
fix(pypi): allow index probes to fail on root path

### DIFF
--- a/python/private/pypi/simpleapi_download.bzl
+++ b/python/private/pypi/simpleapi_download.bzl
@@ -158,6 +158,7 @@ def _get_dist_urls(ctx, *, default_index, index_urls, index_url_overrides, sourc
             parse_index = True,
             versions = {pkg: None for pkg in sources},
             block = block,
+            allow_fail = True,
             **kwargs
         )
         if hasattr(download, "wait"):
@@ -170,6 +171,8 @@ def _get_dist_urls(ctx, *, default_index, index_urls, index_url_overrides, sourc
 
     found_on_index = {}
     for index_url, result in results.items():
+        if not result.success:
+            continue
         for pkg in sources:
             if pkg in found_on_index:
                 # We have already found the package, skip searching for it in


### PR DESCRIPTION
In rules_python v2.0.0, the module extension introduced a step to fetch the list of available packages from each index to create a mapping and optimize downloads. This is implemented in `python/private/pypi/simpleapi_download.bzl` in `_get_dist_urls`. It unconditionally attempts to download the root page of every index in `index_urls` (with `parse_index = True`).

If an extra index does not support root listing (e.g., it's just a file server hosting wheels and returns 404 Not Found for the root path), the build fails with an IOException.

This change passes `allow_fail = True` to `read_simpleapi` when probing indexes, and checks `result.success` before accessing `result.output`, skipping failed indexes.

Fixes #3769