### PR TITLE
ci: update RBE toolchain version from ubuntu2204 to ubuntu2404

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -296,7 +296,7 @@ tasks:
     <<: *minimum_supported_version
     <<: *reusable_config
     name: "RBE: Ubuntu, minimum Bazel"
-    platform: rbe_ubuntu2204
+    platform: rbe_ubuntu2404
     build_flags:
       - "--experimental_repository_cache_hardlinks=false"
       # BazelCI sets --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1,
@@ -315,7 +315,7 @@ tasks:
   rbe:
     <<: *reusable_config
     name: "RBE: Ubuntu"
-    platform: rbe_ubuntu2204
+    platform: rbe_ubuntu2404
     # TODO @aignas 2024-12-11: get the RBE working in CI for bazel 8.0
     # See https://github.com/bazelbuild/rules_python/issues/2499
     bazel: 8.x

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ bazel_dep(name = "bazel_features", version = "1.21.0")
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "package_metadata", version = "0.0.7")
 bazel_dep(name = "platforms", version = "0.0.11")
-bazel_dep(name = "rules_cc", version = "0.1.5")
+bazel_dep(name = "rules_cc", version = "0.2.17")
 
 # Those are loaded only when using py_proto_library
 # Use py_proto_library directly from protobuf repository

--- a/python/private/internal_dev_deps.bzl
+++ b/python/private/internal_dev_deps.bzl
@@ -26,7 +26,7 @@ def _internal_dev_deps_impl(mctx):
     # otherwise refer to RBE docs.
     rbe_preconfig(
         name = "buildkite_config",
-        toolchain = "ubuntu2204",
+        toolchain = "ubuntu2404",
     )
     runtime_env_repo(name = "rules_python_runtime_env_tc_info")
 


### PR DESCRIPTION
RBE has dropped support for older platform

Fixing https://buildkite.com/bazel/rules-python-python/builds/15434#019e2c2c-c708-4c20-bc05-a9a5b1215d2f