### PR TITLE
fix(coverage): skip lcov report when no data was collected

### DIFF
--- a/news/3832.fixed.md
+++ b/news/3832.fixed.md
@@ -1,0 +1,1 @@
+(coverage) Skip lcov report when no data was collected.

--- a/python/private/stage2_bootstrap_template.py
+++ b/python/private/stage2_bootstrap_template.py
@@ -357,6 +357,7 @@ def _maybe_collect_coverage(enable):
     print_verbose_coverage("Sources:\n" + "\n".join(unique_dirs))
 
     import coverage
+    from coverage.exceptions import NoDataError
 
     coverage_dir = os.environ["COVERAGE_DIR"]
     unique_id = uuid.uuid4()
@@ -416,7 +417,7 @@ source =
                     # they were transient code-under-test in /tmp
                     ignore_errors=True,
                 )
-            except coverage.exceptions.NoDataError:
+            except NoDataError:
                 # coverage.py raises NoDataError instead of writing a report when
                 # no instrumented Python code was executed. This is common and
                 # benign, e.g. a binary that only spawns another process, or a

--- a/python/private/stage2_bootstrap_template.py
+++ b/python/private/stage2_bootstrap_template.py
@@ -408,15 +408,28 @@ source =
             cov.stop()
             lcov_path = os.path.join(coverage_dir, "pylcov_{}.dat".format(unique_id))
             print_verbose_coverage("generating lcov from:", lcov_path)
-            cov.lcov_report(
-                outfile=lcov_path,
-                # Ignore errors because sometimes instrumented files aren't
-                # readable afterwards. e.g. if they come from /dev/fd or if
-                # they were transient code-under-test in /tmp
-                ignore_errors=True,
-            )
-            if os.path.isfile(lcov_path):
-                unresolve_symlinks(lcov_path)
+            try:
+                cov.lcov_report(
+                    outfile=lcov_path,
+                    # Ignore errors because sometimes instrumented files aren't
+                    # readable afterwards. e.g. if they come from /dev/fd or if
+                    # they were transient code-under-test in /tmp
+                    ignore_errors=True,
+                )
+            except coverage.exceptions.NoDataError:
+                # coverage.py raises NoDataError instead of writing a report when
+                # no instrumented Python code was executed. This is common and
+                # benign, e.g. a binary that only spawns another process, or a
+                # test whose instrumented sources happen not to run any Python.
+                # Letting the error propagate would fail an otherwise passing
+                # test, so skip writing the (empty) report instead.
+                # See https://github.com/bazel-contrib/rules_python/issues/2762.
+                print_verbose_coverage(
+                    "no coverage data collected; skipping lcov report:", lcov_path
+                )
+            else:
+                if os.path.isfile(lcov_path):
+                    unresolve_symlinks(lcov_path)
     finally:
         try:
             os.unlink(rcfile_name)

--- a/python/private/stage2_bootstrap_template.py
+++ b/python/private/stage2_bootstrap_template.py
@@ -418,12 +418,9 @@ source =
                     ignore_errors=True,
                 )
             except NoDataError:
-                # coverage.py raises NoDataError instead of writing a report when
-                # no instrumented Python code was executed. This is common and
-                # benign, e.g. a binary that only spawns another process, or a
-                # test whose instrumented sources happen not to run any Python.
-                # Letting the error propagate would fail an otherwise passing
-                # test, so skip writing the (empty) report instead.
+                # coverage.py raises NoDataError if no instrumented Python code ran
+                # (e.g. tests not running Python, or subprocess-only binaries).
+                # Skip the report to avoid failing otherwise passing tests.
                 # See https://github.com/bazel-contrib/rules_python/issues/2762.
                 print_verbose_coverage(
                     "no coverage data collected; skipping lcov report:", lcov_path


### PR DESCRIPTION
Under `bazel coverage`, coverage.py raises `NoDataError` from `lcov_report()`
when no instrumented Python code was executed, instead of writing an (empty)
report. This error currently propagates out of the coverage bootstrap and fails
an otherwise passing test.

This is common and benign in a few setups:

- a `py_binary` that only spawns another process and runs no Python itself
- a test whose instrumented sources happen not to execute any Python

**Before:** `bazel coverage //a:test` fails with `coverage.exceptions.NoDataError`
even though `bazel test //a:test` passes.

**After:** the `NoDataError` is caught and the empty report is skipped, so the
test result is unchanged by whether coverage data happened to be collected.

This mirrors the reporter's suggestion in #2762 to "ignore the return code of
`coverage lcov`", applied in-process. As noted on the original report and in
#3823, there is no in-repo harness for exercising real coverage collection, so
this change does not add an automated test.

Fixes #2762
