### PR TITLE
chore(release): pass missing --remote argument to release workflows

### DIFF
--- a/.github/workflows/release_process_backports.yaml
+++ b/.github/workflows/release_process_backports.yaml
@@ -35,6 +35,6 @@ jobs:
       - name: Process Pending Backports
         run: |
           bazel run //tools/private/release -- \
-            process-backports --issue ${{ inputs.issue }}
+            process-backports --issue ${{ inputs.issue }} --remote origin
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_promote_rc.yaml
+++ b/.github/workflows/release_promote_rc.yaml
@@ -34,6 +34,6 @@ jobs:
       - name: Run Promote RC
         run: |
           bazel run //tools/private/release -- \
-            promote-rc ${{ inputs.version }}
+            promote-rc ${{ inputs.version }} --remote origin
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/tools/private/release/release_test.py
+++ b/tests/tools/private/release/release_test.py
@@ -514,7 +514,9 @@ blabla
     def test_valid_version(self):
         # These should not raise an exception
         releaser.create_parser().parse_args(["prepare", "0.28.0"])
-        releaser.create_parser().parse_args(["promote-rc", "1.0.0"])
+        releaser.create_parser().parse_args(
+            ["promote-rc", "1.0.0", "--remote", "origin"]
+        )
         releaser.create_parser().parse_args(
             ["create-release-issue", "--version", "1.2.3rc4"]
         )
@@ -1112,7 +1114,7 @@ class CmdPromoteRcTest(unittest.TestCase):
 
     def test_promote_rc_success(self):
         # Arrange
-        args = MagicMock(version="2.0.0", issue=123, dry_run=False)
+        args = MagicMock(version="2.0.0", issue=123, dry_run=False, remote="my-remote")
         self.mock_git.get_remote_tags.return_value = ["2.0.0-rc0", "2.0.0-rc1"]
         self.mock_git.get_commit_sha.return_value = "abcdef123456"
         self.mock_git.tag_exists.return_value = False
@@ -1124,12 +1126,12 @@ class CmdPromoteRcTest(unittest.TestCase):
 
         # Assert
         self.assertEqual(result, 0)
-        self.mock_git.fetch.assert_called_once_with("upstream", tags=True, force=True)
+        self.mock_git.fetch.assert_called_once_with("my-remote", tags=True, force=True)
         self.mock_git.get_commit_sha.assert_called_once_with("2.0.0-rc1")
         self.mock_git.checkout.assert_not_called()
         self.mock_git.tag_exists.assert_called_once_with("2.0.0")
         self.mock_git.tag.assert_called_once_with("2.0.0", "abcdef123456")
-        self.mock_git.push.assert_called_once_with("upstream", "2.0.0")
+        self.mock_git.push.assert_called_once_with("my-remote", "2.0.0")
 
         # Verify issue update
         self.mock_gh.get_issue_body.assert_called_once_with(123)
@@ -1148,7 +1150,7 @@ class CmdPromoteRcTest(unittest.TestCase):
 
     def test_promote_rc_resolve_issue_success(self):
         # Arrange
-        args = MagicMock(version="2.0.0", issue=None, dry_run=False)
+        args = MagicMock(version="2.0.0", issue=None, dry_run=False, remote="my-remote")
         self.mock_git.get_remote_tags.return_value = ["2.0.0-rc1"]
         self.mock_git.tag_exists.return_value = False
         self.mock_gh.get_release_tracking_issue.side_effect = None
@@ -1162,11 +1164,12 @@ class CmdPromoteRcTest(unittest.TestCase):
 
         # Assert
         self.assertEqual(result, 0)
+        self.mock_git.fetch.assert_called_once_with("my-remote", tags=True, force=True)
         self.mock_gh.get_release_tracking_issue.assert_called_once_with("2.0.0")
         self.mock_git.get_commit_sha.assert_called_once_with("2.0.0-rc1")
         self.mock_git.checkout.assert_not_called()
         self.mock_git.tag.assert_called_once_with("2.0.0", "abcdef123456")
