### PR TITLE
chore(release): fix release label consistency in workflows and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_tracking_template.md
+++ b/.github/ISSUE_TEMPLATE/release_tracking_template.md
@@ -2,7 +2,7 @@
 name: Release Tracking Issue
 about: Checklist for tracking a new release of rules_python.
 title: 'Release <version>'
-labels: ['type:release']
+labels: ['type: release']
 ---
 # Release tasks
 - [ ] Prepare Release | status=awaiting-preparation

--- a/.github/workflows/cut_release_branch.yml
+++ b/.github/workflows/cut_release_branch.yml
@@ -10,8 +10,8 @@ permissions:
 
 jobs:
   cut_branch:
-    # Run only if the issue has the type:release label
-    if: contains(github.event.issue.labels.*.name, 'type:release')
+    # Run only if the issue has the type: release label
+    if: contains(github.event.issue.labels.*.name, 'type: release')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/process_backports.yml
+++ b/.github/workflows/process_backports.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   process_backports:
-    # Always gate GHA runs to ensure we are operating on a type:release labeled issue if metadata is queried
+    # Always gate GHA runs to ensure we are operating on a type: release labeled issue if metadata is queried
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This change fixes the release tracking and branch cutting workflows to use the correct type: release label with a space. This ensures the automation triggers correctly and matches the label expected by the release tool.