### PR TITLE
chore: verify pr-metadata-checks behavior

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -109,4 +109,4 @@ bzl_library(
     visibility = ["//:__subpackages__"],
 )
 
-# No-op change to verify PR metadata checks
+# Another no-op change to verify PR metadata checks behavior


### PR DESCRIPTION
This is another no-op change to verify the workflow behavior.