### PR TITLE
fix: run bazel-diff in cquery mode under bazelci

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -27,6 +27,7 @@ buildifier:
 .reusable_config: &reusable_config
   environment:
     USE_BAZEL_DIFF: "1"
+    EXP_USE_CQUERY: "true"
   build_targets:
     - "--"
     - "..."

--- a/tests/uv/lock/pyproject_toml/BUILD.bazel
+++ b/tests/uv/lock/pyproject_toml/BUILD.bazel
@@ -27,4 +27,5 @@ diff_test(
     timeout = "short",
     file1 = ":requirements",
     file2 = "requirements.txt",
+    visibility = ["//tests/uv/lock:__pkg__"],
 )


### PR DESCRIPTION
This PR fixes the CI breakage on main where bazel-diff ran in plain query
 mode, ignoring target_compatible_with and attempting to run
platform-incompatible tests.

BazelCI has an `EXP_USE_CQUERY` env variable that uses cquery to identify
targets instead. Try that, which should respect TCW and filter out
targets that would be passed to bazel-diff.