### PR TITLE
feat: updates to the py_extension rule for building C extensions

### DIFF
--- a/python/private/cc/py_extension_rule.bzl
+++ b/python/private/cc/py_extension_rule.bzl
@@ -12,6 +12,8 @@ load("//python/private:toolchain_types.bzl", "TARGET_TOOLCHAIN_TYPE")
 
 def _py_extension_impl(ctx):
     module_name = ctx.attr.module_name or ctx.label.name
+    repo_name = ctx.label.workspace_name or ctx.workspace_name
+    import_path = repo_name + "/" + ctx.label.package
     cc_toolchain = ctx.toolchains["@bazel_tools//tools/cpp:toolchain_type"].cc
     feature_configuration = cc_common.configure_features(
         ctx = ctx,
@@ -20,11 +22,8 @@ def _py_extension_impl(ctx):
 
     # Collect CcInfo from all deps for compilation
     static_deps_infos = [dep[CcInfo] for dep in ctx.attr.static_deps]
-    dynamic_deps_infos = [dep[CcInfo] for dep in ctx.attr.dynamic_deps]
+    dynamic_deps_infos = [dep[CcSharedLibraryInfo] for dep in ctx.attr.dynamic_deps]
     external_deps_infos = [dep[CcInfo] for dep in ctx.attr.external_deps]
-    all_deps_cc_info = cc_common.merge_cc_infos(
-        cc_infos = static_deps_infos + dynamic_deps_infos + external_deps_infos,
-    )
 
     # Static deps are linked directly into the .so
     static_cc_info = cc_common.merge_cc_infos(
@@ -32,9 +31,10 @@ def _py_extension_impl(ctx):
     )
 
     # Dynamic deps are linked as shared libraries
-    dynamic_linking_context = cc_common.merge_cc_infos(
-        cc_infos = dynamic_deps_infos,
-    ).linking_context
+    linker_inputs = [dep.linker_input for dep in dynamic_deps_infos]
+    dynamic_linking_context = cc_common.create_linking_context(
+        linker_inputs = depset(linker_inputs),
+    )
 
     user_link_flags = []
     user_link_flags.append("-Wl,--export-dynamic-symbol=PyInit_{module_name}".format(
@@ -97,14 +97,26 @@ def _py_extension_impl(ctx):
     ))
 
     # Propagate CcInfo from dynamic and external deps, but not static ones.
+    dynamic_cc_info = CcInfo(linking_context = dynamic_linking_context)
     propagated_cc_info = cc_common.merge_cc_infos(
-        cc_infos = dynamic_deps_infos + external_deps_infos,
+        cc_infos = [dynamic_cc_info] + external_deps_infos,
     )
 
+    runfiles = ctx.runfiles(files = [py_dso])
+    transitive_runfiles = []
+    for dep in ctx.attr.static_deps + ctx.attr.dynamic_deps + ctx.attr.external_deps:
+        if DefaultInfo in dep:
+            transitive_runfiles.append(dep[DefaultInfo].default_runfiles)
+    runfiles = runfiles.merge_all(transitive_runfiles)
+
     return [
-        DefaultInfo(files = depset([py_dso])),
+        DefaultInfo(
+            files = depset([py_dso]),
+            runfiles = runfiles,
+        ),
         PyInfo(
             transitive_sources = depset([py_dso]),
+            imports = depset([import_path]),
         ),
         propagated_cc_info,
     ]
@@ -113,8 +125,8 @@ _MaybeBuiltinPyInfo = [[BuiltinPyInfo]] if BuiltinPyInfo != None else []
 
 PY_EXTENSION_ATTRS = COMMON_ATTRS | {
     "dynamic_deps": lambda: attrb.LabelList(
-        providers = [CcInfo],
-        doc = "cc_library targets to be dynamically linked.",
+        providers = [CcSharedLibraryInfo],
+        doc = "cc_shared_library targets to be dynamically linked.",
         default = [],
     ),
     "external_deps": lambda: attrb.LabelList(

--- a/python/private/cc/py_extension_rule.bzl
+++ b/python/private/cc/py_extension_rule.bzl
@@ -51,9 +51,15 @@ def _py_extension_impl(ctx):
         user_link_flags.append("-Wl,--allow-shlib-undefined")
 
     # todo: use toolchain to determine `abi3.` infix
-    # todo: use toolchain to determine platform extension (pyd, so, etc)
-    output_filename = "{module_name}.{ext}".format(
+    py_toolchain = ctx.toolchains[TARGET_TOOLCHAIN_TYPE]
+    py_runtime = py_toolchain.py3_runtime
+    cc_toolchain = ctx.toolchains["@bazel_tools//tools/cpp:toolchain_type"].cc
+    platform_tag, ext = _get_platform_and_extension(cc_toolchain)
+    output_filename = "{module_name}.{pyc_tag}{abi_flags}-{platform}.{ext}".format(
         module_name = module_name,
+        pyc_tag = py_runtime.pyc_tag,      # e.g. "cpython-311"
+        abi_flags = py_runtime.abi_flags,  # e.g. "" or "d"
+        platform = platform_tag,           # e.g. "x86_64-linux-gnu"
         ext = "so",
     )
     py_dso = ctx.actions.declare_file(output_filename)
@@ -160,3 +166,78 @@ def create_py_extension_rule_builder(**kwargs):
     return builder
 
 py_extension = create_py_extension_rule_builder().build()
+
+# Map Bazel's internal CPU names to PEP 3149 standard architecture names
+_BAZEL_CPU_TO_PEP_ARCH = {
+    "k8": "x86_64",
+    "amd64": "x86_64",
+    "x86_64": "x86_64",
+    "aarch64": "aarch64",
+    "arm64": "arm64",
+    "darwin": "x86_64",       # Historical Bazel Mac CPU
+    "darwin_x86_64": "x86_64",
+    "darwin_arm64": "arm64",
+    "x64_windows": "x86_64",
+    "arm64_windows": "arm64",
+}
+
+def _get_platform_and_extension(cc_toolchain):
+    """Derives the PEP 3149 platform tag and extension from the C++ toolchain.
+
+    Args:
+        cc_toolchain: The CcToolchainInfo provider (usually obtained via
+          ctx.toolchains["@bazel_tools//tools/cpp:toolchain_type"].cc)
+
+    Returns:
+        A tuple of (platform_tag, extension)
+          e.g., ("x86_64-linux-gnu", "so") or ("win_amd64", "pyd")
+    """
+    # 1. Get the GNU target name (e.g., "local-linux-gnu" or "x86_64-unknown-linux-gnu")
+    target_name = cc_toolchain.target_gnu_system_name
+
+    # 2. Detect the OS family
+    is_windows = "windows" in target_name or "mingw" in target_name or "msvc" in target_name
+    is_mac = "apple" in target_name or "darwin" in target_name
+
+    # 3. Determine the extension for Python C extensions
+    # Windows uses .pyd; Unix (Linux/macOS) uses .so for Python modules
+    ext = "pyd" if is_windows else "so"
+
+    # 4. Parse the architecture from the target_name
+    # e.g., "x86_64-unknown-linux-gnu" -> "x86_64"
+    target_parts = target_name.split("-")
+    arch = target_parts[0]
+
+    # 5. Handle the "local" placeholder by falling back to cc_toolchain.cpu
+    if arch == "local":
+        cpu = cc_toolchain.cpu
+        # Resolve the Bazel CPU name to a standard PEP architecture
+        arch = _BAZEL_CPU_TO_PEP_ARCH.get(cpu, cpu)
+    # Normalize standard names if they came from a full target_name
+    elif arch == "amd64":
+        arch = "x86_64"
+    elif arch == "aarch64":
+        arch = "arm64" if is_mac else "aarch64"
+
+    # 6. Derive the PEP 3149 / PEP 425 platform tag
+    if is_windows:
+        platform_tag = "win_amd64" if arch == "x86_64" else "win32"
+    elif is_mac:
+        platform_tag = "darwin"
+    else:
+        # Linux/Unix: Reconstruct the triplet, dropping the vendor if present
+        os_part = "linux"
+        abi_part = "gnu"
+
+        if len(target_parts) == 4:
+            # [arch, vendor, os, abi]
+            os_part = target_parts[2]
+            abi_part = target_parts[3]
+        elif len(target_parts) == 3:
+            # [arch, os, abi]
+            os_part = target_parts[1]
+            abi_part = target_parts[2]
+
+        platform_tag = "{}-{}-{}".format(arch, os_part, abi_part)
+
+    return platform_tag, ext

--- a/python/private/cc/py_extension_rule.bzl
+++ b/python/private/cc/py_extension_rule.bzl
@@ -50,18 +50,25 @@ def _py_extension_impl(ctx):
     if ctx.attr.external_deps:
         user_link_flags.append("-Wl,--allow-shlib-undefined")
 
-    # todo: use toolchain to determine `abi3.` infix
-    py_toolchain = ctx.toolchains[TARGET_TOOLCHAIN_TYPE]
-    py_runtime = py_toolchain.py3_runtime
-    cc_toolchain = ctx.toolchains["@bazel_tools//tools/cpp:toolchain_type"].cc
-    platform_tag, ext = _get_platform_and_extension(cc_toolchain)
-    output_filename = "{module_name}.{pyc_tag}{abi_flags}-{platform}.{ext}".format(
-        module_name = module_name,
-        pyc_tag = py_runtime.pyc_tag,      # e.g. "cpython-311"
-        abi_flags = py_runtime.abi_flags,  # e.g. "" or "d"
-        platform = platform_tag,           # e.g. "x86_64-linux-gnu"
-        ext = "so",
-    )
+    ext = _get_extension(cc_toolchain)
+    use_py_limited_api = ctx.attr.py_limited_api and ctx.attr.py_limited_api != "none"
+    if use_py_limited_api:
+        output_filename = "{module_name}.abi3.{ext}".format(
+            module_name=module_name,
+            ext=ext,
+        )
+    else:
+        py_toolchain = ctx.toolchains[TARGET_TOOLCHAIN_TYPE]
+        py_runtime = py_toolchain.py3_runtime
+        cc_toolchain = ctx.toolchains["@bazel_tools//tools/cpp:toolchain_type"].cc
+        platform_tag = _get_platform(cc_toolchain)
+        output_filename = "{module_name}.{pyc_tag}{abi_flags}-{platform}.{ext}".format(
+            module_name = module_name,
+            pyc_tag = py_runtime.pyc_tag,      # e.g. "cpython-311"
+            abi_flags = py_runtime.abi_flags,  # e.g. "" or "d"
+            platform = platform_tag,           # e.g. "x86_64-linux-gnu"
+            ext = "so",
+        )
     py_dso = ctx.actions.declare_file(output_filename)
 
     static_linking_context = static_cc_info.linking_context
@@ -148,6 +155,12 @@ PY_EXTENSION_ATTRS = COMMON_ATTRS | {
     "copts": lambda: attrb.StringList(),
     "linkopts": lambda: attrb.StringList(),
     "module_name": lambda: attrb.String(),
+    "py_limited_api": lambda: attrb.String(
+        doc = ("Minimum Python version to target for the Limited API (e.g., '3.8'). " +
+               "Set to 'none' (the default) to disable the Limited API and build a " +
+               "version-specific extension."),
+        default = "none"
+    ),
 }
 
 def create_py_extension_rule_builder(**kwargs):
@@ -181,34 +194,48 @@ _BAZEL_CPU_TO_PEP_ARCH = {
     "arm64_windows": "arm64",
 }
 
-def _get_platform_and_extension(cc_toolchain):
-    """Derives the PEP 3149 platform tag and extension from the C++ toolchain.
+def _get_extension(cc_toolchain):
+    """
+    Derives the appropriate file extension from the C++ toolchain.
 
     Args:
         cc_toolchain: The CcToolchainInfo provider (usually obtained via
           ctx.toolchains["@bazel_tools//tools/cpp:toolchain_type"].cc)
 
     Returns:
-        A tuple of (platform_tag, extension)
-          e.g., ("x86_64-linux-gnu", "so") or ("win_amd64", "pyd")
+        The extension, e.g. "so" or "pyd"
     """
-    # 1. Get the GNU target name (e.g., "local-linux-gnu" or "x86_64-unknown-linux-gnu")
+
+    # Windows uses .pyd; Unix (Linux/macOS) uses .so for Python modules
+    target_name = cc_toolchain.target_gnu_system_name
+    is_windows = "windows" in target_name or "mingw" in target_name or "msvc" in target_name
+    ext = "pyd" if is_windows else "so"
+    return ext
+
+
+def _get_platform(cc_toolchain):
+    """Derives the PEP 3149 platform tag from the C++ toolchain.
+
+    Args:
+        cc_toolchain: The CcToolchainInfo provider (usually obtained via
+          ctx.toolchains["@bazel_tools//tools/cpp:toolchain_type"].cc)
+
+    Returns:
+        The platform tag, e.g. "x86_64-linux-gnu" or "win_amd64"
+    """
+    # Get the GNU target name (e.g., "local-linux-gnu" or "x86_64-unknown-linux-gnu")
     target_name = cc_toolchain.target_gnu_system_name
 
-    # 2. Detect the OS family
+    # Detect the OS family
     is_windows = "windows" in target_name or "mingw" in target_name or "msvc" in target_name
     is_mac = "apple" in target_name or "darwin" in target_name
 
-    # 3. Determine the extension for Python C extensions
-    # Windows uses .pyd; Unix (Linux/macOS) uses .so for Python modules
-    ext = "pyd" if is_windows else "so"
-
-    # 4. Parse the architecture from the target_name
+    # Parse the architecture from the target_name
     # e.g., "x86_64-unknown-linux-gnu" -> "x86_64"
     target_parts = target_name.split("-")
     arch = target_parts[0]
 
-    # 5. Handle the "local" placeholder by falling back to cc_toolchain.cpu
+    # Handle the "local" placeholder by falling back to cc_toolchain.cpu
     if arch == "local":
         cpu = cc_toolchain.cpu
         # Resolve the Bazel CPU name to a standard PEP architecture
@@ -219,7 +246,7 @@ def _get_platform_and_extension(cc_toolchain):
     elif arch == "aarch64":
         arch = "arm64" if is_mac else "aarch64"
 
-    # 6. Derive the PEP 3149 / PEP 425 platform tag
+    # Derive the PEP 3149 / PEP 425 platform tag
     if is_windows:
         platform_tag = "win_amd64" if arch == "x86_64" else "win32"
     elif is_mac:
@@ -240,4 +267,4 @@ def _get_platform_and_extension(cc_toolchain):
 
         platform_tag = "{}-{}-{}".format(arch, os_part, abi_part)
 
-    return platform_tag, ext
+    return platform_tag

--- a/python/private/cc/py_extension_rule.bzl
+++ b/python/private/cc/py_extension_rule.bzl
@@ -53,6 +53,9 @@ def _py_extension_impl(ctx):
     ext = _get_extension(cc_toolchain)
     use_py_limited_api = ctx.attr.py_limited_api and ctx.attr.py_limited_api != "none"
     if use_py_limited_api:
+        # check that all dependencies have compatible API versions, if defined
+        _check_limited_api_compatibility(ctx, ctx.attr.py_limited_api)
+
         output_filename = "{module_name}.abi3.{ext}".format(
             module_name=module_name,
             ext=ext,
@@ -156,9 +159,29 @@ PY_EXTENSION_ATTRS = COMMON_ATTRS | {
     "linkopts": lambda: attrb.StringList(),
     "module_name": lambda: attrb.String(),
     "py_limited_api": lambda: attrb.String(
-        doc = ("Minimum Python version to target for the Limited API (e.g., '3.8'). " +
-               "Set to 'none' (the default) to disable the Limited API and build a " +
-               "version-specific extension."),
+        doc = """\
+            The minimum Python version to target for the Limited API (e.g., '3.8').
+
+            If set to a version string (e.g., '3.8') instead of 'none':
+              - Configures the output filename to use the simple '.abi3' suffix (e.g.,
+                'ext.abi3.so').
+              - Strictly validates that all linked C++ dependencies (static_deps,
+                dynamic_deps, etc.) are binary-compatible with this target version,
+                failing the build if a dependency is missing the 'Py_LIMITED_API' define
+                or targets a newer version.
+
+            Note: Since the py_extension rule only links pre-compiled libraries, you must
+            manually add the preprocessor macro to the cc_library targets that compile your
+            C/C++ sources, for example:
+                cc_library(
+                    name = "my_impl",
+                    srcs = ["my_code.c"],
+                    defines = ["Py_LIMITED_API=0x03080000"],
+                    ...
+                )
+
+            Set to 'none' (the default) to build a standard, version-specific extension.
+            """,
         default = "none"
     ),
 }
@@ -211,7 +234,6 @@ def _get_extension(cc_toolchain):
     is_windows = "windows" in target_name or "mingw" in target_name or "msvc" in target_name
     ext = "pyd" if is_windows else "so"
     return ext
-
 
 def _get_platform(cc_toolchain):
     """Derives the PEP 3149 platform tag from the C++ toolchain.
@@ -268,3 +290,106 @@ def _get_platform(cc_toolchain):
         platform_tag = "{}-{}-{}".format(arch, os_part, abi_part)
 
     return platform_tag
+
+
+def _version_to_hex(version_str):
+    """Converts a version string like '3.10' to Python's version hex '0x030a0000'."""
+    parts = version_str.split(".")
+    if len(parts) != 2:
+        fail("Invalid py_limited_api version '{}', expected 'major.minor' format (e.g., '3.8')".format(version_str))
+
+    major = int(parts[0])
+    minor = int(parts[1])
+
+    if major != 3:
+        fail("Python Limited API is only supported for Python 3.2+ (got Python {})".format(major))
+    if minor < 2:
+        fail("Python Limited API is only supported for Python 3.2+ (got 3.{})".format(minor))
+
+    # Format the minor version as a 2-digit hex (e.g., 10 -> "0a")
+    # Starlark doesn't seem to support %02x formatting
+
+    return "0x03%x%x0000" % (int(minor/16), minor%16)
+
+
+def _check_limited_api_compatibility(ctx, ext_version_str):
+    """Validates that all C++ dependencies are binary-compatible with the extension's Limited API target."""
+    if ext_version_str == "none":
+        return
+
+    ext_version_hex = _version_to_hex(ext_version_str)
+    ext_version_val = int(ext_version_hex, 16)
+
+    # Collect all dependencies that might propagate CcInfo
+    deps = []
+    deps.extend(ctx.attr.static_deps)
+    deps.extend(ctx.attr.dynamic_deps)
+    deps.extend(ctx.attr.external_deps)
+
+    for dep in deps:
+        if CcInfo not in dep:
+            continue
+
+        comp_ctx = dep[CcInfo].compilation_context
+
+        # Detect if the dependency has access to Python headers
+        has_python_headers = False
+        for header in comp_ctx.headers.to_list():
+            if header.basename == "Python.h":
+                has_python_headers = True
+                break
+
+        # Inspect the propagated defines
+        has_limited_api_define = False
+        limited_api_define_value = None
+
+        for define in comp_ctx.defines.to_list():
+            if define.startswith("Py_LIMITED_API="):
+                has_limited_api_define = True
+                limited_api_define_value = define.split("=")[1]
+            elif define == "Py_LIMITED_API":
+                has_limited_api_define = True
+                limited_api_define_value = "unspecified"
+
+        # Enforce the compatibility contract
+
+        # Contract Rule A: If the library uses Python, it MUST use the Limited API
+        if has_python_headers and not has_limited_api_define:
+            fail((
+                "\nERROR: Unsafe Python C API usage in dependency:\n" +
+                "  Dependency '{dep}' includes Python headers (contains 'Python.h')\n" +
+                "  but does NOT define 'Py_LIMITED_API'.\n" +
+                "  This will link unstable Python symbols into your Stable ABI extension.\n" +
+                "  Please add: defines = [\"Py_LIMITED_API={ext_hex}\"] to '{dep}'."
+            ).format(
+                dep = dep.label,
+                ext_hex = ext_version_hex,
+            ))
+
+        # Contract Rule B: If the Limited API is defined, it must be version-safe
+        if has_limited_api_define:
+            if limited_api_define_value == "unspecified":
+                fail((
+                    "\nERROR: Unsafe Python Limited API definition in dependency\n" +
+                    "  Dependency '{dep}' defines 'Py_LIMITED_API' without a version hex.\n" +
+                    "  Please change it to specify the target version explicitly, " +
+                    "for example: defines = [\"Py_LIMITED_API={ext_hex}\"]"
+                ).format(
+                    dep = dep.label,
+                    ext_hex = ext_version_hex,
+                ))
+            else:
+                dep_version_val = int(limited_api_define_value, 16)
+                if dep_version_val > ext_version_val:
+                    fail((
+                        "\nERROR: Incompatible Python Limited API targets detected\n" +
+                        "  Extension '{self}' targets version '{ext_ver}' ({ext_hex}).\n" +
+                        "  Dependency '{dep}' targets a NEWER version ({dep_hex}).\n" +
+                        "  You cannot link a newer Limited API library into an older extension."
+                    ).format(
+                        self = ctx.label,
+                        ext_ver = ext_version_str,
+                        ext_hex = ext_version_hex,
+                        dep = dep.label,
+                        dep_hex = limited_api_define_value,
+            ))

--- a/tests/cc/py_extension/BUILD.bazel
+++ b/tests/cc/py_extension/BUILD.bazel
@@ -22,7 +22,7 @@ py_extension(
 py_extension(
     name = "ext_shared",
     dynamic_deps = [
-        ":add_one",
+        ":add_one_shared",
     ],
     static_deps = [
         ":ext_shared_impl",

--- a/tests/cc/py_extension/BUILD.bazel
+++ b/tests/cc/py_extension/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 load("//python:py_test.bzl", "py_test")
 
 # buildifier: disable=bzl-visibility

--- a/tests/cc/py_extension/BUILD.bazel
+++ b/tests/cc/py_extension/BUILD.bazel
@@ -93,6 +93,24 @@ cc_library(
     hdrs = ["add_one_helper.h"],
 )
 
+py_extension(
+    name = "ext_limited",
+    static_deps = [":ext_limited_impl"],
+    py_limited_api = '3.8'
+)
+
+cc_library(
+    name = "ext_limited_impl",
+    srcs = ["ext_limited.c"],
+    copts = [
+        "-fPIC",
+        "-fvisibility=hidden",
+    ],
+    deps = [
+        "@rules_python//python/cc:current_py_cc_headers",
+    ],
+)
+
 py_test(
     name = "py_extension_test",
     srcs = ["py_extension_test.py"],

--- a/tests/cc/py_extension/BUILD.bazel
+++ b/tests/cc/py_extension/BUILD.bazel
@@ -102,6 +102,7 @@ py_extension(
 cc_library(
     name = "ext_limited_impl",
     srcs = ["ext_limited.c"],
+    defines = ["Py_LIMITED_API=0x3080000"],
     copts = [
         "-fPIC",
         "-fvisibility=hidden",
@@ -110,6 +111,26 @@ cc_library(
         "@rules_python//python/cc:current_py_cc_headers",
     ],
 )
+
+
+# test cases:
+# py_limited_api
+#   - 3.8 -> 3.8    ok
+#   - 3.8 -> 3.9
+#   - 3.9 -> 3.8
+#   - 3.9 -> 3.9    ok
+#   - none -> 3.8
+#   - 3.8 -> none   fail
+#   - 3.8 -> nopy   ok
+#   - none -> none  ok?
+#   - none -> nopy  ok?
+# invalid values for version string
+#   - 2.x
+#   - 3.0 and 3.1
+#   - 4.x
+#   - not version string, e.g. "asdf"
+#   - patch versions? 3.8.4 ?
+#   - empty string or null?
 
 py_test(
     name = "py_extension_test",

--- a/tests/cc/py_extension/BUILD.bazel
+++ b/tests/cc/py_extension/BUILD.bazel
@@ -5,6 +5,7 @@ load("//python:py_test.bzl", "py_test")
 # buildifier: disable=bzl-visibility
 load("//python/cc:py_extension.bzl", "py_extension")
 load(":py_extension_tests.bzl", "py_extension_analysis_test_suite")
+load(":py_limited_api_tests.bzl", "py_limited_api_test_suite")
 
 package(
     default_testonly = True,
@@ -112,26 +113,6 @@ cc_library(
     ],
 )
 
-
-# test cases:
-# py_limited_api
-#   - 3.8 -> 3.8    ok
-#   - 3.8 -> 3.9
-#   - 3.9 -> 3.8
-#   - 3.9 -> 3.9    ok
-#   - none -> 3.8
-#   - 3.8 -> none   fail
-#   - 3.8 -> nopy   ok
-#   - none -> none  ok?
-#   - none -> nopy  ok?
-# invalid values for version string
-#   - 2.x
-#   - 3.0 and 3.1
-#   - 4.x
-#   - not version string, e.g. "asdf"
-#   - patch versions? 3.8.4 ?
-#   - empty string or null?
-
 py_test(
     name = "py_extension_test",
     srcs = ["py_extension_test.py"],
@@ -144,4 +125,8 @@ py_test(
 
 py_extension_analysis_test_suite(
     name = "py_extension_analysis_tests",
+)
+
+py_limited_api_test_suite(
+    name = "py_limited_api_tests",
 )

--- a/tests/cc/py_extension/ext_limited.c
+++ b/tests/cc/py_extension/ext_limited.c
@@ -1,0 +1,22 @@
+#include <Python.h>
+
+static PyObject* get_limited_api_version(PyObject* self, PyObject* args) {
+    return PyUnicode_FromFormat("0x%X", Py_LIMITED_API);
+}
+
+static PyMethodDef ModuleMethods[] = {
+    {"get_limited_api_version", do_alpha, METH_NOARGS, "Get the version of the limited API this extension was compiled against.."},
+    {NULL, NULL, 0, NULL}
+};
+
+static struct PyModuleDef ext_limited_module = {
+    PyModuleDef_HEAD_INIT,
+    "ext_limited",
+    NULL,
+    -1,
+    ModuleMethods
+};
+
+PyMODINIT_FUNC PyInit_ext_limited(void) {
+    return PyModule_Create(&ext_limited_module);
+}

--- a/tests/cc/py_extension/ext_limited.c
+++ b/tests/cc/py_extension/ext_limited.c
@@ -1,11 +1,11 @@
 #include <Python.h>
 
 static PyObject* get_limited_api_version(PyObject* self, PyObject* args) {
-    return PyUnicode_FromFormat("0x%X", Py_LIMITED_API);
+    return PyUnicode_FromFormat("0x%08x", Py_LIMITED_API);
 }
 
 static PyMethodDef ModuleMethods[] = {
-    {"get_limited_api_version", do_alpha, METH_NOARGS, "Get the version of the limited API this extension was compiled against.."},
+    {"get_limited_api_version", get_limited_api_version, METH_NOARGS, "Get the version of the limited API this extension was compiled against."},
     {NULL, NULL, 0, NULL}
 };
 

--- a/tests/cc/py_extension/py_extension_test.py
+++ b/tests/cc/py_extension/py_extension_test.py
@@ -1,9 +1,11 @@
-import unittest
 import os
-from python.runfiles import runfiles
-from elftools.elf.elffile import ELFFile
-from elftools.elf.dynamic import DynamicSection
+import unittest
+
 import ext_shared
+from elftools.elf.dynamic import DynamicSection
+from elftools.elf.elffile import ELFFile
+
+from python.runfiles import runfiles
 
 
 class PyExtensionTest(unittest.TestCase):

--- a/tests/cc/py_extension/py_extension_test.py
+++ b/tests/cc/py_extension/py_extension_test.py
@@ -20,7 +20,7 @@ class PyExtensionTest(unittest.TestCase):
             self.assertTrue(isinstance(dynamic_section, DynamicSection))
 
             needed_libs = [tag.needed for tag in dynamic_section.iter_tags() if tag.entry.d_tag == 'DT_NEEDED']
-            self.assertIn('libdyn_dep_a.so', needed_libs)
+            self.assertIn('libadd_one_shared.so', needed_libs)
 
             # Check for the PyInit symbol
             dynsym_section = elf.get_section_by_name('.dynsym')
@@ -30,7 +30,7 @@ class PyExtensionTest(unittest.TestCase):
             self.assertIn('PyInit_ext_shared', symbols)
 
     def test_import_and_call(self):
-        self.assertEqual(ext_shared.my_c_function(), 42)
+        self.assertEqual(ext_shared.do_alpha(), 43)
 
 
 if __name__ == "__main__":

--- a/tests/cc/py_extension/py_extension_test.py
+++ b/tests/cc/py_extension/py_extension_test.py
@@ -5,29 +5,36 @@ from elftools.elf.elffile import ELFFile
 from elftools.elf.dynamic import DynamicSection
 import ext_shared
 
+
 class PyExtensionTest(unittest.TestCase):
     def test_inspect_elf(self):
         r = runfiles.Create()
         ext_path = r.Rlocation("rules_python/tests/cc/py_extension/ext_shared.so")
-        self.assertTrue(os.path.exists(ext_path), f"Could not find ext_shared.so at {ext_path}")
+        self.assertTrue(
+            os.path.exists(ext_path), f"Could not find ext_shared.so at {ext_path}"
+        )
 
-        with open(ext_path, 'rb') as f:
+        with open(ext_path, "rb") as f:
             elf = ELFFile(f)
 
             # Check for DT_NEEDED entry for the dynamic library
-            dynamic_section = elf.get_section_by_name('.dynamic')
+            dynamic_section = elf.get_section_by_name(".dynamic")
             self.assertIsNotNone(dynamic_section)
             self.assertTrue(isinstance(dynamic_section, DynamicSection))
 
-            needed_libs = [tag.needed for tag in dynamic_section.iter_tags() if tag.entry.d_tag == 'DT_NEEDED']
-            self.assertIn('libadd_one_shared.so', needed_libs)
+            needed_libs = [
+                tag.needed
+                for tag in dynamic_section.iter_tags()
+                if tag.entry.d_tag == "DT_NEEDED"
+            ]
+            self.assertIn("libadd_one_shared.so", needed_libs)
 
             # Check for the PyInit symbol
-            dynsym_section = elf.get_section_by_name('.dynsym')
+            dynsym_section = elf.get_section_by_name(".dynsym")
             self.assertIsNotNone(dynsym_section)
 
             symbols = [s.name for s in dynsym_section.iter_symbols()]
-            self.assertIn('PyInit_ext_shared', symbols)
+            self.assertIn("PyInit_ext_shared", symbols)
 
     def test_import_and_call(self):
         self.assertEqual(ext_shared.do_alpha(), 43)

--- a/tests/cc/py_extension/py_extension_tests.bzl
+++ b/tests/cc/py_extension/py_extension_tests.bzl
@@ -22,17 +22,19 @@ load("//python/private:py_info.bzl", "PyInfo")
 _tests = []
 
 def _test_static_deps_impl(env, target):
-    py_info = env.expect.that_target(target).has_provider(PyInfo)
-    cc_info = env.expect.that_target(target).has_provider(CcInfo)
+    env.expect.that_target(target).has_provider(PyInfo)
+    py_info = target[PyInfo]
+    env.expect.that_target(target).has_provider(CcInfo)
+    cc_info = target[CcInfo]
 
     # The .so should be in PyInfo
-    env.expect.that_collection(py_info.transitive_sources).has_size(1)
-    env.expect.that_collection(py_info.transitive_sources).contains_predicate(
-        matching.str_matches("ext_static.so$"),
+    env.expect.that_collection(py_info.transitive_sources.to_list()).has_size(1)
+    env.expect.that_depset_of_files(py_info.transitive_sources).contains_predicate(
+        matching.file_basename_equals("ext_static.cpython-311-x86_64-linux-gnu.so"),
     )
 
     # CcInfo from static_deps should not be propagated.
-    env.expect.that_collection(cc_info.linking_context.linker_inputs.to_list()).is_empty()
+    env.expect.that_depset_of_files(cc_info.linking_context.linker_inputs).contains_exactly([])
 
 def _test_static_deps(name):
     analysis_test(
@@ -44,17 +46,20 @@ def _test_static_deps(name):
 _tests.append(_test_static_deps)
 
 def _test_dynamic_deps_impl(env, target):
-    py_info = env.expect.that_target(target).has_provider(PyInfo)
-    cc_info = env.expect.that_target(target).has_provider(CcInfo)
+    env.expect.that_target(target).has_provider(PyInfo)
+    py_info = target[PyInfo]
+    env.expect.that_target(target).has_provider(CcInfo)
+    cc_info = target[CcInfo]
 
     # The .so should be in PyInfo
-    env.expect.that_collection(py_info.transitive_sources).has_size(1)
-    env.expect.that_collection(py_info.transitive_sources).contains_predicate(
-        matching.str_matches("ext_shared.so$"),
+    env.expect.that_collection(py_info.transitive_sources.to_list()).has_size(1)
+    env.expect.that_depset_of_files(py_info.transitive_sources).contains_predicate(
+        matching.file_basename_equals("ext_shared.cpython-311-x86_64-linux-gnu.so"),
     )
 
     # CcInfo from dynamic_deps should be propagated.
-    env.expect.that_collection(cc_info.linking_context.linker_inputs.to_list()).is_not_empty()
+    print(cc_info.linking_context.linker_inputs.to_list())
+    env.expect.that_collection(cc_info.linking_context.linker_inputs.to_list()).has_size(1)
 
 def _test_dynamic_deps(name):
     analysis_test(

--- a/tests/cc/py_extension/py_limited_api_tests.bzl
+++ b/tests/cc/py_extension/py_limited_api_tests.bzl
@@ -1,0 +1,77 @@
+# Copyright 2025 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the py_limited_api attribute for py_extension."""
+
+load("@rules_testing//lib:analysis_test.bzl", "analysis_test", "test_suite")
+load("@rules_testing//lib:truth.bzl", "matching")
+load("@rules_testing//lib:util.bzl", "util")
+load("//python/cc:py_extension.bzl", "py_extension")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+
+def _test_limited_same_version(name):
+    # given
+    util.helper_target(
+        cc_library,
+        name = name + '_csl',
+        defines = ["Py_LIMITED_API=0x3080000"],
+        deps = [
+            "@rules_python//python/cc:current_py_cc_headers",
+        ],
+    )
+    py_extension(
+        name = name + '_pyext',
+        static_deps = [':' + name + '_csl'],
+        py_limited_api = '3.8',
+    )
+
+    # when
+    analysis_test(
+        name = name,
+        target = name + "_pyext",
+        impl=_test_limited_same_version_impl)
+
+def _test_limited_same_version_impl(env, target):
+    # then
+    env.expect.that_target(target).default_outputs().contains(
+        "tests/cc/py_extension/test_limited_same_version_pyext.abi3.so"
+    )
+
+# test cases:
+# py_limited_api
+#   - 3.8 -> 3.9
+#   - 3.9 -> 3.8
+#   - 3.9 -> 3.9    ok
+#   - none -> 3.8
+#   - 3.8 -> none   fail
+#   - 3.8 -> nopy   ok
+#   - none -> none  ok?
+#   - none -> nopy  ok?
+# invalid values for version string
+#   - 2.x
+#   - 3.0 and 3.1
+#   - 4.x
+#   - not version string, e.g. "asdf"
+#   - patch versions? 3.8.4 ?
+#   - empty string or null?
+
+
+def py_limited_api_test_suite(name):
+    test_suite(
+        name = name,
+        tests = [
+            _test_limited_same_version,
+        ],
+    )


### PR DESCRIPTION
This builds on the existing `py-extension` branch. It adds support for platform and abi tags in the resulting library filename. The `:py_extension_test`, `:py_extension_analysis_tests`, and `:py_limited_api_tests` test targets in `//tests/cc/py_extension` now build and pass.

Relates to https://github.com/bazel-contrib/rules_python/issues/3283