### PR TITLE
fix(rules): disambiguate slash target venv outputs

### DIFF
--- a/news/slash-target-venv-output.fixed.md
+++ b/news/slash-target-venv-output.fixed.md
@@ -1,0 +1,3 @@
+(rules) Fixed venv output paths for `py_binary` and `py_test` targets whose
+names contain path separators so distinct targets with the same basename no
+longer share the same venv output directory.

--- a/python/private/py_executable.bzl
+++ b/python/private/py_executable.bzl
@@ -306,6 +306,9 @@ def _create_executable(
     else:
         base_executable_name = executable.basename
 
+    # Venv outputs are package-relative, so targets like foo/tool and bar/tool
+    # need the full label name to avoid both declaring _tool.venv.
+    venv_output_prefix = ctx.label.name.replace("/", "_")
     venv = None
 
     # The check for stage2_bootstrap_template is to support legacy
@@ -318,7 +321,7 @@ def _create_executable(
     ):
         venv = _create_venv(
             ctx,
-            output_prefix = base_executable_name,
+            output_prefix = venv_output_prefix,
             imports = imports,
             runtime_details = runtime_details,
             add_runfiles_root_to_sys_path = (

--- a/python/private/py_executable.bzl
+++ b/python/private/py_executable.bzl
@@ -306,9 +306,9 @@ def _create_executable(
     else:
         base_executable_name = executable.basename
 
-    # Venv outputs are package-relative, so targets like foo/tool and bar/tool
-    # need the full label name to avoid both declaring _tool.venv.
-    venv_output_prefix = ctx.label.name.replace("/", "_")
+    # Venv outputs are package-relative, so preserve the full target name to
+    # avoid collisions between targets like foo/tool, bar/tool, and foo_tool.
+    venv_output_prefix = ctx.label.name
     venv = None
 
     # The check for stage2_bootstrap_template is to support legacy

--- a/tests/base_rules/py_executable_base_tests.bzl
+++ b/tests/base_rules/py_executable_base_tests.bzl
@@ -519,6 +519,36 @@ def _test_py_runtime_info_provided_impl(env, target):
 
 _tests.append(_test_py_runtime_info_provided)
 
+def _test_venv_output_prefix_with_path_separators(name, config):
+    rt_util.helper_target(
+        config.rule,
+        name = name + "/foo/tool",
+        srcs = ["main.py"],
+        main = "main.py",
+    )
+    rt_util.helper_target(
+        config.rule,
+        name = name + "/bar/tool",
+        srcs = ["main.py"],
+        main = "main.py",
+    )
+    analysis_test(
+        name = name,
+        impl = _test_venv_output_prefix_with_path_separators_impl,
+        targets = {
+            "bar": name + "/bar/tool",
+            "foo": name + "/foo/tool",
+        },
+    )
+
+def _test_venv_output_prefix_with_path_separators_impl(env, targets):
+    for target in [targets.foo, targets.bar]:
+        target = env.expect.that_target(target)
+        venv_name = "_{}.venv/pyvenv.cfg".format(target.meta.format_str("{name}").replace("/", "_"))
+        target.runfiles().contains_predicate(matching.str_endswith(venv_name))
+
+_tests.append(_test_venv_output_prefix_with_path_separators)
+
 def _test_windows_target_with_path_separators(name, config):
     rt_util.helper_target(
         config.rule,

--- a/tests/base_rules/py_executable_base_tests.bzl
+++ b/tests/base_rules/py_executable_base_tests.bzl
@@ -551,8 +551,10 @@ def _test_venv_output_prefix_with_path_separators(name, config):
 def _test_venv_output_prefix_with_path_separators_impl(env, targets):
     for target in [targets.foo, targets.bar, targets.foo_underscore]:
         target = env.expect.that_target(target)
-        venv_name = "_{}.venv/pyvenv.cfg".format(target.meta.format_str("{name}"))
-        target.runfiles().contains_predicate(matching.str_endswith(venv_name))
+        venv_file = "*/_{}.venv/*site-packages/bazel.pth".format(
+            target.meta.format_str("{name}"),
+        )
+        target.runfiles().contains_predicate(matching.str_matches(venv_file))
 
 _tests.append(_test_venv_output_prefix_with_path_separators)
 

--- a/tests/base_rules/py_executable_base_tests.bzl
+++ b/tests/base_rules/py_executable_base_tests.bzl
@@ -532,19 +532,26 @@ def _test_venv_output_prefix_with_path_separators(name, config):
         srcs = ["main.py"],
         main = "main.py",
     )
+    rt_util.helper_target(
+        config.rule,
+        name = name + "/foo_tool",
+        srcs = ["main.py"],
+        main = "main.py",
+    )
     analysis_test(
         name = name,
         impl = _test_venv_output_prefix_with_path_separators_impl,
         targets = {
             "bar": name + "/bar/tool",
             "foo": name + "/foo/tool",
+            "foo_underscore": name + "/foo_tool",
         },
     )
 
 def _test_venv_output_prefix_with_path_separators_impl(env, targets):
-    for target in [targets.foo, targets.bar]:
+    for target in [targets.foo, targets.bar, targets.foo_underscore]:
         target = env.expect.that_target(target)
-        venv_name = "_{}.venv/pyvenv.cfg".format(target.meta.format_str("{name}").replace("/", "_"))
+        venv_name = "_{}.venv/pyvenv.cfg".format(target.meta.format_str("{name}"))
         target.runfiles().contains_predicate(matching.str_endswith(venv_name))
 
 _tests.append(_test_venv_output_prefix_with_path_separators)


### PR DESCRIPTION
Fixes venv output naming for `py_binary` and `py_test` targets whose names
contain path separators.

Before this change, the venv output prefix was derived from the executable
basename. Distinct targets such as `//:foo/tool` and `//:bar/tool` both have
executable basename `tool`, so they could both declare the same
package-relative venv output directory:

```text
bazel-out/.../bin/_tool.venv
```

After this change, the venv output prefix is derived from the full target name
with `/` replaced by `_`, so those targets use separate venv output directories
such as:

```text
_foo_tool.venv
_bar_tool.venv
```

Added regression coverage for slash-named executable targets in the shared
`py_binary` / `py_test` base-rule tests.

Fixes #3844
