### PR TITLE
fix(pip_compile): Forward target compatibility to *.update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,8 @@ END_UNRELEASED_TEMPLATE
   `.exe` launcher
   ([#3789](https://github.com/bazel-contrib/rules_python/issues/3789)).
 * Fix the forwarding of `target_compatible_with` from `compile_pip_requirements`
-  towards the underlying `*.update` target
+  towards the underlying `*.update` target.
+  ([#3787](https://github.com/bazel-contrib/rules_python/pull/3787))
 
 
 {#v0-0-0-added}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,8 @@ END_UNRELEASED_TEMPLATE
   path separators; the bootstrap stub is now declared as a sibling of the
   `.exe` launcher
   ([#3789](https://github.com/bazel-contrib/rules_python/issues/3789)).
+* Fix the forwarding of `target_compatible_with` from `compile_pip_requirements`
+  towards the underlying `*.update` target
 
 
 {#v0-0-0-added}

--- a/python/private/pypi/pip_compile.bzl
+++ b/python/private/pypi/pip_compile.bzl
@@ -173,6 +173,7 @@ def pip_compile(
         name = name + ".update",
         env = env,
         python_version = kwargs.get("python_version", None),
+        target_compatible_with = kwargs.get("target_compatible_with", []),
         **attrs
     )
 


### PR DESCRIPTION
With this changset we enable users to build and test `//...` in their repositories also with platforms that do not support Python.

For example, a user might use Python for tooling and automation, where he develops only on Linux. Then he could set `target_compatible_with` to `@platforms//os:linux`, but he uses C++ for his production code. Where he crosscompiles to other operating systems (e.g. QNX, TriCore).

In order to enable this, we need to forward `target_compatible_with` also to the ` also to the  also to the `*.update` target.
