### PR TITLE
fix(ci): bump rules_cc to 0.2.17 to unbreak RBE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,15 @@ END_UNRELEASED_TEMPLATE
   default to `true`.
 * (pypi) The data files of a wheel (bin, includes, etc) are now always included
   as a library's data dependencies.
+* (deps/bzlmod) Bumped the bzlmod `rules_cc` dependency from `0.1.5` to
+  `0.2.17`. This is the minimum version exposing
+  `cc/toolchains:feature_injection.bzl`, which the BazelCI-injected
+  `buildkite_config//cc/cc_toolchain_config.bzl` now loads unconditionally
+  on RBE. The WORKSPACE `http_archive` pin is left at `0.1.5` because
+  `rules_cc` 0.2.17+ requires consumers to also call
+  `compatibility_proxy_repo()` in their WORKSPACE, which would be a
+  breaking change for existing users; WORKSPACE consumers don't use RBE
+  in this repo and aren't affected by the BazelCI change.
 
 {#v0-0-0-fixed}
 ### Fixed

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ bazel_dep(name = "bazel_features", version = "1.21.0")
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "package_metadata", version = "0.0.7")
 bazel_dep(name = "platforms", version = "0.0.11")
-bazel_dep(name = "rules_cc", version = "0.1.5")
+bazel_dep(name = "rules_cc", version = "0.2.17")
 
 # Those are loaded only when using py_proto_library
 # Use py_proto_library directly from protobuf repository

--- a/tests/integration/local_toolchains/MODULE.bazel
+++ b/tests/integration/local_toolchains/MODULE.bazel
@@ -16,7 +16,7 @@ module(name = "module_under_test")
 bazel_dep(name = "rules_python", version = "0.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "platforms", version = "0.0.11")
-bazel_dep(name = "rules_cc", version = "0.1.5")
+bazel_dep(name = "rules_cc", version = "0.2.17")
 
 local_path_override(
     module_name = "rules_python",


### PR DESCRIPTION
## Why

RBE has been failing on every recent build (e.g. `main` HEAD [build 15455](https://buildkite.com/bazel/rules-python-python/builds/15455)) with:

```
cannot load '@@rules_cc+//cc/toolchains:feature_injection.bzl': no such file
```

BazelCI's injected `buildkite_config//cc/cc_toolchain_config.bzl` now loads `feature_injection.bzl` unconditionally. That file landed in `rules_cc` 0.2.17; the current pin is 0.1.5. RBE uses bzlmod (see `.bazelrc`), so the bzlmod pin is what matters.

## What changed

Bzlmod `rules_cc` pin only: `0.1.5` → `0.2.17` in `MODULE.bazel` and `tests/integration/local_toolchains/MODULE.bazel`.

WORKSPACE `http_archive` pins are intentionally left at `0.1.5`. Bumping them broke 22 jobs in the first push to this PR ([build 15462](https://buildkite.com/bazel/rules-python-python/builds/15462)) because `rules_cc` 0.2.17 requires WORKSPACE consumers to also call `compatibility_proxy_repo()` — a breaking change for downstream users. WORKSPACE jobs don't use RBE in this repo.

## Test plan

Reproduced both the original RBE break and the workspace regression in a Docker container, then verified the split-pin fix locally:
- WORKSPACE Bazel 7.4.1: `bazel build //python/...` + `examples/multi_python_versions //...` pass
- Bzlmod Bazel 9.1.0: `bazel mod graph` resolves `rules_cc@0.2.17`; `cc/toolchains/feature_injection.bzl` is present
- RBE itself can only be exercised on BazelCI

Surfaced while investigating CI on #3775/#3776 (backports for #3773).