### PR TITLE
build: release 2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,12 +47,12 @@ BEGIN_UNRELEASED_TEMPLATE
 END_UNRELEASED_TEMPLATE
 -->
 
-{#v0-0-0}
-## Unreleased
+{#v2-0-3}
+## [2.0.3] - 2026-06-15
 
-[0.0.0]: https://github.com/bazel-contrib/rules_python/releases/tag/0.0.0
+[2.0.3]: https://github.com/bazel-contrib/rules_python/releases/tag/2.0.3
 
-{#v0-0-0-fixed}
+{#v2-0-3-fixed}
 ### Fixed
 * (pypi) Assume that all of the packages are available on a particular hub if
   there is only a single PyPI compatible index to be used. This saves us an expensive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,19 @@ BEGIN_UNRELEASED_TEMPLATE
 END_UNRELEASED_TEMPLATE
 -->
 
+{#v0-0-0}
+## Unreleased
+
+[0.0.0]: https://github.com/bazel-contrib/rules_python/releases/tag/0.0.0
+
+{#v0-0-0-fixed}
+### Fixed
+* (pypi) Assume that all of the packages are available on a particular hub if
+  there is only a single PyPI compatible index to be used. This saves us an expensive
+  PyPI download and supports PyPI mirror implementations that do not support the root
+  index functionality. Fixes
+  ([#3769](https://github.com/bazel-contrib/rules_python/pull/3769)).
+
 {#v2-0-2}
 ## [2.0.2] - 2026-05-14
 

--- a/python/private/pypi/simpleapi_download.bzl
+++ b/python/private/pypi/simpleapi_download.bzl
@@ -131,9 +131,15 @@ def simpleapi_download(
     return contents
 
 def _get_dist_urls(ctx, *, default_index, index_urls, index_url_overrides, sources, read_simpleapi, attr, block, _fail = fail, **kwargs):
-    if index_url_overrides:
+    # Ensure the value is not frozen
+    index_urls = [] + (index_urls or [])
+    if default_index not in index_urls:
+        index_urls.append(default_index)
+
+    index_url_overrides = index_url_overrides or {}
+    if index_url_overrides or len(index_urls) == 1:
         # Let's not call the index at all and just assume that all of the overrides have been
-        # specified.
+        # specified or there is only a single index and there is no need to download anything
         return {
             pkg: _normalize_url("{}/{}/".format(
                 index_url_overrides.get(pkg, default_index),
@@ -144,11 +150,6 @@ def _get_dist_urls(ctx, *, default_index, index_urls, index_url_overrides, sourc
 
     downloads = {}
     results = {}
-
-    # Ensure the value is not frozen
-    index_urls = [] + (index_urls or [])
-    if default_index not in index_urls:
-        index_urls.append(default_index)
 
     for index_url in index_urls:
         download = read_simpleapi(

--- a/tests/integration/bzlmod_lockfile/MODULE.bazel.lock
+++ b/tests/integration/bzlmod_lockfile/MODULE.bazel.lock
@@ -107,7 +107,6 @@
     "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
     "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
     "https://bcr.bazel.build/modules/rules_cc/0.1.2/MODULE.bazel": "557ddc3a96858ec0d465a87c0a931054d7dcfd6583af2c7ed3baf494407fd8d0",
-    "https://bcr.bazel.build/modules/rules_cc/0.1.5/MODULE.bazel": "88dfc9361e8b5ae1008ac38f7cdfd45ad738e4fa676a3ad67d19204f045a1fd8",
     "https://bcr.bazel.build/modules/rules_cc/0.2.0/MODULE.bazel": "b5c17f90458caae90d2ccd114c81970062946f49f355610ed89bebf954f5783c",
     "https://bcr.bazel.build/modules/rules_cc/0.2.13/MODULE.bazel": "eecdd666eda6be16a8d9dc15e44b5c75133405e820f620a234acc4b1fdc5aa37",
     "https://bcr.bazel.build/modules/rules_cc/0.2.17/MODULE.bazel": "1849602c86cb60da8613d2de887f9566a6d354a6df6d7009f9d04a14402f9a84",
@@ -640,42 +639,7 @@
           }
         }
       },
-      "fact_version": "v1",
-      "index_urls": {
-        "https://pypi.org/simple/": {
-          "backports_tarfile": "/simple/backports-tarfile/",
-          "certifi": "/simple/certifi/",
-          "cffi": "/simple/cffi/",
-          "charset_normalizer": "/simple/charset-normalizer/",
-          "cryptography": "/simple/cryptography/",
-          "docutils": "/simple/docutils/",
-          "idna": "/simple/idna/",
-          "importlib_metadata": "/simple/importlib-metadata/",
-          "jaraco_classes": "/simple/jaraco-classes/",
-          "jaraco_context": "/simple/jaraco-context/",
-          "jaraco_functools": "/simple/jaraco-functools/",
-          "jeepney": "/simple/jeepney/",
-          "keyring": "/simple/keyring/",
-          "markdown_it_py": "/simple/markdown-it-py/",
-          "mdurl": "/simple/mdurl/",
-          "more_itertools": "/simple/more-itertools/",
-          "nh3": "/simple/nh3/",
-          "pkginfo": "/simple/pkginfo/",
-          "pycparser": "/simple/pycparser/",
-          "pygments": "/simple/pygments/",
-          "pywin32_ctypes": "/simple/pywin32-ctypes/",
-          "readme_renderer": "/simple/readme-renderer/",
-          "requests": "/simple/requests/",
-          "requests_toolbelt": "/simple/requests-toolbelt/",
-          "rfc3986": "/simple/rfc3986/",
-          "rich": "/simple/rich/",
-          "secretstorage": "/simple/secretstorage/",
-          "six": "/simple/six/",
-          "twine": "/simple/twine/",
-          "urllib3": "/simple/urllib3/",
-          "zipp": "/simple/zipp/"
-        }
-      }
+      "fact_version": "v1"
     }
   }
 }

--- a/tests/pypi/simpleapi_download/simpleapi_download_tests.bzl
+++ b/tests/pypi/simpleapi_download/simpleapi_download_tests.bzl
@@ -174,12 +174,6 @@ _tests.append(_test_index_overrides)
 def _test_download_url(env):
     downloads = {}
     reads = [
-        # The first read is the index which seeds the downloads later
-        """
-        <a href="/main/simple/bar/">bar</a>
-        <a href="/main/simple/baz/">baz</a>
-        <a href="/main/simple/foo/">foo</a>
-        """,
         "",
         "",
         "",
@@ -213,7 +207,6 @@ def _test_download_url(env):
     )
 
     env.expect.that_dict(downloads).contains_exactly({
-        "https://example.com/main/simple/": "path/for/https___example_com_main_simple.html",
         "https://example.com/main/simple/bar/": "path/for/https___example_com_main_simple_bar.html",
         "https://example.com/main/simple/baz/": "path/for/https___example_com_main_simple_baz.html",
         "https://example.com/main/simple/foo/": "path/for/https___example_com_main_simple_foo.html",
@@ -321,12 +314,6 @@ _tests.append(_test_download_url_parallel_with_overrides)
 def _test_download_envsubst_url(env):
     downloads = {}
     reads = [
-        # The first read is the index which seeds the downloads later
-        """
-        <a href="/main/simple/bar/">bar</a>
-        <a href="/main/simple/baz/">baz</a>
-        <a href="/main/simple/foo/">foo</a>
-        """,
         "",
         "",
         "",
@@ -360,7 +347,6 @@ def _test_download_envsubst_url(env):
     )
 
     env.expect.that_dict(downloads).contains_exactly({
-        "https://example.com/main/simple/": "path/for/~index_url~.html",
         "https://example.com/main/simple/bar/": "path/for/~index_url~_bar.html",
         "https://example.com/main/simple/baz/": "path/for/~index_url~_baz.html",
         "https://example.com/main/simple/foo/": "path/for/~index_url~_foo.html",


### PR DESCRIPTION
This PR cherry-picks #3799 into the `release/2.0` branch with the associated Changelog.
With this change `rules_python` will no longer query the root index to determine which
packages should come from which index if there is only one index used.

Included changes:
* `10e1f7c9`: `fix(pypi): do not fail on indexes without root index (#3799)`
* `CHANGELOG.md` updates for version `2.0.3` (#3820).

Fixes #3769
Work towards #3806