### PR TITLE
chore(release): refactor process-backports and various release tool fixes

### DIFF
--- a/tests/tools/private/release/release_test.py
+++ b/tests/tools/private/release/release_test.py
@@ -35,6 +35,7 @@ def _mock_git_and_gh(test_case):
     mock_git.branch_exists.return_value = False
     mock_git.tag_exists.return_value = False
     mock_gh.get_release_tracking_issue.side_effect = NoTrackingIssueError("Not found")
+    mock_gh.get_open_pr.return_value = None
 
 
 class TempDirTestCase(unittest.TestCase):
@@ -798,6 +799,100 @@ class CmdPrepareTest(TempDirTestCase):
         self.mock_git.fetch.assert_called_once()
         self.mock_gh.get_release_tracking_issue.assert_called_once_with("2.0.0")
         self.mock_git.add_modified_and_deleted.assert_not_called()
+
+    @patch("tools.private.release.prepare.changelog_news")
+    @patch("tools.private.release.prepare.replace_version_next")
+    def test_prepare_use_associated_pr_from_tracking_issue(
+        self, mock_replace, mock_changelog
+    ):
+        # Arrange
+        args = MagicMock(version="2.0.0", issue=None, dry_run=False)
+        self.mock_git.status.side_effect = ["", ""]
+        self.mock_git.branch_exists.return_value = True
+        self.mock_gh.get_release_tracking_issue.side_effect = None
+        self.mock_gh.get_release_tracking_issue.return_value = 123
+        self.mock_gh.get_open_pr.return_value = None
+        # PR #456 is already associated in the tracking issue
+        self.mock_gh.get_issue_body.return_value = (
+            "- [ ] Prepare Release | status=pending pr=#456"
+        )
+
+        # Act
+        result = releaser.cmd_prepare(args)
+
+        # Assert
+        self.assertEqual(result, 0)
+        self.mock_git.checkout.assert_called_once_with("prepare-2.0.0")
+        self.mock_git.commit.assert_not_called()
+        self.mock_git.push.assert_called_once_with(
+            "origin", "prepare-2.0.0", set_upstream=True
+        )
+        self.mock_gh.get_open_pr.assert_called_once_with("prepare-2.0.0")
+        self.mock_gh.create_pr.assert_not_called()  # Should NOT create a new PR
+        self.mock_gh.update_issue_body.assert_called_once()
+        call_args = self.mock_gh.update_issue_body.call_args[0]
+        self.assertIn("pr=#456", call_args[1])
+
+    @patch("tools.private.release.prepare.changelog_news")
+    @patch("tools.private.release.prepare.replace_version_next")
+    def test_prepare_create_pr_when_none_associated(self, mock_replace, mock_changelog):
+        # Arrange
+        args = MagicMock(version="2.0.0", issue=None, dry_run=False)
+        self.mock_git.status.side_effect = ["", ""]
+        self.mock_git.branch_exists.return_value = True
+        self.mock_gh.get_release_tracking_issue.side_effect = None
+        self.mock_gh.get_release_tracking_issue.return_value = 123
+        self.mock_gh.get_open_pr.return_value = None
+        # No PR associated in the tracking issue
+        self.mock_gh.get_issue_body.return_value = "- [ ] Prepare Release"
+        self.mock_gh.create_pr.return_value = "https://github.com/foo/bar/pull/789"
+
+        # Act
+        result = releaser.cmd_prepare(args)
+
+        # Assert
+        self.assertEqual(result, 0)
+        self.mock_git.checkout.assert_called_once_with("prepare-2.0.0")
+        self.mock_git.commit.assert_not_called()
+        self.mock_git.push.assert_called_once_with(
+            "origin", "prepare-2.0.0", set_upstream=True
+        )
+        self.mock_gh.get_open_pr.assert_called_once_with("prepare-2.0.0")
+        self.mock_gh.create_pr.assert_called_once_with("2.0.0", 123)
+        self.mock_gh.update_issue_body.assert_called_once()
+        call_args = self.mock_gh.update_issue_body.call_args[0]
+        self.assertIn("pr=#789", call_args[1])
+
+    @patch("tools.private.release.prepare.changelog_news")
+    @patch("tools.private.release.prepare.replace_version_next")
+    def test_prepare_reuse_existing_pr(self, mock_replace, mock_changelog):
+        # Arrange
+        args = MagicMock(version="2.0.0", issue=None, dry_run=False)
+        self.mock_git.status.side_effect = ["", ""]
+        self.mock_git.branch_exists.return_value = True
+        self.mock_gh.get_release_tracking_issue.side_effect = None
+        self.mock_gh.get_release_tracking_issue.return_value = 123
+        self.mock_gh.get_open_pr.return_value = {
+            "number": 456,
+            "url": "https://github.com/foo/bar/pull/456",
+        }
+        self.mock_gh.get_issue_body.return_value = "- [ ] Prepare Release"
+
+        # Act
+        result = releaser.cmd_prepare(args)
+
+        # Assert
+        self.assertEqual(result, 0)
+        self.mock_git.checkout.assert_called_once_with("prepare-2.0.0")
+        self.mock_git.commit.assert_not_called()
+        self.mock_git.push.assert_called_once_with(
+            "origin", "prepare-2.0.0", set_upstream=True
+        )
+        self.mock_gh.get_open_pr.assert_called_once_with("prepare-2.0.0")
+        self.mock_gh.create_pr.assert_not_called()
+        self.mock_gh.update_issue_body.assert_called_once()
+        call_args = self.mock_gh.update_issue_body.call_args[0]
+        self.assertIn("pr=#456", call_args[1])
 
     @patch("tools.private.release.prepare.changelog_news")
     @patch("tools.private.release.prepare.replace_version_next")

--- a/tests/tools/private/release/release_test.py
+++ b/tests/tools/private/release/release_test.py
@@ -1511,7 +1511,7 @@ class CmdProcessBackportsTest(unittest.TestCase):
         self.mock_git.checkout.assert_called_once_with(
             "release/2.0", track_remote="origin"
         )
-        self.mock_git.cherry_pick.assert_called_once_with("abcdef12", no_commit=False)
+        self.mock_git.cherry_pick.assert_called_once_with("abcdef12")
         self.mock_changelog_news.update_changelog.assert_called_once_with(
             "2.0.0", "2026-07-01"
         )
@@ -1552,6 +1552,7 @@ class CmdProcessBackportsTest(unittest.TestCase):
 
         self.mock_git.sort_commits_chronologically.return_value = ["abcdef12"]
         self.mock_git.get_commit_sha.return_value = "12345678"
+        self.mock_git.get_commit_message.return_value = 'Cherry-pick "fix bug"'
 
         result = releaser.cmd_process_backports(args)
 
@@ -1562,12 +1563,14 @@ class CmdProcessBackportsTest(unittest.TestCase):
         self.mock_git.checkout.assert_called_once_with(
             "release/2.0", track_remote="origin"
         )
-        self.mock_git.cherry_pick.assert_called_once_with("abcdef12", no_commit=True)
+        self.mock_git.cherry_pick.assert_called_once_with("abcdef12")
         self.mock_changelog_news.update_changelog.assert_called_once_with(
             "2.0.0", "2026-07-01"
         )
-        self.mock_git.reset_hard.assert_called_once_with("HEAD")
-        self.mock_git.commit.assert_not_called()
+        self.mock_git.commit.assert_called_once_with(
+            'Cherry-pick "fix bug"\n\nWork towards #123', amend=True
+        )
+        self.mock_git.reset_hard.assert_called_once_with("12345678")
         self.mock_git.push.assert_not_called()
         self.mock_gh.update_issue_body.assert_not_called()
 
@@ -1664,7 +1667,7 @@ class CmdProcessBackportsTest(unittest.TestCase):
         self.mock_git.checkout.assert_called_once_with(
             "release/2.0", track_remote="origin"
         )
-        self.mock_git.cherry_pick.assert_called_once_with("abcdef12", no_commit=False)
+        self.mock_git.cherry_pick.assert_called_once_with("abcdef12")
         self.mock_git.cherry_pick_abort.assert_called_once()
 
         self.mock_gh.update_issue_body.assert_called_once()

--- a/tests/tools/private/release/release_test.py
+++ b/tests/tools/private/release/release_test.py
@@ -1526,7 +1526,9 @@ class CmdProcessBackportsTest(unittest.TestCase):
         self.assertEqual(call_args[0], 123)
         self.assertIn("- [x] #124 | status=done rc=rc0 commit=12345678", call_args[1])
 