-        self.mock_git.push.assert_called_once_with("upstream", "2.0.0")
+        self.mock_git.push.assert_called_once_with("my-remote", "2.0.0")
         self.mock_gh.get_issue_body.assert_called_once_with(123)
         expected_updated_body = (
             "- [x] Tag Final | status=done tag=2.0.0 commit=abcdef12"
@@ -1183,7 +1186,7 @@ class CmdPromoteRcTest(unittest.TestCase):
 
     def test_promote_rc_defaults_to_determine_next_version(self):
         # Arrange
-        args = MagicMock(version=None, issue=123, dry_run=False)
+        args = MagicMock(version=None, issue=123, dry_run=False, remote="my-remote")
         self.mock_git.get_current_branch.return_value = "release/2.0"
         self.mock_git.get_tags.return_value = ["2.0.0"]
         self.mock_git.get_remote_tags.return_value = ["2.0.1-rc0"]
@@ -1197,14 +1200,15 @@ class CmdPromoteRcTest(unittest.TestCase):
 
         # Assert
         self.assertEqual(result, 0)
+        self.mock_git.fetch.assert_called_once_with("my-remote", tags=True, force=True)
         self.mock_git.get_current_branch.assert_called_once()
         self.mock_git.get_tags.assert_called_once()
-        self.mock_git.get_remote_tags.assert_called_once_with("upstream")
+        self.mock_git.get_remote_tags.assert_called_once_with("my-remote")
 
         self.mock_git.checkout.assert_not_called()
         self.mock_git.get_commit_sha.assert_called_once_with("2.0.1-rc0")
         self.mock_git.tag.assert_called_once_with("2.0.1", "12345678")
-        self.mock_git.push.assert_called_once_with("upstream", "2.0.1")
+        self.mock_git.push.assert_called_once_with("my-remote", "2.0.1")
 
         expected_updated_body = (
             "- [x] Tag Final | status=done tag=2.0.1 commit=12345678"
@@ -1221,7 +1225,7 @@ class CmdPromoteRcTest(unittest.TestCase):
 
     def test_promote_rc_dry_run_success(self):
         # Arrange
-        args = MagicMock(version="2.0.0", issue=123, dry_run=True)
+        args = MagicMock(version="2.0.0", issue=123, dry_run=True, remote="my-remote")
         self.mock_git.get_remote_tags.return_value = ["2.0.0-rc0", "2.0.0-rc1"]
         self.mock_git.get_commit_sha.return_value = "abcdef123456"
         self.mock_git.tag_exists.return_value = False
@@ -1233,7 +1237,7 @@ class CmdPromoteRcTest(unittest.TestCase):
 
         # Assert
         self.assertEqual(result, 0)
-        self.mock_git.fetch.assert_called_once_with("upstream", tags=True, force=True)
+        self.mock_git.fetch.assert_called_once_with("my-remote", tags=True, force=True)
         self.mock_git.get_commit_sha.assert_called_once_with("2.0.0-rc1")
         self.mock_git.tag_exists.assert_called_once_with("2.0.0")
 
@@ -1245,7 +1249,7 @@ class CmdPromoteRcTest(unittest.TestCase):
 
     def test_promote_rc_tag_already_exists(self):
         # Arrange
-        args = MagicMock(version="2.0.0", issue=123)
+        args = MagicMock(version="2.0.0", issue=123, remote="my-remote")
         self.mock_git.get_remote_tags.return_value = ["2.0.0-rc1"]
         self.mock_git.tag_exists.return_value = True
 
@@ -1262,7 +1266,7 @@ class CmdPromoteRcTest(unittest.TestCase):
 
     def test_promote_rc_issue_not_found(self):
         # Arrange
-        args = MagicMock(version="2.0.0", issue=None)
+        args = MagicMock(version="2.0.0", issue=None, remote="my-remote")
         self.mock_git.get_remote_tags.return_value = ["2.0.0-rc1"]
         self.mock_git.tag_exists.return_value = False
         self.mock_gh.get_release_tracking_issue.side_effect = NoTrackingIssueError(
@@ -1282,7 +1286,7 @@ class CmdPromoteRcTest(unittest.TestCase):
 
     def test_promote_rc_issue_malformed(self):
         # Arrange
-        args = MagicMock(version="2.0.0", issue=123)
+        args = MagicMock(version="2.0.0", issue=123, remote="my-remote")
         self.mock_git.get_remote_tags.return_value = ["2.0.0-rc1"]
         self.mock_git.tag_exists.return_value = False
         self.mock_git.get_commit_sha.return_value = "abcdef123456"
@@ -1302,7 +1306,7 @@ class CmdPromoteRcTest(unittest.TestCase):
 
     def test_promote_rc_no_rc_found(self):
         # Arrange
-        args = MagicMock(version="2.0.0", issue=123)
+        args = MagicMock(version="2.0.0", issue=123, remote="my-remote")
         self.mock_git.get_remote_tags.return_value = []
 
         # Act

--- a/tools/private/release/promote_rc.py
+++ b/tools/private/release/promote_rc.py
@@ -25,14 +25,14 @@ class PromoteRc:
     def run(self) -> int:
         """Executes the promote-rc subcommand (Phase 3)."""
         args = self.args
-        # Fetch from upstream to ensure we have the latest tags
-        self.git.fetch("upstream", tags=True, force=True)
+        # Fetch from remote to ensure we have the latest tags
+        self.git.fetch(args.remote, tags=True, force=True)
 
         version = args.version
         if version is None:
             version = determine_next_version()
 
-        latest_rc = get_latest_rc_tag(version, remote="upstream")
+        latest_rc = get_latest_rc_tag(version, remote=args.remote)
         if not latest_rc:
             print(f"Error: No release candidate tags found matching {version}-rc*")
             return 1
@@ -86,9 +86,9 @@ class PromoteRc:
             f" {commit_sha[:8]}) using tracking issue #{issue_num}..."
         )
 
-        # Tag the specific commit without checkout, and push to upstream
+        # Tag the specific commit without checkout, and push to remote
         self.git.tag(version, commit_sha)
-        self.git.push("upstream", version)
+        self.git.push(args.remote, version)
 
         print(f"Updating tracking issue #{issue_num} checklist...")
         self.gh.update_issue_body(issue_num, updated_body)
@@ -126,6 +126,12 @@ class PromoteRc:
             "--issue",
             type=int,
             help="The tracking issue number (optional).",
+        )
+        parser.add_argument(
+            "--remote",
+            type=str,
+            required=True,
+            help="The git remote to push the final tag to (required).",
         )
         parser.add_argument(
             "--dry-run",


### PR DESCRIPTION
Workflows using `process-backports` and `promote-rc` subcommands were failing
due to missing or hardcoded remote arguments.

- Added `--remote` parameter to `promote-rc` subcommand.
- Updated `release_process_backports.yaml` and `release_promote_rc.yaml` to
  pass `--remote origin`.
- Updated tests in `release_test.py` to support and verify the new argument.
