### PR TITLE
chore: use direct @dev_pip targets instead of requirement()

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("@dev_pip//:requirements.bzl", "requirement")
 load("@sphinxdocs//sphinxdocs:readthedocs.bzl", "readthedocs_install")
 load("@sphinxdocs//sphinxdocs:sphinx.bzl", "sphinx_build_binary", "sphinx_docs")
 load("@sphinxdocs//sphinxdocs:sphinx_docs_library.bzl", "sphinx_docs_library")
@@ -175,13 +174,13 @@ sphinx_build_binary(
     },
     target_compatible_with = _TARGET_COMPATIBLE_WITH,
     deps = [
-        requirement("sphinx"),
-        requirement("sphinx_rtd_theme"),
-        requirement("myst_parser"),
-        requirement("readthedocs_sphinx_ext"),
-        requirement("typing_extensions"),
-        requirement("sphinx_autodoc2"),
-        requirement("sphinx_reredirects"),
+        "@dev_pip//myst_parser",
+        "@dev_pip//readthedocs_sphinx_ext",
+        "@dev_pip//sphinx",
+        "@dev_pip//sphinx_autodoc2",
+        "@dev_pip//sphinx_reredirects",
+        "@dev_pip//sphinx_rtd_theme",
+        "@dev_pip//typing_extensions",
         "@sphinxdocs//sphinxdocs/src/sphinx_bzl",
     ],
 )


### PR DESCRIPTION
Use @dev_pip//<pkg> format instead of the requirement() macro. This aligns with modern bzlmod patterns and simplifies the BUILD file.