-    def test_process_backports_dry_run(self):
+    @patch("tools.private.release.process_backports.datetime")
+    def test_process_backports_dry_run(self, mock_datetime):
+        mock_datetime.date.today.return_value = datetime.date(2026, 7, 1)
         args = MagicMock(issue=123, remote="origin", dry_run=True)
         self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
         self.mock_gh.get_issue_body.return_value = """

--- a/tests/tools/private/release/release_test.py
+++ b/tests/tools/private/release/release_test.py
@@ -1462,7 +1462,9 @@ class CmdProcessBackportsTest(unittest.TestCase):
         self.mock_git.fetch.assert_has_calls(
             [call("origin", tags=True, force=True), call("origin")]
         )
-        self.mock_git.checkout.assert_called_once_with("release/2.0")
+        self.mock_git.checkout.assert_called_once_with(
+            "release/2.0", track_remote="origin"
+        )
         self.mock_git.cherry_pick.assert_called_once_with("abcdef12", no_commit=False)
         self.mock_changelog_news.update_changelog.assert_called_once_with(
             "2.0.0", "2026-07-01"
@@ -1507,7 +1509,9 @@ class CmdProcessBackportsTest(unittest.TestCase):
         self.mock_git.fetch.assert_has_calls(
             [call("origin", tags=True, force=True), call("origin")]
         )
-        self.mock_git.checkout.assert_called_once_with("release/2.0")
+        self.mock_git.checkout.assert_called_once_with(
+            "release/2.0", track_remote="origin"
+        )
         self.mock_git.cherry_pick.assert_called_once_with("abcdef12", no_commit=True)
         self.mock_changelog_news.update_changelog.assert_called_once_with(
             "2.0.0", "2026-07-01"
@@ -1607,7 +1611,9 @@ class CmdProcessBackportsTest(unittest.TestCase):
         result = releaser.cmd_process_backports(args)
 
         self.assertEqual(result, 1)
-        self.mock_git.checkout.assert_called_once_with("release/2.0")
+        self.mock_git.checkout.assert_called_once_with(
+            "release/2.0", track_remote="origin"
+        )
         self.mock_git.cherry_pick.assert_called_once_with("abcdef12", no_commit=False)
         self.mock_git.cherry_pick_abort.assert_called_once()
 

--- a/tests/tools/private/release/release_test.py
+++ b/tests/tools/private/release/release_test.py
@@ -6,7 +6,7 @@ import tempfile
 import unittest
 from unittest.mock import MagicMock, call, patch
 
-from tools.private.release import changelog_news, release as releaser, utils
+from tools.private.release import changelog_news, git, release as releaser, utils
 from tools.private.release.gh import MultipleTrackingIssuesError, NoTrackingIssueError
 
 
@@ -1674,6 +1674,43 @@ class CmdProcessBackportsTest(unittest.TestCase):
 
         self.mock_git.commit.assert_not_called()
         self.mock_git.push.assert_not_called()
+
+
+class GitCheckoutTest(unittest.TestCase):
+    @patch("tools.private.release.git.run_cmd")
+    def test_checkout_simple(self, mock_run_cmd):
+        git.checkout("my-branch")
+        mock_run_cmd.assert_called_once_with(
+            "git", "checkout", "my-branch", capture_output=False
+        )
+
+    @patch("tools.private.release.git.branch_exists")
+    @patch("tools.private.release.git.run_cmd")
+    def test_checkout_track_remote_new_branch(self, mock_run_cmd, mock_branch_exists):
+        mock_branch_exists.return_value = False
+
+        git.checkout("my-branch", track_remote="origin")
+
+        mock_branch_exists.assert_called_once_with("my-branch")
+        mock_run_cmd.assert_called_once_with(
+            "git", "checkout", "--track", "origin/my-branch", capture_output=False
+        )
+
+    @patch("tools.private.release.git.reset_hard")
+    @patch("tools.private.release.git.branch_exists")
+    @patch("tools.private.release.git.run_cmd")
+    def test_checkout_track_remote_existing_branch(
+        self, mock_run_cmd, mock_branch_exists, mock_reset_hard
+    ):
+        mock_branch_exists.return_value = True
+
+        git.checkout("my-branch", track_remote="origin")
+
+        mock_branch_exists.assert_called_once_with("my-branch")
+        mock_run_cmd.assert_called_once_with(
+            "git", "checkout", "my-branch", capture_output=False
+        )
+        mock_reset_hard.assert_called_once_with("origin/my-branch")
 
 
 if __name__ == "__main__":

--- a/tests/tools/private/release/release_test.py
+++ b/tests/tools/private/release/release_test.py
@@ -1455,6 +1455,7 @@ class CmdProcessBackportsTest(unittest.TestCase):
 
         self.mock_git.sort_commits_chronologically.return_value = ["abcdef12"]
         self.mock_git.get_commit_sha.return_value = "12345678"
+        self.mock_git.get_commit_message.return_value = 'Cherry-pick "fix bug"'
 
         result = releaser.cmd_process_backports(args)
 
@@ -1470,7 +1471,9 @@ class CmdProcessBackportsTest(unittest.TestCase):
             "2.0.0", "2026-07-01"
         )
         self.mock_git.add.assert_called_once_with("CHANGELOG.md", "news/")
-        self.mock_git.commit.assert_called_once_with("", amend=True, no_edit=True)
+        self.mock_git.commit.assert_called_once_with(
+            'Cherry-pick "fix bug"\n\nWork towards #123', amend=True
+        )
         self.mock_git.push.assert_called_once_with("origin", "release/2.0")
 
         self.mock_gh.update_issue_body.assert_called_once()

--- a/tests/tools/private/release/release_test.py
+++ b/tests/tools/private/release/release_test.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import pathlib
 import shutil
@@ -20,12 +21,14 @@ def _mock_git_and_gh(test_case):
     patch("tools.private.release.prepare.git", new=mock_git).start()
     patch("tools.private.release.create_release_branch.git", new=mock_git).start()
     patch("tools.private.release.create_rc.git", new=mock_git).start()
+    patch("tools.private.release.process_backports.git", new=mock_git).start()
     patch("tools.private.release.utils.git", new=mock_git).start()
 
     patch("tools.private.release.release.gh", new=mock_gh).start()
     patch("tools.private.release.prepare.gh", new=mock_gh).start()
     patch("tools.private.release.create_release_branch.gh", new=mock_gh).start()
     patch("tools.private.release.create_rc.gh", new=mock_gh).start()
+    patch("tools.private.release.process_backports.gh", new=mock_gh).start()
     mock_gh.MultipleTrackingIssuesError = MultipleTrackingIssuesError
     mock_gh.NoTrackingIssueError = NoTrackingIssueError
 
@@ -984,7 +987,19 @@ class CmdCreateRcTest(unittest.TestCase):
             comment_call_args[1],
         )
         self.assertIn(
-            "- Trigger Release Workflow: [Release Workflow](https://github.com/bazel-contrib/rules_python/actions/workflows/release.yml)",
+            "- [Github Release 2.0.0-rc0](https://github.com/bazel-contrib/rules_python/releases/tag/2.0.0-rc0)",
+            comment_call_args[1],
+        )
+        self.assertIn(
+            "- BCR Entry: [rules_python@2.0.0](https://registry.bazel.build/modules/rules_python/2.0.0)",
+            comment_call_args[1],
+        )
+        self.assertIn(
+            "- [BCR PRs](https://github.com/bazelbuild/bazel-central-registry/pulls?q=is%3Apr+rules_python+2.0.0)",
+            comment_call_args[1],
+        )
+        self.assertIn(
+            "- [Release workflow status](https://github.com/bazel-contrib/rules_python/actions/workflows/release.yml)",
             comment_call_args[1],
         )
         self.assertNotIn("🚀", comment_call_args[1])
@@ -1029,7 +1044,19 @@ class CmdCreateRcTest(unittest.TestCase):
             comment_call_args[1],
         )
         self.assertIn(
-            "- Trigger Release Workflow: [Release Workflow](https://github.com/bazel-contrib/rules_python/actions/workflows/release.yml)",
+            "- [Github Release 2.0.0-rc1](https://github.com/bazel-contrib/rules_python/releases/tag/2.0.0-rc1)",
+            comment_call_args[1],
+        )
+        self.assertIn(
+            "- BCR Entry: [rules_python@2.0.0](https://registry.bazel.build/modules/rules_python/2.0.0)",
+            comment_call_args[1],
+        )
+        self.assertIn(
+            "- [BCR PRs](https://github.com/bazelbuild/bazel-central-registry/pulls?q=is%3Apr+rules_python+2.0.0)",
+            comment_call_args[1],
+        )
+        self.assertIn(
+            "- [Release workflow status](https://github.com/bazel-contrib/rules_python/actions/workflows/release.yml)",
             comment_call_args[1],
         )
         self.assertNotIn("🚀", comment_call_args[1])
@@ -1382,6 +1409,215 @@ class CmdCreateReleaseBranchTest(unittest.TestCase):
         self.mock_git.fetch.assert_called_once_with("my-remote")
         self.mock_git.push.assert_not_called()
         self.mock_gh.update_issue_body.assert_not_called()
+
+
+class CmdProcessBackportsTest(unittest.TestCase):
+    def setUp(self):
+        _mock_git_and_gh(self)
+        self.mock_changelog_news = patch(
+            "tools.private.release.process_backports.changelog_news"
+        ).start()
+        self.addCleanup(patch.stopall)
+
+    def test_process_backports_no_pending(self):
+        args = MagicMock(issue=123, remote="origin", dry_run=False)
+        self.mock_gh.get_issue_body.return_value = "No backports here"
+
+        result = releaser.cmd_process_backports(args)
+
+        self.assertEqual(result, 0)
+        self.mock_gh.get_issue_body.assert_called_once_with(123)
+        self.mock_git.fetch.assert_not_called()
+
+    @patch("tools.private.release.process_backports.datetime")
+    def test_process_backports_success(self, mock_datetime):
+        mock_datetime.date.today.return_value = datetime.date(2026, 7, 1)
+        args = MagicMock(issue=123, remote="origin", dry_run=False)
+        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
+        self.mock_gh.get_issue_body.return_value = """
+## Checklist
+- [ ] Prepare Release
+- [ ] Create Release branch
+
+## Backports
+- [ ] #124 | status=pending
+"""
+        self.mock_git.get_remote_tags.return_value = []
+
+        def mock_resolve(items):
+            for item in items:
+                if item.pr_ref == "#124":
+                    item.commit = "abcdef12"
+                    item.status = "done"
+            return items
+
+        self.mock_gh.get_merge_commits_for_prs.side_effect = mock_resolve
+
+        self.mock_git.sort_commits_chronologically.return_value = ["abcdef12"]
+        self.mock_git.get_commit_sha.return_value = "12345678"
+
+        result = releaser.cmd_process_backports(args)
+
+        self.assertEqual(result, 0)
+        self.mock_git.fetch.assert_has_calls(
+            [call("origin", tags=True, force=True), call("origin")]
+        )
+        self.mock_git.checkout.assert_called_once_with("release/2.0")
+        self.mock_git.cherry_pick.assert_called_once_with("abcdef12", no_commit=False)
+        self.mock_changelog_news.update_changelog.assert_called_once_with(
+            "2.0.0", "2026-07-01"
+        )
+        self.mock_git.add.assert_called_once_with("CHANGELOG.md", "news/")
+        self.mock_git.commit.assert_called_once_with("", amend=True, no_edit=True)
+        self.mock_git.push.assert_called_once_with("origin", "release/2.0")
+
+        self.mock_gh.update_issue_body.assert_called_once()
+        call_args = self.mock_gh.update_issue_body.call_args[0]
+        self.assertEqual(call_args[0], 123)
+        self.assertIn("- [x] #124 | status=done rc=rc0 commit=12345678", call_args[1])
+
+    def test_process_backports_dry_run(self):
+        args = MagicMock(issue=123, remote="origin", dry_run=True)
+        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
+        self.mock_gh.get_issue_body.return_value = """
+## Checklist
+- [ ] Prepare Release
+- [ ] Create Release branch
+
+## Backports
+- [ ] #124 | status=pending
+"""
+        self.mock_git.get_remote_tags.return_value = []
+
+        def mock_resolve(items):
+            for item in items:
+                if item.pr_ref == "#124":
+                    item.commit = "abcdef12"
+                    item.status = "done"
+            return items
+
+        self.mock_gh.get_merge_commits_for_prs.side_effect = mock_resolve
+
+        self.mock_git.sort_commits_chronologically.return_value = ["abcdef12"]
+        self.mock_git.get_commit_sha.return_value = "12345678"
+
+        result = releaser.cmd_process_backports(args)
+
+        self.assertEqual(result, 0)
+        self.mock_git.fetch.assert_has_calls(
+            [call("origin", tags=True, force=True), call("origin")]
+        )
+        self.mock_git.checkout.assert_called_once_with("release/2.0")
+        self.mock_git.cherry_pick.assert_called_once_with("abcdef12", no_commit=True)
+        self.mock_changelog_news.update_changelog.assert_called_once_with(
+            "2.0.0", "2026-07-01"
+        )
+        self.mock_git.reset_hard.assert_called_once_with("HEAD")
+        self.mock_git.commit.assert_not_called()
+        self.mock_git.push.assert_not_called()
+        self.mock_gh.update_issue_body.assert_not_called()
+
+    def test_process_backports_ignored_and_failed_states(self):
+        args = MagicMock(issue=123, remote="origin", dry_run=False)
+        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
+        self.mock_gh.get_issue_body.return_value = """
+## Checklist
+- [ ] Prepare Release
+- [ ] Create Release branch
+
+## Backports
+- [ ] #124 | status=pending
+- [ ] #125 | status=pending
+- [ ] #126 | status=pending
+"""
+        self.mock_git.get_remote_tags.return_value = []
+
+        def mock_resolve(items):
+            for item in items:
+                if item.pr_ref == "#124":
+                    item.status = "open-pr"
+                elif item.pr_ref == "#125":
+                    item.status = "draft-pr"
+                elif item.pr_ref == "#126":
+                    item.status = "error-closed-pr"
+            return items
+
+        self.mock_gh.get_merge_commits_for_prs.side_effect = mock_resolve
+
+        result = releaser.cmd_process_backports(args)
+
+        self.assertEqual(result, 1)
+        self.mock_gh.update_issue_body.assert_called_once()
+        call_args = self.mock_gh.update_issue_body.call_args[0]
+        self.assertEqual(call_args[0], 123)
+        self.assertIn("- [ ] #126 | status=error-closed-pr", call_args[1])
+        self.assertNotIn("status=open-pr", call_args[1])
+        self.assertNotIn("status=draft-pr", call_args[1])
+        self.mock_git.checkout.assert_not_called()
+        self.mock_git.cherry_pick.assert_not_called()
+
+    def test_process_backports_ignored_error_status(self):
+        args = MagicMock(issue=123, remote="origin", dry_run=False)
+        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
+        self.mock_gh.get_issue_body.return_value = """
+## Checklist
+- [ ] Prepare Release
+- [ ] Create Release branch
+
+## Backports
+- [ ] #124 | status=error-merge-conflict
+- [ ] #125 | status=error-some-other-error
+"""
+        self.mock_git.get_remote_tags.return_value = []
+        self.mock_gh.get_merge_commits_for_prs.return_value = []
+
+        result = releaser.cmd_process_backports(args)
+
+        self.assertEqual(result, 0)
+        self.mock_gh.get_merge_commits_for_prs.assert_not_called()
+        self.mock_git.checkout.assert_not_called()
+
+    @patch("tools.private.release.process_backports.datetime")
+    def test_process_backports_cherry_pick_failed(self, mock_datetime):
+        mock_datetime.date.today.return_value = datetime.date(2026, 7, 1)
+        args = MagicMock(issue=123, remote="origin", dry_run=False)
+        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
+        self.mock_gh.get_issue_body.return_value = """
+## Checklist
+- [ ] Prepare Release
+- [ ] Create Release branch
+
+## Backports
+- [ ] #124 | status=pending
+"""
+        self.mock_git.get_remote_tags.return_value = []
+
+        def mock_resolve(items):
+            for item in items:
+                if item.pr_ref == "#124":
+                    item.commit = "abcdef12"
+                    item.status = "done"
+            return items
+
+        self.mock_gh.get_merge_commits_for_prs.side_effect = mock_resolve
+
+        self.mock_git.sort_commits_chronologically.return_value = ["abcdef12"]
+        self.mock_git.cherry_pick.side_effect = Exception("Cherry-pick conflict")
+
+        result = releaser.cmd_process_backports(args)
+
+        self.assertEqual(result, 1)
+        self.mock_git.checkout.assert_called_once_with("release/2.0")
+        self.mock_git.cherry_pick.assert_called_once_with("abcdef12", no_commit=False)
+        self.mock_git.cherry_pick_abort.assert_called_once()
+
+        self.mock_gh.update_issue_body.assert_called_once()
+        call_args = self.mock_gh.update_issue_body.call_args[0]
+        self.assertEqual(call_args[0], 123)
+        self.assertIn("- [ ] #124 | status=error-merge-conflict", call_args[1])
+
+        self.mock_git.commit.assert_not_called()
+        self.mock_git.push.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/tools/private/release/release_test.py
+++ b/tests/tools/private/release/release_test.py
@@ -1061,6 +1061,51 @@ class CmdCreateRcTest(unittest.TestCase):
         )
         self.assertNotIn("🚀", comment_call_args[1])
 
+    def test_create_rc_gating_on_backports(self):
+        # Arrange
+        args = MagicMock(issue=123, remote="my-remote")
+        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
+        self.mock_gh.get_issue_body.return_value = """
+## Checklist
+- [x] Prepare Release | status=done pr=#122 commit=abcdef12
+- [x] Create Release branch | status=done branch=release/2.0 commit=abcdef12
+- [ ] Tag RC0 | status=pending
+
+## Backports
+- [ ] #124 | status=pending
+"""
+        # Act
+        result = releaser.cmd_create_rc(args)
+
+        # Assert
+        self.assertEqual(result, 1)
+        self.mock_git.tag.assert_not_called()
+        self.mock_git.push.assert_not_called()
+
+    def test_create_rc_with_finished_backports(self):
+        # Arrange
+        args = MagicMock(issue=123, remote="my-remote")
+        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
+        self.mock_gh.get_issue_body.return_value = """
+## Checklist
+- [x] Prepare Release | status=done pr=#122 commit=abcdef12
+- [x] Create Release branch | status=done branch=release/2.0 commit=abcdef12
+- [ ] Tag RC0 | status=pending
+
+## Backports
+- [x] #124 | status=done rc=rc0 commit=abcdef12
+"""
+        self.mock_git.get_remote_tags.return_value = []
+        self.mock_git.get_commit_sha.return_value = "1234567890"
+
+        # Act
+        result = releaser.cmd_create_rc(args)
+
+        # Assert
+        self.assertEqual(result, 0)
+        self.mock_git.tag.assert_called_once_with("2.0.0-rc0", "my-remote/release/2.0")
+        self.mock_git.push.assert_called_once_with("my-remote", "2.0.0-rc0")
+
 
 class CmdPromoteRcTest(unittest.TestCase):
     def setUp(self):

--- a/tools/private/release/BUILD.bazel
+++ b/tools/private/release/BUILD.bazel
@@ -15,6 +15,7 @@ py_binary(
         "gh.py",
         "git.py",
         "prepare.py",
+        "process_backports.py",
         "release.py",
         "release_issue.py",
         "shell.py",

--- a/tools/private/release/create_rc.py
+++ b/tools/private/release/create_rc.py
@@ -94,15 +94,17 @@ def cmd_create_rc(args):
     gh.update_issue_body(args.issue, updated_body)
 
     tag_url = f"{REPO_URL}/releases/tag/{next_rc}"
+    bcr_entry_url = f"https://registry.bazel.build/modules/rules_python/{version}"
     bcr_search_url = f"https://github.com/bazelbuild/bazel-central-registry/pulls?q=is%3Apr+rules_python+{version}"
     release_workflow_url = f"{REPO_URL}/actions/workflows/release.yml"
     comment_body = f"""**New Release Candidate Tagged!** 🐍🌿
 
 Release Candidate **{next_rc}** has been successfully generated and tagged on branch `{branch_name}`.
 
