### PR TITLE
fix(build-data): remove CONFIG_MODE from build data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ END_UNRELEASED_TEMPLATE
 
 {#v0-0-0-removed}
 ### Removed
+* (build_data) Removed CONFIG_MODE from build data
+  ([#3793](https://github.com/bazel-contrib/rules_python/issues/3793)).
 * (coverage) Support for python 3.8 has been dropped from the bundled
   `coverage.py` wheel set, since coverage.py 7.6.2 dropped it.
 

--- a/python/private/build_data_writer.ps1
+++ b/python/private/build_data_writer.ps1
@@ -1,7 +1,6 @@
 $OutputPath = $env:OUTPUT
 $Lines = @(
     "TARGET $env:TARGET",
-    "CONFIG_MODE $env:CONFIG_MODE",
     "STAMPED $env:STAMPED"
 )
 

--- a/python/private/build_data_writer.sh
+++ b/python/private/build_data_writer.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 echo "TARGET $TARGET" >> $OUTPUT
-echo "CONFIG_MODE $CONFIG_MODE" >> $OUTPUT
 echo "STAMPED $STAMPED" >> $OUTPUT
 if [ -n "$VERSION_FILE" ]; then
   cat "$VERSION_FILE" >> "$OUTPUT"

--- a/python/private/py_executable.bzl
+++ b/python/private/py_executable.bzl
@@ -1578,9 +1578,6 @@ def _write_build_data(ctx):
         executable = action_exe,
         arguments = [action_args],
         env = {
-            # Include config mode so that binaries can detect if they're
-            # being used as a build tool or not, allowing for runtime optimizations.
-            "CONFIG_MODE": "EXEC" if _is_tool_config(ctx) else "TARGET",
             "INFO_FILE": info_file.path if info_file else "",
             "OUTPUT": build_data.path,
             # Include this so it's explicit, otherwise, one has to detect

--- a/tests/build_data/build_data_test.py
+++ b/tests/build_data/build_data_test.py
@@ -15,7 +15,6 @@ class BuildDataTest(unittest.TestCase):
         self.assertIn("BUILD_USER ", build_data)
         self.assertIn("BUILD_TIMESTAMP ", build_data)
         self.assertIn("FORMATTED_DATE ", build_data)
-        self.assertIn("CONFIG_MODE TARGET", build_data)
         self.assertIn("STAMPED TRUE", build_data)
 
     def test_tool_build_data(self):
@@ -25,7 +24,6 @@ class BuildDataTest(unittest.TestCase):
             build_data = fp.read()
 
         self.assertIn("STAMPED FALSE", build_data)
-        self.assertIn("CONFIG_MODE EXEC", build_data)
 
 
 unittest.main()


### PR DESCRIPTION
CONFIG_MODE was included in the build data but it is not actively used
and can cause issues with reproducibility. Removing it simplifies the
build data and improves reproducibility.

Closes #3793
