### PR TITLE
fix(system_python): backport Debian 10 Buster bug into 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,28 @@ BEGIN_UNRELEASED_TEMPLATE
 END_UNRELEASED_TEMPLATE
 -->
 
+{#v0-0-0}
+## Unreleased
+
+[0.0.0]: https://github.com/bazel-contrib/rules_python/releases/tag/0.0.0
+
+{#v0-0-0-removed}
+### Removed
+* Nothing removed.
+
+{#v0-0-0-changed}
+### Changed
+* Nothing changed.
+
+{#v0-0-0-fixed}
+### Fixed
+* (system_python) Fix AttributeError exception on Debian 10 Buster
+  ([#3774](https://github.com/bazel-contrib/rules_python/issues/3774)).
+
+{#v0-0-0-added}
+### Added
+* Nothing added.
+
 {#v2-0-1}
 ## [2.0.1] - 2026-05-08
 

--- a/python/private/python_bootstrap_template.txt
+++ b/python/private/python_bootstrap_template.txt
@@ -541,7 +541,6 @@ def main():
   print_verbose("VENV_REL_SITE_PACKAGES:", VENV_REL_SITE_PACKAGES)
   print_verbose("WORKSPACE_NAME:", WORKSPACE_NAME )
   print_verbose("bootstrap sys.executable:", sys.executable)
-  print_verbose("bootstrap sys._base_executable:", sys._base_executable)
   print_verbose("bootstrap sys.version:", sys.version)
 
   args = sys.argv[1:]


### PR DESCRIPTION
This attribute is not part of the Python public API and in  Debian 10 Buster (OpenJDK 11, gcc 8.3.0) it seems to not be defined.

This reverts one of the debug logging statements added in https://github.com/bazel-contrib/rules_python/pull/3667

Fixes #3774