-- View Tag: [{next_rc}]({tag_url})
-- Track BCR Progress: [Search BCR Pull Requests]({bcr_search_url})
-- Trigger Release Workflow: [Release Workflow]({release_workflow_url})"""
+- [Github Release {next_rc}]({tag_url})
+- BCR Entry: [rules_python@{version}]({bcr_entry_url})
+- [BCR PRs]({bcr_search_url})
+- [Release workflow status]({release_workflow_url})"""
     gh.post_issue_comment(args.issue, comment_body)
     print("RC creation completed successfully!")
     return 0

--- a/tools/private/release/create_rc.py
+++ b/tools/private/release/create_rc.py
@@ -30,7 +30,7 @@ def cmd_create_rc(args):
     # Gating: RC tagging is blocked if any backport is unchecked OR does not have status=done
     backports = parse_backports(body)
     conflicting_or_pending = [
-        b for b in backports if not b["checked"] or b["status"] != "done"
+        b for b in backports if not b.checked or b.status != "done"
     ]
     if conflicting_or_pending:
         print(

--- a/tools/private/release/gh.py
+++ b/tools/private/release/gh.py
@@ -4,6 +4,7 @@ import json
 import os
 import tempfile
 
+from tools.private.release.release_issue import BackportTask
 from tools.private.release.shell import run_cmd
 
 _REPO = "bazel-contrib/rules_python"
@@ -179,13 +180,13 @@ def get_open_pr(branch_name):
 
 
 def get_pr_info(pr_num):
-    """Gets information about a PR, including state, merge commit, and body."""
+    """Gets information about a PR, including state, merge commit, body, and draft status."""
     output = run_cmd(
         "gh",
         "pr",
         "view",
         str(pr_num),
-        "--json=state,mergeCommit,body",
+        "--json=state,mergeCommit,body,isDraft",
     )
     return json.loads(output) if output else {}
 
@@ -202,30 +203,44 @@ def post_issue_comment(issue_num, comment_body):
     )
 
 
