### PR TITLE
chore: tell agents to not amend or rebase PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ ALWAYS FOLLOW THESE RULES. NEVER VIOLATE THEM.
 Ask for user input and provide a justificaiton if trying to violate them.
 
 * NEVER run `bazel clean --expunge`.
+* Once a PR is created, do not amend or rebase.
 
 ## Style and conventions
 


### PR DESCRIPTION
Amending or rebasing open pull requests complicates the review process by
obscuring change history and making it difficult to track incremental updates.

This change adds an explicit rule to `AGENTS.md` under the "RULES TO ALWAYS
FOLLOW AND NEVER IGNORE" section, instructing agents to avoid amending or
rebasing once a pull request has been created.
