### PR TITLE
docs: split toolchain bumps from #3708 into 2.0.2 and 1.9.1 changelog sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,12 +94,20 @@ END_UNRELEASED_TEMPLATE
   Fixes [#3296](https://github.com/bazel-contrib/rules_python/issues/3296).
 * (gazelle) Support alias_kind directive.
   Fixes [#3183](https://github.com/bazel-contrib/rules_python/issues/3183).
-* (toolchains) `3.13.12`, `3.14.3` Python toolchain from [20260325] release.
-* (toolchains) `3.10.20`, `3.11.15`, `3.12.13`, `3.13.13` `3.14.4`, `3.15.0a8`
-* Python toolchain from [20260414] release.
 * (pypi) `package_metadata` support, fixes 
   [#2054](https://github.com/bazel-contrib/rules_python/issues/2054).
 * (coverage) Add support for python 3.14 and bump `coverage.py` to 7.10.7.
+
+{#v2-0-2}
+## [2.0.2] - 2026-05-14
+
+[2.0.2]: https://github.com/bazel-contrib/rules_python/releases/tag/2.0.2
+
+{#v2-0-2-added}
+### Added
+* (toolchains) `3.13.12`, `3.14.3` Python toolchain from [20260325] release.
+* (toolchains) `3.10.20`, `3.11.15`, `3.12.13`, `3.13.13` `3.14.4`, `3.15.0a8`
+* Python toolchain from [20260414] release.
 
 [20260325]: https://github.com/astral-sh/python-build-standalone/releases/tag/20260325
 [20260414]: https://github.com/astral-sh/python-build-standalone/releases/tag/20260414
@@ -229,6 +237,17 @@ Other changes:
     {obj}`PyExecutableInfo.venv_interpreter_symlinks` adde
 * (wheel) Add support for `add_path_prefix` argument in `py_wheel` which can be
   used to prepend a prefix to the files in the wheel.
+
+{#v1-9-1}
+## [1.9.1] - 2026-05-14
+
+[1.9.1]: https://github.com/bazel-contrib/rules_python/releases/tag/1.9.1
+
+{#v1-9-1-added}
+### Added
+* (toolchains) `3.13.12`, `3.14.3` Python toolchain from [20260325] release.
+* (toolchains) `3.10.20`, `3.11.15`, `3.12.13`, `3.13.13` `3.14.4`, `3.15.0a8`
+* Python toolchain from [20260414] release.
 
 {#v1-9-0}
 ## [1.9.0] - 2026-02-21


### PR DESCRIPTION
Per [@aignas's comment](https://github.com/bazel-contrib/rules_python/issues/3773#issuecomment-4439327299) on #3773, moves the toolchain bullets that #3708 added under `Unreleased` into dated `2.0.2` and `1.9.1` sections so the next release from `main` doesn't re-announce them.

**Before:** Bullets sit under `Unreleased` on `main`.

**After:** New `## [2.0.2] - 2026-05-14` section between `Unreleased` and `2.0.1`, and a new `## [1.9.1] - 2026-05-14` section between `2.0.0` and `1.9.0`. Bullet text is reused verbatim.

Companion PRs:
- #3775 — backport #3708 to `release/2.0` (2.0.2)
- #3776 — backport #3708 to `release/1.9` (1.9.1)

Refs #3773.