### PR TITLE
fix(system_python): Remove printing of not always present attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ END_UNRELEASED_TEMPLATE
   installed wheel targets, except when built from sdist
   ([#3024](https://github.com/bazel-contrib/rules_python/issues/3024)).
 * (system_python) Fix AttributeError exception on Debian 10 Buster
+  python installations which may not set `sys._base_executable`
   ([#3774](https://github.com/bazel-contrib/rules_python/issues/3774)).
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ END_UNRELEASED_TEMPLATE
 * (pypi) Fix `importlib.metadata.files` by ensuring `RECORD` is included in
   installed wheel targets, except when built from sdist
   ([#3024](https://github.com/bazel-contrib/rules_python/issues/3024)).
+* (system_python) Fix AttributeError exception on Debian 10 Buster
+  ([#3774](https://github.com/bazel-contrib/rules_python/issues/3774)).
 
 
 {#v0-0-0-added}

--- a/python/private/python_bootstrap_template.txt
+++ b/python/private/python_bootstrap_template.txt
@@ -568,6 +568,7 @@ def main():
   print_verbose("VENV_REL_SITE_PACKAGES:", VENV_REL_SITE_PACKAGES)
   print_verbose("WORKSPACE_NAME:", WORKSPACE_NAME )
   print_verbose("bootstrap sys.executable:", sys.executable)
+  print_verbose("bootstrap sys._base_executable:", getattr(sys, "_base_executable", "unknown"))
   print_verbose("bootstrap sys.version:", sys.version)
 
   args = sys.argv[1:]

--- a/python/private/python_bootstrap_template.txt
+++ b/python/private/python_bootstrap_template.txt
@@ -568,7 +568,6 @@ def main():
   print_verbose("VENV_REL_SITE_PACKAGES:", VENV_REL_SITE_PACKAGES)
   print_verbose("WORKSPACE_NAME:", WORKSPACE_NAME )
   print_verbose("bootstrap sys.executable:", sys.executable)
-  print_verbose("bootstrap sys._base_executable:", sys._base_executable)
   print_verbose("bootstrap sys.version:", sys.version)
 
   args = sys.argv[1:]


### PR DESCRIPTION
This attribute is not part of the Python public API and in  Debian 10 Buster (OpenJDK 11, gcc 8.3.0) it seems to not be defined.

This reverts one of the debug logging statements added in https://github.com/bazel-contrib/rules_python/pull/3667

Fixes #3774