### PR TITLE
chore(release): enable execution in process-backports workflow

### DIFF
--- a/.github/workflows/release_process_backports.yaml
+++ b/.github/workflows/release_process_backports.yaml
@@ -35,6 +35,6 @@ jobs:
       - name: Process Pending Backports
         run: |
           bazel run //tools/private/release -- \
-            process-backports --issue ${{ inputs.issue }} --remote origin
+            process-backports --issue ${{ inputs.issue }} --remote origin --no-dry-run
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Passes `--no-dry-run` to the `process-backports` subcommand in the workflow,
enabling it to actually perform the cherry-picks and push changes instead of
only simulating them.
