### PR TITLE
fix(rules): allow path separators in 'main' attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,10 @@ END_UNRELEASED_TEMPLATE
 * (pypi) Fix `importlib.metadata.files` by ensuring `RECORD` is included in
   installed wheel targets, except when built from sdist
   ([#3024](https://github.com/bazel-contrib/rules_python/issues/3024)).
+* (windows) Fix `py_test`/`py_binary` failure when the target name contains
+  path separators; the bootstrap stub is now declared as a sibling of the
+  `.exe` launcher
+  ([#3789](https://github.com/bazel-contrib/rules_python/issues/3789)).
 
 
 {#v0-0-0-added}

--- a/python/private/py_executable.bzl
+++ b/python/private/py_executable.bzl
@@ -424,7 +424,7 @@ WARNING: Target: {}
 
         # On Windows, the main executable has an "exe" extension, so
         # here we re-use the un-extensioned name for the bootstrap output.
-        bootstrap_output = ctx.actions.declare_file(base_executable_name)
+        bootstrap_output = ctx.actions.declare_file(base_executable_name, sibling = executable)
 
         # The launcher looks for the non-zip executable next to
         # itself, so add it to the default outputs.

--- a/tests/base_rules/py_executable_base_tests.bzl
+++ b/tests/base_rules/py_executable_base_tests.bzl
@@ -65,35 +65,6 @@ def _test_basic_windows_impl(env, target):
 
 _tests.append(_test_basic_windows)
 
-def _test_windows_target_with_path_separators(name, config):
-    rt_util.helper_target(
-        config.rule,
-        name = name + "/nested_subject",
-        srcs = ["main.py"],
-        main = "main.py",
-    )
-    analysis_test(
-        name = name,
-        impl = _test_windows_target_with_path_separators_impl,
-        target = name + "/nested_subject",
-        config_settings = {
-            "//command_line_option:cpu": "windows_x86_64",
-            "//command_line_option:crosstool_top": CROSSTOOL_TOP,
-            "//command_line_option:extra_execution_platforms": [platform_targets.WINDOWS_X86_64],
-            "//command_line_option:extra_toolchains": [CC_TOOLCHAIN],
-            "//command_line_option:platforms": [platform_targets.WINDOWS_X86_64],
-        },
-        attr_values = {},
-    )
-
-def _test_windows_target_with_path_separators_impl(env, target):
-    target = env.expect.that_target(target)
-    target.runfiles().contains_predicate(matching.str_endswith(
-        target.meta.format_str("/{name}"),
-    ))
-
-_tests.append(_test_windows_target_with_path_separators)
-
 def _test_basic_zip(name, config):
     target_compatible_with = select({
         # Disable the new test on windows because we have _test_basic_windows.
@@ -524,6 +495,35 @@ def _test_py_runtime_info_provided_impl(env, target):
         env.expect.that_target(target).has_provider(BuiltinPyRuntimeInfo)
 
 _tests.append(_test_py_runtime_info_provided)
+
+def _test_windows_target_with_path_separators(name, config):
+    rt_util.helper_target(
+        config.rule,
+        name = name + "/nested_subject",
+        srcs = ["main.py"],
+        main = "main.py",
+    )
+    analysis_test(
+        name = name,
+        impl = _test_windows_target_with_path_separators_impl,
+        target = name + "/nested_subject",
+        config_settings = {
+            "//command_line_option:cpu": "windows_x86_64",
+            "//command_line_option:crosstool_top": CROSSTOOL_TOP,
+            "//command_line_option:extra_execution_platforms": [platform_targets.WINDOWS_X86_64],
+            "//command_line_option:extra_toolchains": [CC_TOOLCHAIN],
+            "//command_line_option:platforms": [platform_targets.WINDOWS_X86_64],
+        },
+        attr_values = {},
+    )
+
+def _test_windows_target_with_path_separators_impl(env, target):
+    target = env.expect.that_target(target)
+    target.runfiles().contains_predicate(matching.str_endswith(
+        target.meta.format_str("/{name}"),
+    ))
+
+_tests.append(_test_windows_target_with_path_separators)
 
 # =====
 # You were gonna add a test at the end, weren't you?

--- a/tests/base_rules/py_executable_base_tests.bzl
+++ b/tests/base_rules/py_executable_base_tests.bzl
@@ -65,6 +65,35 @@ def _test_basic_windows_impl(env, target):
 
 _tests.append(_test_basic_windows)
 
+def _test_windows_target_with_path_separators(name, config):
+    rt_util.helper_target(
+        config.rule,
+        name = name + "/nested_subject",
+        srcs = ["main.py"],
+        main = "main.py",
+    )
+    analysis_test(
+        name = name,
+        impl = _test_windows_target_with_path_separators_impl,
+        target = name + "/nested_subject",
+        config_settings = {
+            "//command_line_option:cpu": "windows_x86_64",
+            "//command_line_option:crosstool_top": CROSSTOOL_TOP,
+            "//command_line_option:extra_execution_platforms": [platform_targets.WINDOWS_X86_64],
+            "//command_line_option:extra_toolchains": [CC_TOOLCHAIN],
+            "//command_line_option:platforms": [platform_targets.WINDOWS_X86_64],
+        },
+        attr_values = {},
+    )
+
+def _test_windows_target_with_path_separators_impl(env, target):
+    target = env.expect.that_target(target)
+    target.runfiles().contains_predicate(matching.str_endswith(
+        target.meta.format_str("/{name}"),
+    ))
+
+_tests.append(_test_windows_target_with_path_separators)
+
 def _test_basic_zip(name, config):
     target_compatible_with = select({
         # Disable the new test on windows because we have _test_basic_windows.


### PR DESCRIPTION
Before we would fail when there are target separators present
in the value of the `main` attribute. This PR adds a test and
fixes this by declaring the bootstrap output as a sibling of
the executable.

Fixes #3789