-def resolve_backport_commits(pending_items):
+def get_merge_commits_for_prs(pending_items: list[BackportTask]) -> list[BackportTask]:
     """Resolves PR references in pending backports to their merge commit SHAs.
 
-    Marks unmerged PRs or resolution failures with status='unmerged-pr'.
+    Updates item.status based on PR state if it cannot be resolved.
     """
     resolved_items = []
     for item in pending_items:
-        pr_num = item["pr_ref"].lstrip("#")
+        pr_num = item.pr_ref.lstrip("#")
         print(f"Resolving PR #{pr_num} to merge commit...")
         try:
             pr_info = get_pr_info(pr_num)
-            if not pr_info or pr_info.get("state") != "MERGED":
-                state = pr_info.get("state", "UNKNOWN")
-                print(f"PR #{pr_num} is not merged (state: {state}). Gating.")
-                item["status"] = "unmerged-pr"
+            if not pr_info:
+                print(f"PR #{pr_num} not found. Gating.")
+                item.status = "error-not-found"
             else:
-                merge_commit = pr_info.get("mergeCommit")
-                if merge_commit and "oid" in merge_commit:
-                    item["commit"] = merge_commit["oid"]
+                state = pr_info.get("state")
+                is_draft = pr_info.get("isDraft", False)
+                if state == "OPEN" or is_draft:
+                    print(
+                        f"PR #{pr_num} is open or draft (state: {state}, draft: {is_draft}). Ignoring."
+                    )
+                    item.status = "open-pr" if not is_draft else "draft-pr"
+                elif state == "CLOSED":
+                    print(f"PR #{pr_num} is closed but not merged. Gating.")
+                    item.status = "error-closed-pr"
+                elif state == "MERGED":
+                    merge_commit = pr_info.get("mergeCommit")
+                    if merge_commit and "oid" in merge_commit:
+                        item.commit = merge_commit["oid"]
+                        item.status = "resolved"
+                    else:
+                        print(f"PR #{pr_num} has no merge commit SHA. Gating.")
+                        item.status = "error-no-merge-commit"
                 else:
-                    print(f"PR #{pr_num} has no merge commit SHA. Gating.")
-                    item["status"] = "unmerged-pr"
+                    print(f"PR #{pr_num} has unknown state: {state}. Gating.")
+                    item.status = "error-unknown"
         except Exception as e:
             print(f"Error resolving PR #{pr_num}: {e}. Gating.")
-            item["status"] = "unmerged-pr"
+            item.status = "error-resolution-failed"
         resolved_items.append(item)
     return resolved_items

--- a/tools/private/release/gh.py
+++ b/tools/private/release/gh.py
@@ -162,6 +162,22 @@ def create_pr(version, issue_num):
     )
 
 
