### PR TITLE
chore(release): support custom remote in create-release-branch and refactor

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_tracking_template.md
+++ b/.github/ISSUE_TEMPLATE/release_tracking_template.md
@@ -11,10 +11,27 @@ labels: ['type: release']
 - [ ] Tag Final
 
 ## Backports
-<!-- Items to be cherry-picked into the next RC go here -->
+
+<details>
+<summary><b>How to add backports</b></summary>
+
+To request a backport:
+1. Add a new checklist item under the `## Backports` section.
+2. The format must be: `- [ ] #<PR_NUMBER>` (e.g., `- [ ] #1234`).
+3. Trigger the [Process Backports Workflow](https://github.com/bazel-contrib/rules_python/actions/workflows/process_backports.yml).
+</details>
 
 ---
 *Maintainers: Automation will react to changes on this issue.*
+
+<details>
+<summary><b>Manual Editing</b></summary>
+
+You can manually edit this issue to control the release flow.
+The checklist items use metadata suffix: `| key=value key2=value2`.
+- **Retry Prepare Release**: Reset to `- [ ] Prepare Release | status=awaiting-preparation`.
+- **Force Task Done**: Check the box `- [x]` and add appropriate metadata (e.g. `status=done`).
+</details>
 
 <details>
 <summary><b>Available Commands</b></summary>

--- a/.github/workflows/cut_release_branch.yml
+++ b/.github/workflows/cut_release_branch.yml
@@ -32,6 +32,6 @@ jobs:
       - name: Attempt Branch Creation
         run: |
           bazel run //tools/private/release -- \
-            create-release-branch --issue ${{ github.event.issue.number }}
+            create-release-branch --issue ${{ github.event.issue.number }} --remote origin
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/tools/private/release/release_test.py
+++ b/tests/tools/private/release/release_test.py
@@ -18,10 +18,12 @@ def _mock_git_and_gh(test_case):
     # Patch bindings in modules that import them at module level
     patch("tools.private.release.release.git", new=mock_git).start()
     patch("tools.private.release.prepare.git", new=mock_git).start()
+    patch("tools.private.release.create_release_branch.git", new=mock_git).start()
     patch("tools.private.release.utils.git", new=mock_git).start()
 
     patch("tools.private.release.release.gh", new=mock_gh).start()
     patch("tools.private.release.prepare.gh", new=mock_gh).start()
+    patch("tools.private.release.create_release_branch.gh", new=mock_gh).start()
     mock_gh.MultipleTrackingIssuesError = MultipleTrackingIssuesError
     mock_gh.NoTrackingIssueError = NoTrackingIssueError
 
@@ -1216,6 +1218,77 @@ class CmdPromoteRcTest(unittest.TestCase):
         self.mock_git.checkout.assert_not_called()
         self.mock_git.tag.assert_not_called()
         self.mock_gh.get_issue_body.assert_not_called()
+
+
+class CmdCreateReleaseBranchTest(unittest.TestCase):
+    def setUp(self):
+        _mock_git_and_gh(self)
+
+    def test_create_release_branch_success(self):
+        # Arrange
+        args = MagicMock(issue=123, remote="my-remote")
+        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
+        self.mock_gh.get_issue_body.return_value = """
+## Checklist
+- [x] Prepare Release | status=done pr=#122 commit=abcdef12
+- [ ] Create Release branch | status=pending
+"""
+        self.mock_git.branch_exists.return_value = False
+
+        # Act
+        result = releaser.cmd_create_release_branch(args)
+
+        # Assert
+        self.assertEqual(result, 0)
+        self.mock_git.fetch.assert_called_once_with("my-remote")
+        self.mock_git.checkout.assert_any_call("abcdef12")
+        self.mock_git.checkout.assert_any_call("release/2.0", create_branch=True)
+        self.mock_git.push.assert_called_once_with("my-remote", "release/2.0")
+
+        self.mock_gh.update_issue_body.assert_called_once()
+        call_args = self.mock_gh.update_issue_body.call_args[0]
+        self.assertEqual(call_args[0], 123)
+        self.assertIn(
+            "branch_url=https://github.com/bazel-contrib/rules_python/tree/release/2.0",
+            call_args[1],
+        )
+        self.assertIn("commit=abcdef12", call_args[1])
+
+    def test_create_release_branch_prepare_not_done(self):
+        # Arrange
+        args = MagicMock(issue=123, remote="my-remote")
+        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
+        self.mock_gh.get_issue_body.return_value = """
+## Checklist
+- [ ] Prepare Release | status=pending
+- [ ] Create Release branch | status=pending
+"""
+        # Act
+        result = releaser.cmd_create_release_branch(args)
+
+        # Assert
+        self.assertEqual(result, 1)
+        self.mock_git.fetch.assert_not_called()
+        self.mock_git.push.assert_not_called()
+        self.mock_gh.update_issue_body.assert_not_called()
+
+    def test_create_release_branch_already_checked(self):
+        # Arrange
+        args = MagicMock(issue=123, remote="my-remote")
+        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
+        self.mock_gh.get_issue_body.return_value = """
+## Checklist
+- [x] Prepare Release | status=done pr=#122 commit=abcdef12
+- [x] Create Release branch | status=done branch=release/2.0 commit=abcdef12
+"""
+        # Act
+        result = releaser.cmd_create_release_branch(args)
+
+        # Assert
+        self.assertEqual(result, 0)
+        self.mock_git.fetch.assert_not_called()
+        self.mock_git.push.assert_not_called()
+        self.mock_gh.update_issue_body.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tools/private/release/BUILD.bazel
+++ b/tools/private/release/BUILD.bazel
@@ -10,6 +10,7 @@ py_library(
 py_binary(
     name = "release",
     srcs = [
+        "create_release_branch.py",
         "gh.py",
         "git.py",
         "prepare.py",

--- a/tools/private/release/create_release_branch.py
+++ b/tools/private/release/create_release_branch.py
@@ -1,0 +1,67 @@
+"""Subcommand to create a release branch from a merged PR commit."""
+
+from tools.private.release import gh, git
+from tools.private.release.release_issue import (
+    RELEASE_TITLE_RE,
+    parse_checklist_state,
+    update_task_in_body,
+)
+from tools.private.release.utils import REPO_URL
+
+
+def cmd_create_release_branch(args):
+    """Executes the create-release-branch subcommand."""
+    print(f"Evaluating branch creation for tracking issue #{args.issue}...")
+    body = gh.get_issue_body(args.issue)
+    state = parse_checklist_state(body)
+
+    if (
+        state["prepare_release"]["status"] != "done"
+        or not state["prepare_release"]["commit"]
+    ):
+        print(
+            "Error: Prepare Release task is not marked 'done' with a valid commit SHA."
+        )
+        return 1
+
+    if state["create_branch"]["checked"]:
+        print("Release branch has already been created and checked. Skipping.")
+        return 0
+
+    # Extract version from issue title
+    issue_title = gh.get_issue_title(args.issue)
+    version_match = RELEASE_TITLE_RE.search(issue_title)
+    if not version_match:
+        print(f"Error: Could not parse version from issue title: {issue_title}")
+        return 1
+
+    version = version_match.group(1)
+    branch_version = ".".join(version.split(".")[:2])
+    branch_name = f"release/{branch_version}"
+
+    commit_sha = state["prepare_release"]["commit"]
+    print(f"Cutting branch {branch_name} from commit {commit_sha}...")
+
+    # Create and push branch
+    git.fetch(args.remote)
+    git.checkout(commit_sha)
+
+    if not git.branch_exists(branch_name):
+        git.checkout(branch_name, create_branch=True)
+    else:
+        git.checkout(branch_name)
+        git.merge(commit_sha, ff_only=True)
+
+    git.push(args.remote, branch_name)
+    print(f"Successfully pushed branch {branch_name} to {args.remote}")
+
+    # Update tracking issue checklist
+    print("Updating tracking issue checklist...")
+    branch_url = f"{REPO_URL}/tree/{branch_name}"
+    metadata = {"status": "done", "branch_url": branch_url, "commit": commit_sha[:8]}
+    updated_body = update_task_in_body(
+        body, "Create Release branch", checked=True, metadata=metadata
+    )
+    gh.update_issue_body(args.issue, updated_body)
+    print("Create Release branch task marked complete successfully!")
+    return 0

--- a/tools/private/release/release.py
+++ b/tools/private/release/release.py
@@ -8,19 +8,19 @@ import re
 import sys
 
 from tools.private.release import changelog_news, gh, git
+from tools.private.release.create_release_branch import cmd_create_release_branch
 from tools.private.release.prepare import cmd_prepare
 from tools.private.release.release_issue import (
+    RELEASE_TITLE_RE,
     parse_checklist_state,
     parse_metadata_line,
     update_task_in_body,
 )
 from tools.private.release.utils import (
-    _REPO_URL,
+    REPO_URL,
     determine_next_version,
     get_latest_rc_tag,
 )
-
-_RELEASE_TITLE_RE = re.compile(r"Release (\d+\.\d+\.\d+)", re.IGNORECASE)
 
 
 def _semver_type(value):
@@ -141,63 +141,6 @@ def cmd_complete_prepare(args):
     return 0
 
 
-def cmd_create_release_branch(args):
-    """Executes the create-release-branch subcommand."""
-    print(f"Evaluating branch creation for tracking issue #{args.issue}...")
-    body = gh.get_issue_body(args.issue)
-    state = parse_checklist_state(body)
-
-    if (
-        state["prepare_release"]["status"] != "done"
-        or not state["prepare_release"]["commit"]
-    ):
-        print(
-            "Error: Prepare Release task is not marked 'done' with a valid commit SHA."
-        )
-        return 1
-
-    if state["create_branch"]["checked"]:
-        print("Release branch has already been created and checked. Skipping.")
-        return 0
-
-    # Extract version from issue title
-    issue_title = gh.get_issue_title(args.issue)
-    version_match = _RELEASE_TITLE_RE.search(issue_title)
-    if not version_match:
-        print(f"Error: Could not parse version from issue title: {issue_title}")
-        return 1
-
-    version = version_match.group(1)
-    branch_version = ".".join(version.split(".")[:2])
-    branch_name = f"release/{branch_version}"
-
-    commit_sha = state["prepare_release"]["commit"]
-    print(f"Cutting branch {branch_name} from commit {commit_sha}...")
-
-    # Create and push branch
-    git.fetch("origin")
-    git.checkout(commit_sha)
-
-    if not git.branch_exists(branch_name):
-        git.checkout(branch_name, create_branch=True)
-    else:
-        git.checkout(branch_name)
-        git.merge(commit_sha, ff_only=True)
-
-    git.push("origin", branch_name)
-    print(f"Successfully pushed branch {branch_name}")
-
-    # Update tracking issue checklist
-    print("Updating tracking issue checklist...")
-    metadata = {"status": "done", "branch": branch_name, "commit": commit_sha[:8]}
-    updated_body = update_task_in_body(
-        body, "Create Release branch", checked=True, metadata=metadata
-    )
-    gh.update_issue_body(args.issue, updated_body)
-    print("Create Release branch task marked complete successfully!")
-    return 0
-
-
 def cmd_process_backports(args):
     """Executes the process-backports subcommand."""
     body = gh.get_issue_body(args.issue)
@@ -217,7 +160,7 @@ def cmd_process_backports(args):
 
     # Determine branch name from issue title
     issue_title = gh.get_issue_title(args.issue)
-    version_match = _RELEASE_TITLE_RE.search(issue_title)
+    version_match = RELEASE_TITLE_RE.search(issue_title)
     if not version_match:
         print(f"Error: Could not parse version from issue title: {issue_title}")
         return 1
@@ -348,7 +291,7 @@ def cmd_create_rc(args):
 
     # Resolve version and branch
     issue_title = gh.get_issue_title(args.issue)
-    version_match = _RELEASE_TITLE_RE.search(issue_title)
+    version_match = RELEASE_TITLE_RE.search(issue_title)
     if not version_match:
         print(f"Error: Could not parse version from issue title: {issue_title}")
         return 1
@@ -405,7 +348,7 @@ def cmd_create_rc(args):
     updated_body = update_task_in_body(body, task_name, checked=True, metadata=metadata)
     gh.update_issue_body(args.issue, updated_body)
 
-    tag_url = f"{_REPO_URL}/releases/tag/{next_rc}"
+    tag_url = f"{REPO_URL}/releases/tag/{next_rc}"
     bcr_search_url = f"https://github.com/bazelbuild/bazel-central-registry/pulls?q=is%3Apr+rules_python+{version}"
     comment_body = f"""🚀 **New Release Candidate Tagged!**
 
@@ -489,7 +432,7 @@ def cmd_promote_rc(args):
     print(f"Posting comment to tracking issue #{issue_num}...")
     import urllib.parse
 
-    release_url = f"{_REPO_URL}/releases/tag/{version}"
+    release_url = f"{REPO_URL}/releases/tag/{version}"
     bcr_query = f'is:pr ("bazel-contrib/rules_python" in:title) ("@{version}" in:title)'
     bcr_search_url = f"https://github.com/bazelbuild/bazel-central-registry/pulls?q={urllib.parse.quote(bcr_query)}"
     comment_body = (
@@ -575,6 +518,12 @@ def create_parser():
         type=int,
         required=True,
         help="The tracking issue number (required).",
+    )
+    create_branch_parser.add_argument(
+        "--remote",
+        type=str,
+        required=True,
+        help="The git remote to create the branch on (required).",
     )
 
     # Subcommand: process-backports

--- a/tools/private/release/release_issue.py
+++ b/tools/private/release/release_issue.py
@@ -2,6 +2,8 @@
 
 import re
 
+RELEASE_TITLE_RE = re.compile(r"Release (\d+\.\d+\.\d+)", re.IGNORECASE)
+
 
 def parse_metadata_line(line):
     """Parses a checklist line with optional | key=value metadata."""

--- a/tools/private/release/utils.py
+++ b/tools/private/release/utils.py
@@ -8,7 +8,7 @@ from packaging.version import parse as parse_version
 
 from tools.private.release import git
 
-_REPO_URL = "https://github.com/bazel-contrib/rules_python"
+REPO_URL = "https://github.com/bazel-contrib/rules_python"
 
 _EXCLUDE_PATTERNS = [
     "./.git/*",


### PR DESCRIPTION
- Add --remote flag to create-release-branch subcommand to support pushing to upstream locally and origin in GHA.
- Factor cmd_create_release_branch out of release.py into create_release_branch.py.
- Use branch_url instead of branch name in tracking issue metadata.
- Update release tracking template with manual editing and backporting instructions.