### PR TITLE
docs: update changelog for 2.0.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,8 +144,7 @@ END_UNRELEASED_TEMPLATE
 * (pypi) Assume that all of the packages are available on a particular hub if
   there is only a single PyPI compatible index to be used. This saves us an expensive
   PyPI download and supports PyPI mirror implementations that do not support the root
-  index functionality. Fixes
-  ([#3769](https://github.com/bazel-contrib/rules_python/pull/3769)).
+  index functionality. Fixes [#3769](https://github.com/bazel-contrib/rules_python/pull/3769).
 
 {#v2-0-2}
 ## [2.0.2] - 2026-05-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,11 +106,6 @@ END_UNRELEASED_TEMPLATE
 * Fix the forwarding of `target_compatible_with` from `compile_pip_requirements`
   towards the underlying `*.update` target.
   ([#3787](https://github.com/bazel-contrib/rules_python/pull/3787))
-* (pypi) Assume that all of the packages are available on a particular hub if
-  there is only a single PyPI compatible index to be used. This saves us an expensive
-  PyPI download and supports PyPI mirror implementations that do not support the root
-  index functionality. Fixes
-  ([#3769](https://github.com/bazel-contrib/rules_python/pull/3769)).
 * (uv) allow user overwrite the build environment using `--action_env` to allow
   setting authentication for the index URL.
   ([#3405](https://github.com/bazel-contrib/rules_python/issues/3405))
@@ -138,6 +133,19 @@ END_UNRELEASED_TEMPLATE
 * (pypi) `package_metadata` support, fixes 
   [#2054](https://github.com/bazel-contrib/rules_python/issues/2054).
 * (coverage) Add support for python 3.14 and bump `coverage.py` to 7.10.7.
+
+{#v2-0-3}
+## [2.0.3] - 2026-06-15
+
+[2.0.3]: https://github.com/bazel-contrib/rules_python/releases/tag/2.0.3
+
+{#v2-0-3-fixed}
+### Fixed
+* (pypi) Assume that all of the packages are available on a particular hub if
+  there is only a single PyPI compatible index to be used. This saves us an expensive
+  PyPI download and supports PyPI mirror implementations that do not support the root
+  index functionality. Fixes
+  ([#3769](https://github.com/bazel-contrib/rules_python/pull/3769)).
 
 {#v2-0-2}
 ## [2.0.2] - 2026-05-14


### PR DESCRIPTION
This PR updates the changelog on `main` to document the
`2.0.3` release and moves the cherry-picked fix out of the
`Unreleased` section.

Companion to the release PR #3819 on the `release/2.0` branch.