+def get_open_pr(branch_name):
+    """Returns PR info if an open PR exists for the given branch, else None."""
+    cmd = [
+        "gh",
+        "pr",
+        "list",
+        f"--repo={_REPO}",
+        f"--head={branch_name}",
+        "--state=open",
+        "--json=number,url",
+    ]
+    output = run_cmd(*cmd)
+    prs = json.loads(output) if output else []
+    return prs[0] if prs else None
+
+
 def get_pr_info(pr_num):
     """Gets information about a PR, including state, merge commit, and body."""
     output = run_cmd(

--- a/tools/private/release/git.py
+++ b/tools/private/release/git.py
@@ -11,12 +11,28 @@ def get_tags():
     return output.splitlines() if output else []
 
 
-def checkout(ref, create_branch=False):
-    """Checks out a git reference (tag, branch, or commit)."""
+def checkout(
+    ref: str, create_branch: bool = False, track_remote: str | None = None
+) -> None:
+    """Checks out a git reference (tag, branch, or commit).
+
+    Args:
+        ref: The git reference (tag, branch, or commit) to checkout.
+        create_branch: If True, creates the branch before checking it out.
+        track_remote: If specified, checks out the branch tracking this remote's
+            corresponding branch.
+    """
+    cmd = ["git", "checkout"]
     if create_branch:
-        run_cmd("git", "checkout", "-b", ref, capture_output=False)
+        cmd.append("-b")
+    if track_remote:
+        if branch_exists(ref):
+            cmd.append(ref)
+        else:
+            cmd.extend(["--track", f"{track_remote}/{ref}"])
     else:
-        run_cmd("git", "checkout", ref, capture_output=False)
+        cmd.append(ref)
+    run_cmd(*cmd, capture_output=False)
 
 
 def add(*files):

--- a/tools/private/release/git.py
+++ b/tools/private/release/git.py
@@ -134,6 +134,15 @@ def get_commit_sha(ref="HEAD", short=False):
     return run_cmd(*cmd)
 
 
+def get_commit_message(ref: str = "HEAD") -> str:
+    """Returns the commit message of a given reference.
+
+    Args:
+        ref: The git reference to get the message from. Defaults to 'HEAD'.
+    """
+    return run_cmd("git", "log", "-1", "--format=%B", ref)
+
+
 def branch_exists(branch_name):
     """Returns True if a local branch exists."""
     try:

--- a/tools/private/release/git.py
+++ b/tools/private/release/git.py
@@ -97,19 +97,13 @@ def tag(tag_name, commit_ref):
     run_cmd("git", "tag", tag_name, commit_ref, capture_output=False)
 
 
-def cherry_pick(sha: str, no_commit: bool = False) -> None:
+def cherry_pick(sha: str) -> None:
     """Cherry-picks a commit.
 
     Args:
         sha: The commit SHA to cherry-pick.
-        no_commit: If True, applies the changes to working tree and index
-            but does not create a commit.
     """
-    cmd = ["git", "cherry-pick", "-x"]
-    if no_commit:
-        cmd.append("--no-commit")
-    cmd.append(sha)
-    run_cmd(*cmd, capture_output=False)
+    run_cmd("git", "cherry-pick", "-x", sha, capture_output=False)
 
 
 def cherry_pick_abort():

--- a/tools/private/release/git.py
+++ b/tools/private/release/git.py
@@ -75,14 +75,33 @@ def tag(tag_name, commit_ref):
     run_cmd("git", "tag", tag_name, commit_ref, capture_output=False)
 
 
-def cherry_pick(sha):
-    """Cherry-picks a commit using -x to append the original commit info."""
-    run_cmd("git", "cherry-pick", "-x", sha, capture_output=False)
+def cherry_pick(sha: str, no_commit: bool = False) -> None:
+    """Cherry-picks a commit.
+
+    Args:
+        sha: The commit SHA to cherry-pick.
+        no_commit: If True, applies the changes to working tree and index
+            but does not create a commit.
+    """
+    cmd = ["git", "cherry-pick", "-x"]
+    if no_commit:
+        cmd.append("--no-commit")
+    cmd.append(sha)
+    run_cmd(*cmd, capture_output=False)
 
 
 def cherry_pick_abort():
     """Aborts an in-progress cherry-pick operation."""
     run_cmd("git", "cherry-pick", "--abort", capture_output=False)
+
+
+def reset_hard(ref: str = "HEAD") -> None:
+    """Resets the index and working tree to a specific reference.
+
+    Args:
+        ref: The git reference to reset to. Defaults to 'HEAD'.
+    """
+    run_cmd("git", "reset", "--hard", ref, capture_output=False)
 
 
 def status():

--- a/tools/private/release/git.py
+++ b/tools/private/release/git.py
@@ -25,14 +25,20 @@ def checkout(
     cmd = ["git", "checkout"]
     if create_branch:
         cmd.append("-b")
+
+    should_reset_hard = False
     if track_remote:
         if branch_exists(ref):
             cmd.append(ref)
+            should_reset_hard = True
         else:
             cmd.extend(["--track", f"{track_remote}/{ref}"])
     else:
         cmd.append(ref)
     run_cmd(*cmd, capture_output=False)
+
+    if should_reset_hard:
+        reset_hard(f"{track_remote}/{ref}")
 
 
 def add(*files):

--- a/tools/private/release/prepare.py
+++ b/tools/private/release/prepare.py
@@ -2,7 +2,10 @@ import datetime
 import pathlib
 
 from tools.private.release import changelog_news, gh, git
-from tools.private.release.release_issue import update_task_in_body
+from tools.private.release.release_issue import (
+    parse_checklist_state,
+    update_task_in_body,
+)
 from tools.private.release.utils import (
     determine_next_version,
     replace_version_next,
@@ -102,26 +105,47 @@ def cmd_prepare(args):
         print(f"[DRY RUN] Would push branch {branch_name} to origin")
     else:
         modified_files = git.status()
-        if not modified_files:
+        if modified_files:
+            # Stage all modified and deleted tracked files
+            git.add_modified_and_deleted()
+            git.commit(f"Prepare release {version}")
+        else:
             print("No files modified by the release tool. Nothing to commit.")
-            return 0
 
-        # Stage all modified and deleted tracked files
-        git.add_modified_and_deleted()
-
-        git.commit(f"Prepare release {version}")
+        print(f"Pushing branch {branch_name} to origin...")
         git.push("origin", branch_name, set_upstream=True)
 
     # --- Create PR ---
-    if args.dry_run:
-        target_issue = f"#{issue_num}" if issue_num else "<NEW_ISSUE>"
+    # Determine if we need to create a PR or reuse an existing one
+    open_pr = gh.get_open_pr(branch_name)
+    associated_pr = None
+
+    if not open_pr and issue_num:
+        body = gh.get_issue_body(issue_num)
+        state = parse_checklist_state(body)
+        associated_pr = state["prepare_release"]["pr"]
+
+    if open_pr:
+        pr_num = open_pr["number"]
+        pr_url = open_pr["url"]
+        print(f"Open Pull Request already exists: {pr_url} (PR #{pr_num})")
+    elif associated_pr:
+        pr_num = associated_pr.lstrip("#")
+        pr_url = f"https://github.com/bazel-contrib/rules_python/pull/{pr_num}"
         print(
-            f"[DRY RUN] Would create Pull Request for branch {branch_name} targeting issue {target_issue}"
+            f"PR #{pr_num} is already associated in tracking issue #{issue_num}. Using it."
         )
     else:
-        pr_url = gh.create_pr(version, issue_num)
-        pr_num = pr_url.split("/")[-1]
-        print(f"Created Pull Request: {pr_url} (PR #{pr_num})")
+        if args.dry_run:
+            target_issue = f"#{issue_num}" if issue_num else "<NEW_ISSUE>"
+            print(
+                f"[DRY RUN] Would create Pull Request for branch {branch_name} targeting issue {target_issue}"
+            )
+            pr_num = "<NEW_PR>"
+        else:
+            pr_url = gh.create_pr(version, issue_num)
+            pr_num = pr_url.split("/")[-1]
+            print(f"Created Pull Request: {pr_url} (PR #{pr_num})")
 
     # --- Update checklist ---
     if args.dry_run:

--- a/tools/private/release/process_backports.py
+++ b/tools/private/release/process_backports.py
@@ -1,6 +1,7 @@
 """Subcommand to process pending backports."""
 
 import datetime
+from typing import Any
 
 from tools.private.release import changelog_news, gh, git
 from tools.private.release.release_issue import (
@@ -9,6 +10,141 @@ from tools.private.release.release_issue import (
     update_task_in_body,
 )
 from tools.private.release.utils import get_latest_rc_tag
+
+
+def _process_pr_commit_infos(
+    pr_commit_infos, body, issue, dry_run
+) -> tuple[list[str], dict[str, Any], list[str], list[str], str]:
+    shas = []
+    sha_to_item = {}
+    failed_prs = []
+    ignored_prs = []
+    for item in pr_commit_infos:
+        if item.commit:
+            sha = item.commit
+            sha_to_item[sha] = item
+            shas.append(sha)
+        elif item.status in ("open-pr", "draft-pr"):
+            print(f"PR {item.pr_ref} is open or draft. Ignoring.")
+            ignored_prs.append(item.pr_ref)
+        else:
+            failed_prs.append(item.pr_ref)
+            status_to_set = item.status or "error-unmerged-pr"
+            if dry_run:
+                print(
+                    f"[DRY RUN] Would update tracking issue checklist for unresolved PR {item.pr_ref} to status={status_to_set}"
+                )
+            else:
+                print(
+                    f"Updating tracking issue checklist for unresolved PR {item.pr_ref}..."
+                )
+                try:
+                    body = update_task_in_body(
+                        body,
+                        item.pr_ref,
+                        checked=False,
+                        metadata={"status": status_to_set},
+                    )
+                    gh.update_issue_body(issue, body)
+                except Exception as e:
+                    print(
+                        f"ERROR: Failed to update tracking issue for unresolved PR {item.pr_ref}: {e}"
+                    )
+    return shas, sha_to_item, failed_prs, ignored_prs, body
+
+
+def _cherry_pick_and_update_prs(
+    sorted_shas,
+    sha_to_item,
+    body,
+    issue,
+    remote,
+    dry_run,
+    version,
+    branch_name,
+    next_rc_suffix,
+) -> tuple[list[str], str]:
+    failed_prs = []
+    for sha in sorted_shas:
+        item = sha_to_item[sha]
+        print(f"Cherry-picking {item.pr_ref} / {sha}...")
+        try:
+            git.cherry_pick(sha, no_commit=dry_run)
+
+            # Perform news processing (merging news/ files into the changelog)
+            print(f"Merging news fragments into changelog for PR {item.pr_ref}...")
+            release_date = datetime.date.today().strftime("%Y-%m-%d")
+            changelog_news.update_changelog(version, release_date)
+
+            if not dry_run:
+                # Stage changelog changes and news/ deletions
+                git.add("CHANGELOG.md", "news/")
+
+                # Amend cherry-pick commit to include news merging and deletions,
+                # and reference the release tracking issue.
+                print(f"Amending cherry-pick commit for PR {item.pr_ref}...")
+                current_msg = git.get_commit_message("HEAD")
+                new_msg = f"{current_msg.strip()}\n\nWork towards #{issue}"
+                git.commit(new_msg, amend=True)
+
+                # Push amended commit
+                git.push(remote, branch_name)
+
+                new_sha = git.get_commit_sha("HEAD", short=True)
+                metadata = {"status": "done", "rc": next_rc_suffix, "commit": new_sha}
+                print(f"Updating tracking issue checklist for PR {item.pr_ref}...")
+                try:
+                    body = update_task_in_body(
+                        body, item.pr_ref, checked=True, metadata=metadata
+                    )
+                    gh.update_issue_body(issue, body)
+                except Exception as e:
+                    print(
+                        f"ERROR: Failed to update tracking issue for PR {item.pr_ref}: {e}"
+                    )
+                print(f"Success: backported {item.pr_ref} / {sha} to {branch_name}")
+            else:
+                print(
+                    f"[DRY RUN] Success: {item.pr_ref} / {sha} can be backported without error."
+                )
+                print(
+                    f"[DRY RUN] Would update tracking issue checklist for PR {item.pr_ref} to status=done"
+                )
+        except Exception as e:
+            print(f"ERROR: Conflict or error on {sha}: {e}. Aborting.")
+            try:
+                git.cherry_pick_abort()
+            except Exception:
+                pass
+            failed_prs.append(item.pr_ref)
+
+            if dry_run:
+                print(
+                    f"[DRY RUN] Would update tracking issue checklist for failed PR {item.pr_ref} to status=error-merge-conflict"
+                )
+            else:
+                print(
+                    f"Updating tracking issue checklist for failed PR {item.pr_ref}..."
+                )
+                try:
+                    body = update_task_in_body(
+                        body,
+                        item.pr_ref,
+                        checked=False,
+                        metadata={"status": "error-merge-conflict"},
+                    )
+                    gh.update_issue_body(issue, body)
+                    print(
+                        f"Updated back port of {item.pr_ref} to status=error-merge-conflict (unchecked)"
+                    )
+                except Exception as e:
+                    print(
+                        f"ERROR: Failed to update tracking issue for failed PR {item.pr_ref}: {e}"
+                    )
+        finally:
+            if dry_run:
+                git.reset_hard("HEAD")
+    return failed_prs, body
 
 
 def cmd_process_backports(args):
@@ -51,43 +187,9 @@ def cmd_process_backports(args):
     # Resolve PRs to merge commits using gh helper.
     pr_commit_infos = gh.get_merge_commits_for_prs(pending_items)
 
-    shas = []
-    sha_to_item = {}
-    failed_prs = []
-    ignored_prs = []
-    for item in pr_commit_infos:
-        if item.commit:
-            sha = item.commit
-            sha_to_item[sha] = item
-            shas.append(sha)
-        elif item.status in ("open-pr", "draft-pr"):
-            print(f"PR {item.pr_ref} is open or draft. Ignoring.")
-            ignored_prs.append(item.pr_ref)
-        else:
-            # Handle case where PR could not be resolved to a merge commit.
-            # We immediately mark it as failed in the tracking issue.
-            failed_prs.append(item.pr_ref)
-            status_to_set = item.status or "error-unmerged-pr"
-            if args.dry_run:
-                print(
-                    f"[DRY RUN] Would update tracking issue checklist for unresolved PR {item.pr_ref} to status={status_to_set}"
-                )
-            else:
-                print(
-                    f"Updating tracking issue checklist for unresolved PR {item.pr_ref}..."
-                )
-                try:
-                    body = update_task_in_body(
-                        body,
-                        item.pr_ref,
-                        checked=False,
-                        metadata={"status": status_to_set},
-                    )
-                    gh.update_issue_body(args.issue, body)
-                except Exception as e:
-                    print(
-                        f"ERROR: Failed to update tracking issue for unresolved PR {item.pr_ref}: {e}"
-                    )
+    shas, sha_to_item, failed_prs, ignored_prs, body = _process_pr_commit_infos(
+        pr_commit_infos, body, args.issue, args.dry_run
+    )
 
     if not shas:
         print("No valid merge commits to process.")
@@ -111,85 +213,18 @@ def cmd_process_backports(args):
     git.fetch(args.remote)
     git.checkout(branch_name, track_remote=args.remote)
 
-    for sha in sorted_shas:
-        item = sha_to_item[sha]
-        print(f"Cherry-picking {item.pr_ref} / {sha}...")
-        try:
-            git.cherry_pick(sha, no_commit=args.dry_run)
-
-            # Perform news processing (merging news/ files into the changelog)
-            print(f"Merging news fragments into changelog for PR {item.pr_ref}...")
-            release_date = datetime.date.today().strftime("%Y-%m-%d")
-            changelog_news.update_changelog(version, release_date)
-
-            if not args.dry_run:
-                # Stage changelog changes and news/ deletions
-                git.add("CHANGELOG.md", "news/")
-
-                # Amend cherry-pick commit to include news merging and deletions,
-                # and reference the release tracking issue.
-                print(f"Amending cherry-pick commit for PR {item.pr_ref}...")
-                current_msg = git.get_commit_message("HEAD")
-                new_msg = f"{current_msg.strip()}\n\nWork towards #{args.issue}"
-                git.commit(new_msg, amend=True)
-
-                # Push amended commit
-                git.push(args.remote, branch_name)
-
-                new_sha = git.get_commit_sha("HEAD", short=True)
-                metadata = {"status": "done", "rc": next_rc_suffix, "commit": new_sha}
-                print(f"Updating tracking issue checklist for PR {item.pr_ref}...")
-                try:
-                    body = update_task_in_body(
-                        body, item.pr_ref, checked=True, metadata=metadata
-                    )
-                    gh.update_issue_body(args.issue, body)
-                except Exception as e:
-                    print(
-                        f"ERROR: Failed to update tracking issue for PR {item.pr_ref}: {e}"
-                    )
-                print(f"Success: backported {item.pr_ref} / {sha} to {branch_name}")
-            else:
-                print(
-                    f"[DRY RUN] Success: {item.pr_ref} / {sha} can be backported without error."
-                )
-                print(
-                    f"[DRY RUN] Would update tracking issue checklist for PR {item.pr_ref} to status=done"
-                )
-        except Exception as e:
-            print(f"ERROR: Conflict or error on {sha}: {e}. Aborting.")
-            try:
-                git.cherry_pick_abort()
-            except Exception:
-                pass
-            failed_prs.append(item.pr_ref)
-
-            if args.dry_run:
-                print(
-                    f"[DRY RUN] Would update tracking issue checklist for failed PR {item.pr_ref} to status=error-merge-conflict"
-                )
-            else:
-                print(
-                    f"Updating tracking issue checklist for failed PR {item.pr_ref}..."
-                )
-                try:
-                    body = update_task_in_body(
-                        body,
-                        item.pr_ref,
-                        checked=False,
-                        metadata={"status": "error-merge-conflict"},
-                    )
-                    gh.update_issue_body(args.issue, body)
-                    print(
-                        f"Updated back port of {item.pr_ref} to status=error-merge-conflict (unchecked)"
-                    )
-                except Exception as e:
-                    print(
-                        f"ERROR: Failed to update tracking issue for failed PR {item.pr_ref}: {e}"
-                    )
-        finally:
-            if args.dry_run:
-                git.reset_hard("HEAD")
+    new_failed_prs, body = _cherry_pick_and_update_prs(
+        sorted_shas,
+        sha_to_item,
+        body,
+        args.issue,
+        args.remote,
+        args.dry_run,
+        version,
+        branch_name,
+        next_rc_suffix,
+    )
+    failed_prs.extend(new_failed_prs)
 
     if failed_prs:
         print("ERROR: One or more cherry-picks/resolutions failed:")

--- a/tools/private/release/process_backports.py
+++ b/tools/private/release/process_backports.py
@@ -109,7 +109,7 @@ def cmd_process_backports(args):
     sorted_shas = git.sort_commits_chronologically(shas)
 
     git.fetch(args.remote)
-    git.checkout(branch_name)
+    git.checkout(branch_name, track_remote=args.remote)
 
     for sha in sorted_shas:
         item = sha_to_item[sha]

--- a/tools/private/release/process_backports.py
+++ b/tools/private/release/process_backports.py
@@ -126,9 +126,12 @@ def cmd_process_backports(args):
                 # Stage changelog changes and news/ deletions
                 git.add("CHANGELOG.md", "news/")
 
-                # Amend cherry-pick commit to include news merging and deletions
+                # Amend cherry-pick commit to include news merging and deletions,
+                # and reference the release tracking issue.
                 print(f"Amending cherry-pick commit for PR {item.pr_ref}...")
-                git.commit("", amend=True, no_edit=True)
+                current_msg = git.get_commit_message("HEAD")
+                new_msg = f"{current_msg.strip()}\n\nWork towards #{args.issue}"
+                git.commit(new_msg, amend=True)
 
                 # Push amended commit
                 git.push(args.remote, branch_name)

--- a/tools/private/release/process_backports.py
+++ b/tools/private/release/process_backports.py
@@ -69,24 +69,24 @@ def _cherry_pick_and_update_prs(
         item = sha_to_item[sha]
         print(f"Cherry-picking {item.pr_ref} / {sha}...")
         try:
-            git.cherry_pick(sha, no_commit=dry_run)
+            git.cherry_pick(sha)
 
             # Perform news processing (merging news/ files into the changelog)
             print(f"Merging news fragments into changelog for PR {item.pr_ref}...")
             release_date = datetime.date.today().strftime("%Y-%m-%d")
             changelog_news.update_changelog(version, release_date)
 
+            # Stage changelog changes and news/ deletions
+            git.add("CHANGELOG.md", "news/")
+
+            # Amend cherry-pick commit to include news merging and deletions,
+            # and reference the release tracking issue.
+            print(f"Amending cherry-pick commit for PR {item.pr_ref}...")
+            current_msg = git.get_commit_message("HEAD")
+            new_msg = f"{current_msg.strip()}\n\nWork towards #{issue}"
+            git.commit(new_msg, amend=True)
+
             if not dry_run:
-                # Stage changelog changes and news/ deletions
-                git.add("CHANGELOG.md", "news/")
-
-                # Amend cherry-pick commit to include news merging and deletions,
-                # and reference the release tracking issue.
-                print(f"Amending cherry-pick commit for PR {item.pr_ref}...")
-                current_msg = git.get_commit_message("HEAD")
-                new_msg = f"{current_msg.strip()}\n\nWork towards #{issue}"
-                git.commit(new_msg, amend=True)
-
                 # Push amended commit
                 git.push(remote, branch_name)
 
@@ -141,9 +141,6 @@ def _cherry_pick_and_update_prs(
                     print(
                         f"ERROR: Failed to update tracking issue for failed PR {item.pr_ref}: {e}"
                     )
-        finally:
-            if dry_run:
-                git.reset_hard("HEAD")
     return failed_prs, body
 
 
@@ -212,19 +209,25 @@ def cmd_process_backports(args):
 
     git.fetch(args.remote)
     git.checkout(branch_name, track_remote=args.remote)
+    start_sha = git.get_commit_sha("HEAD")
 
-    new_failed_prs, body = _cherry_pick_and_update_prs(
-        sorted_shas,
-        sha_to_item,
-        body,
-        args.issue,
-        args.remote,
-        args.dry_run,
-        version,
-        branch_name,
-        next_rc_suffix,
-    )
-    failed_prs.extend(new_failed_prs)
+    try:
+        new_failed_prs, body = _cherry_pick_and_update_prs(
+            sorted_shas,
+            sha_to_item,
+            body,
+            args.issue,
+            args.remote,
+            args.dry_run,
+            version,
+            branch_name,
+            next_rc_suffix,
+        )
+        failed_prs.extend(new_failed_prs)
+    finally:
+        if args.dry_run:
+            print(f"[DRY RUN] Resetting branch {branch_name} to {start_sha}")
+            git.reset_hard(start_sha)
 
     if failed_prs:
         print("ERROR: One or more cherry-picks/resolutions failed:")

--- a/tools/private/release/process_backports.py
+++ b/tools/private/release/process_backports.py
@@ -1,0 +1,201 @@
+"""Subcommand to process pending backports."""
+
+import datetime
+
+from tools.private.release import changelog_news, gh, git
+from tools.private.release.release_issue import (
+    RELEASE_TITLE_RE,
+    parse_backports,
+    update_task_in_body,
+)
+from tools.private.release.utils import get_latest_rc_tag
+
+
+def cmd_process_backports(args):
+    """Executes the process-backports subcommand."""
+    body = gh.get_issue_body(args.issue)
+    items = parse_backports(body)
+
+    pending_items = [
+        item
+        for item in items
+        if not item.checked and not item.status.startswith("error-")
+    ]
+
+    if not pending_items:
+        print("No pending backports found.")
+        return 0
+
+    print(f"Found {len(pending_items)} pending backports to process.")
+
+    # Determine branch name from issue title
+    issue_title = gh.get_issue_title(args.issue)
+    version_match = RELEASE_TITLE_RE.search(issue_title)
+    if not version_match:
+        print(f"Error: Could not parse version from issue title: {issue_title}")
+        return 1
+
+    version = version_match.group(1)
+    branch_version = ".".join(version.split(".")[:2])
+    branch_name = f"release/{branch_version}"
+
+    # Determine next RC tag to write to backport metadata
+    git.fetch(args.remote, tags=True, force=True)
+    latest_rc = get_latest_rc_tag(version, remote=args.remote)
+    if not latest_rc:
+        next_rc_suffix = "rc0"
+    else:
+        rc_num = int(latest_rc.split("-rc")[-1])
+        next_rc_suffix = f"rc{rc_num + 1}"
+
+    # Resolve PRs to merge commits using gh helper.
+    pr_commit_infos = gh.get_merge_commits_for_prs(pending_items)
+
+    shas = []
+    sha_to_item = {}
+    failed_prs = []
+    ignored_prs = []
+    for item in pr_commit_infos:
+        if item.commit:
+            sha = item.commit
+            sha_to_item[sha] = item
+            shas.append(sha)
+        elif item.status in ("open-pr", "draft-pr"):
+            print(f"PR {item.pr_ref} is open or draft. Ignoring.")
+            ignored_prs.append(item.pr_ref)
+        else:
+            # Handle case where PR could not be resolved to a merge commit.
+            # We immediately mark it as failed in the tracking issue.
+            failed_prs.append(item.pr_ref)
+            status_to_set = item.status or "error-unmerged-pr"
+            if args.dry_run:
+                print(
+                    f"[DRY RUN] Would update tracking issue checklist for unresolved PR {item.pr_ref} to status={status_to_set}"
+                )
+            else:
+                print(
+                    f"Updating tracking issue checklist for unresolved PR {item.pr_ref}..."
+                )
+                try:
+                    body = update_task_in_body(
+                        body,
+                        item.pr_ref,
+                        checked=False,
+                        metadata={"status": status_to_set},
+                    )
+                    gh.update_issue_body(args.issue, body)
+                except Exception as e:
+                    print(
+                        f"ERROR: Failed to update tracking issue for unresolved PR {item.pr_ref}: {e}"
+                    )
+
+    if not shas:
+        print("No valid merge commits to process.")
+        if failed_prs:
+            print("Failed PRs:")
+            for pr in failed_prs:
+                print(f"- {pr}")
+            return 1
+        return 0
+
+    # Verify workspace is clean before proceeding
+    if git.status():
+        print(
+            "ERROR: Git workspace is dirty. Please commit or stash changes before running backports."
+        )
+        return 1
+
+    # Sort chronologically using git helper
+    sorted_shas = git.sort_commits_chronologically(shas)
+
+    git.fetch(args.remote)
+    git.checkout(branch_name)
+
+    for sha in sorted_shas:
+        item = sha_to_item[sha]
+        print(f"Cherry-picking {item.pr_ref} / {sha}...")
+        try:
+            git.cherry_pick(sha, no_commit=args.dry_run)
+
+            # Perform news processing (merging news/ files into the changelog)
+            print(f"Merging news fragments into changelog for PR {item.pr_ref}...")
+            release_date = datetime.date.today().strftime("%Y-%m-%d")
+            changelog_news.update_changelog(version, release_date)
+
+            if not args.dry_run:
+                # Stage changelog changes and news/ deletions
+                git.add("CHANGELOG.md", "news/")
+
+                # Amend cherry-pick commit to include news merging and deletions
+                print(f"Amending cherry-pick commit for PR {item.pr_ref}...")
+                git.commit("", amend=True, no_edit=True)
+
+                # Push amended commit
+                git.push(args.remote, branch_name)
+
+                new_sha = git.get_commit_sha("HEAD", short=True)
+                metadata = {"status": "done", "rc": next_rc_suffix, "commit": new_sha}
+                print(f"Updating tracking issue checklist for PR {item.pr_ref}...")
+                try:
+                    body = update_task_in_body(
+                        body, item.pr_ref, checked=True, metadata=metadata
+                    )
+                    gh.update_issue_body(args.issue, body)
+                except Exception as e:
+                    print(
+                        f"ERROR: Failed to update tracking issue for PR {item.pr_ref}: {e}"
+                    )
+                print(f"Success: backported {item.pr_ref} / {sha} to {branch_name}")
+            else:
+                print(
+                    f"[DRY RUN] Success: {item.pr_ref} / {sha} can be backported without error."
+                )
+                print(
+                    f"[DRY RUN] Would update tracking issue checklist for PR {item.pr_ref} to status=done"
+                )
+        except Exception as e:
+            print(f"ERROR: Conflict or error on {sha}: {e}. Aborting.")
+            try:
+                git.cherry_pick_abort()
+            except Exception:
+                pass
+            failed_prs.append(item.pr_ref)
+
+            if args.dry_run:
+                print(
+                    f"[DRY RUN] Would update tracking issue checklist for failed PR {item.pr_ref} to status=error-merge-conflict"
+                )
+            else:
+                print(
+                    f"Updating tracking issue checklist for failed PR {item.pr_ref}..."
+                )
+                try:
+                    body = update_task_in_body(
+                        body,
+                        item.pr_ref,
+                        checked=False,
+                        metadata={"status": "error-merge-conflict"},
+                    )
+                    gh.update_issue_body(args.issue, body)
+                    print(
+                        f"Updated back port of {item.pr_ref} to status=error-merge-conflict (unchecked)"
+                    )
+                except Exception as e:
+                    print(
+                        f"ERROR: Failed to update tracking issue for failed PR {item.pr_ref}: {e}"
+                    )
+        finally:
+            if args.dry_run:
+                git.reset_hard("HEAD")
+
+    if failed_prs:
+        print("ERROR: One or more cherry-picks/resolutions failed:")
+        for pr in failed_prs:
+            print(f"- {pr}")
+        return 1
+
+    if args.dry_run:
+        print("Dry run completed successfully. No errors found.")
+    else:
+        print("All backports successfully processed!")
+    return 0

--- a/tools/private/release/release.py
+++ b/tools/private/release/release.py
@@ -10,6 +10,7 @@ import sys
 from tools.private.release import changelog_news, gh, git
 from tools.private.release.prepare import cmd_prepare
 from tools.private.release.release_issue import (
+    parse_checklist_state,
     parse_metadata_line,
     update_task_in_body,
 )
@@ -33,72 +34,6 @@ def _semver_type(value):
 # ==============================================================================
 # Checklist Parser and Formatter (Using new | key=value syntax)
 # ==============================================================================
-
-
-def parse_checklist_state(body):
-    """Parses the main checklist tasks and their metadata."""
-    state = {
-        "prepare_release": {
-            "checked": False,
-            "status": None,
-            "pr": None,
-            "commit": None,
-        },
-        "create_branch": {
-            "checked": False,
-            "status": None,
-            "branch": None,
-            "commit": None,
-        },
-        "tag_final": {"checked": False, "status": None, "tag": None, "commit": None},
-        "rc_tags": {},  # Dynamically mapped: int -> metadata dict
-    }
-
-    lines = body.splitlines()
-    for line in lines:
-        parsed = parse_metadata_line(line)
-        if not parsed:
-            continue
-
-        name = parsed["name"].strip()
-        meta = parsed["metadata"]
-        checked = parsed["checked"]
-        name_lower = name.lower()
-
-        if "prepare release" in name_lower:
-            state["prepare_release"] = {
-                "checked": checked,
-                "status": meta.get("status"),
-                "pr": meta.get("pr"),
-                "commit": meta.get("commit"),
-            }
-        elif "create release branch" in name_lower:
-            state["create_branch"] = {
-                "checked": checked,
-                "status": meta.get("status"),
-                "branch": meta.get("branch"),
-                "commit": meta.get("commit"),
-            }
-        elif "tag final" in name_lower:
-            state["tag_final"] = {
-                "checked": checked,
-                "status": meta.get("status"),
-                "tag": meta.get("tag"),
-                "commit": meta.get("commit"),
-            }
-        else:
-            # Match Tag RC<num>
-            rc_match = re.match(r"Tag RC(\d+)", name, re.IGNORECASE)
-            if rc_match:
-                rc_num = int(rc_match.group(1))
-                state["rc_tags"][rc_num] = {
-                    "checked": checked,
-                    "status": meta.get("status"),
-                    "tag": meta.get("tag"),
-                    "commit": meta.get("commit"),
-                }
-
-    return state
 
 
 def parse_backports(body):

--- a/tools/private/release/release.py
+++ b/tools/private/release/release.py
@@ -1,19 +1,17 @@
 """A tool to perform release steps."""
 
 import argparse
-import datetime
 import os
 import pathlib
 import re
 import sys
 
-from tools.private.release import changelog_news, gh, git
+from tools.private.release import gh, git
 from tools.private.release.create_rc import cmd_create_rc
 from tools.private.release.create_release_branch import cmd_create_release_branch
 from tools.private.release.prepare import cmd_prepare
+from tools.private.release.process_backports import cmd_process_backports
 from tools.private.release.release_issue import (
-    RELEASE_TITLE_RE,
-    parse_backports,
     update_task_in_body,
 )
 from tools.private.release.utils import (
@@ -104,128 +102,6 @@ def cmd_complete_prepare(args):
     )
     gh.update_issue_body(issue_num, updated_body)
     print("Prepare Release task marked complete successfully!")
-    return 0
-
-
-def cmd_process_backports(args):
-    """Executes the process-backports subcommand."""
-    body = gh.get_issue_body(args.issue)
-    items = parse_backports(body)
-
-    pending_items = [
-        item
-        for item in items
-        if not item["checked"] and item["status"] != "merge-conflict"
-    ]
-
-    if not pending_items:
-        print("No pending backports found.")
-        return 0
-
-    print(f"Found {len(pending_items)} pending backports to process.")
-
-    # Determine branch name from issue title
-    issue_title = gh.get_issue_title(args.issue)
-    version_match = RELEASE_TITLE_RE.search(issue_title)
-    if not version_match:
-        print(f"Error: Could not parse version from issue title: {issue_title}")
-        return 1
-
-    version = version_match.group(1)
-    branch_version = ".".join(version.split(".")[:2])
-    branch_name = f"release/{branch_version}"
-
-    # Determine next RC tag to write to backport metadata
-    git.fetch("origin", tags=True, force=True)
-    latest_rc = get_latest_rc_tag(version, remote="origin")
-    if not latest_rc:
-        next_rc_suffix = "rc0"
-    else:
-        rc_num = int(latest_rc.split("-rc")[-1])
-        next_rc_suffix = f"rc{rc_num + 1}"
-
-    # Resolve PRs to merge commits using gh helper
-    resolved_items = gh.resolve_backport_commits(pending_items)
-
-    shas = []
-    sha_to_item = {}
-    any_failed = False
-    for item in resolved_items:
-        if item.get("commit"):
-            sha = item["commit"]
-            sha_to_item[sha] = item
-            shas.append(sha)
-        else:
-            any_failed = True
-            body = update_task_in_body(
-                body,
-                item["pr_ref"],
-                checked=False,
-                metadata={"status": item.get("status", "failed")},
-            )
-            gh.update_issue_body(args.issue, body)
-
-    if not shas:
-        print("No valid merge commits to process.")
-        if any_failed:
-            return 1
-        return 0
-
-    # Sort chronologically using git helper
-    sorted_shas = git.sort_commits_chronologically(shas)
-
-    git.fetch("origin")
-    git.checkout(branch_name)
-
-    for sha in sorted_shas:
-        item = sha_to_item[sha]
-        print(f"Cherry-picking {sha} (PR {item['pr_ref']})...")
-        try:
-            git.cherry_pick(sha)
-
-            # Perform news processing (merging news/ files into the changelog)
-            print(f"Merging news fragments into changelog for PR {item['pr_ref']}...")
-            release_date = datetime.date.today().strftime("%Y-%m-%d")
-            changelog_news.update_changelog(version, release_date)
-
-            # Stage changelog changes and news/ deletions
-            git.add("CHANGELOG.md", "news/")
-
-            # Amend cherry-pick commit to include news merging and deletions
-            print(f"Amending cherry-pick commit for PR {item['pr_ref']}...")
-            git.commit("", amend=True, no_edit=True)
-
-            # Push amended commit
-            git.push("origin", branch_name)
-
-            new_sha = git.get_commit_sha("HEAD", short=True)
-            metadata = {"status": "done", "rc": next_rc_suffix, "commit": new_sha}
-            body = update_task_in_body(
-                body, item["pr_ref"], checked=True, metadata=metadata
-            )
-            gh.update_issue_body(args.issue, body)
-            print(f"Applied: SUCCESS {new_sha}")
-        except Exception as e:
-            print(f"Conflict or error on {sha}: {e}. Aborting.")
-            try:
-                git.cherry_pick_abort()
-            except Exception:
-                pass
-            any_failed = True
-
-            body = update_task_in_body(
-                body,
-                item["pr_ref"],
-                checked=False,
-                metadata={"status": "merge-conflict"},
-            )
-            gh.update_issue_body(args.issue, body)
-            print("Updated backport item to status=merge-conflict (unchecked)")
-
-    if any_failed:
-        print("One or more cherry-picks/resolutions failed.")
-        return 1
-    print("All backports successfully processed!")
     return 0
 
 
@@ -405,6 +281,18 @@ def create_parser():
         type=int,
         required=True,
         help="The tracking issue number (required).",
+    )
+    process_backports_parser.add_argument(
+        "--remote",
+        type=str,
+        required=True,
+        help="The git remote to push changes to (required).",
+    )
+    process_backports_parser.add_argument(
+        "--dry-run",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Perform a dry run (default: True). Use --no-dry-run to actually execute.",
     )
 
     # Subcommand: create-rc

--- a/tools/private/release/release_issue.py
+++ b/tools/private/release/release_issue.py
@@ -60,3 +60,69 @@ def update_task_in_body(body, task_name, checked, metadata):
         )
 
     return "\n".join(updated_lines)
+
+
+def parse_checklist_state(body):
+    """Parses the main checklist tasks and their metadata."""
+    state = {
+        "prepare_release": {
+            "checked": False,
+            "status": None,
+            "pr": None,
+            "commit": None,
+        },
+        "create_branch": {
+            "checked": False,
+            "status": None,
+            "branch": None,
+            "commit": None,
+        },
+        "tag_final": {"checked": False, "status": None, "tag": None, "commit": None},
+        "rc_tags": {},  # Dynamically mapped: int -> metadata dict
+    }
+
+    lines = body.splitlines()
+    for line in lines:
+        parsed = parse_metadata_line(line)
+        if not parsed:
+            continue
+
+        name = parsed["name"].strip()
+        meta = parsed["metadata"]
+        checked = parsed["checked"]
+        name_lower = name.lower()
+
+        if "prepare release" in name_lower:
+            state["prepare_release"] = {
+                "checked": checked,
+                "status": meta.get("status"),
+                "pr": meta.get("pr"),
+                "commit": meta.get("commit"),
+            }
+        elif "create release branch" in name_lower:
+            state["create_branch"] = {
+                "checked": checked,
+                "status": meta.get("status"),
+                "branch": meta.get("branch"),
+                "commit": meta.get("commit"),
+            }
+        elif "tag final" in name_lower:
+            state["tag_final"] = {
+                "checked": checked,
+                "status": meta.get("status"),
+                "tag": meta.get("tag"),
+                "commit": meta.get("commit"),
+            }
+        else:
+            # Match Tag RC<num>
+            rc_match = re.match(r"Tag RC(\d+)", name, re.IGNORECASE)
+            if rc_match:
+                rc_num = int(rc_match.group(1))
+                state["rc_tags"][rc_num] = {
+                    "checked": checked,
+                    "status": meta.get("status"),
+                    "tag": meta.get("tag"),
+                    "commit": meta.get("commit"),
+                }
+
+    return state

--- a/tools/private/release/release_issue.py
+++ b/tools/private/release/release_issue.py
@@ -1,6 +1,42 @@
-"""Helper functions for managing release tracking issues and checklists."""
-
 import re
+
+
+class BackportTask:
+    """Represents a backport task from the tracking issue checklist."""
+
+    def __init__(
+        self,
+        pr_ref: str,
+        checked: bool,
+        status: str,
+        rc: str | None = None,
+        commit: str | None = None,
+        metadata: dict[str, str] | None = None,
+    ):
+        """Initializes a BackportTask.
+
+        Args:
+            pr_ref: The PR reference (e.g. '#123').
+            checked: Whether the checklist item is checked.
+            status: The status of the backport (e.g. 'pending', 'done',
+                'error-merge-conflict').
+            rc: The release candidate version this PR was backported to.
+            commit: The cherry-pick commit SHA.
+            metadata: Raw metadata parsed from the checklist line.
+        """
+        self.pr_ref = pr_ref
+        self.checked = checked
+        self.status = status
+        self.rc = rc
+        self.commit = commit
+        self.metadata = metadata or {}
+
+    def __repr__(self):
+        return (
+            f"BackportTask(pr_ref={self.pr_ref!r}, checked={self.checked!r}, "
+            f"status={self.status!r}, rc={self.rc!r}, commit={self.commit!r})"
+        )
+
 
 RELEASE_TITLE_RE = re.compile(r"Release (\d+\.\d+\.\d+)", re.IGNORECASE)
 
@@ -147,13 +183,13 @@ def parse_backports(body):
         parsed = parse_metadata_line(line)
         if parsed:
             items.append(
-                {
-                    "pr_ref": parsed["name"],
-                    "checked": parsed["checked"],
-                    "status": parsed["metadata"].get("status", "PENDING"),
-                    "rc": parsed["metadata"].get("rc"),
-                    "commit": parsed["metadata"].get("commit"),
-                    "metadata": parsed["metadata"],
-                }
+                BackportTask(
+                    pr_ref=parsed["name"],
+                    checked=parsed["checked"],
+                    status=parsed["metadata"].get("status", "pending"),
+                    rc=parsed["metadata"].get("rc"),
+                    commit=parsed["metadata"].get("commit"),
+                    metadata=parsed["metadata"],
+                )
             )
     return items


### PR DESCRIPTION
This PR refactors the `process-backports` subcommand, improves its dry-run validation, and fixes a bug in `create-rc`.

### Why the changes are made
- The `process-backports` logic was previously embedded in the main `release.py` script, making it difficult to maintain and extend.
- `process-backports` lacked a robust dry-run validation to safely verify backport applicability without leaving the workspace dirty.
- `process-backports` could fail with checkout ambiguity if the release branch existed on multiple remotes.
- `create-rc` crashed with a fatal subscripting error when trying to access `BackportTask` objects as dictionaries after their recent refactoring.
- `create-rc` tracking issue comments lacked a direct link to the BCR entry for the new version.
