### PR TITLE
fix: use locale-neutral Windows ACL for build data

### DIFF
--- a/news/3886.fixed.md
+++ b/news/3886.fixed.md
@@ -1,0 +1,1 @@
+(windows) Fixed build data generation on localized Windows installations.

--- a/python/private/build_data_writer.ps1
+++ b/python/private/build_data_writer.ps1
@@ -21,7 +21,15 @@ $Utf8NoBom = New-Object System.Text.UTF8Encoding $False
 [System.IO.File]::WriteAllLines($OutputPath, $Lines, $Utf8NoBom)
 
 $Acl = Get-Acl $OutputPath
-$AccessRule = New-Object System.Security.AccessControl.FileSystemAccessRule("Everyone", "Read", "Allow")
+$EveryoneSid = New-Object System.Security.Principal.SecurityIdentifier(
+    [System.Security.Principal.WellKnownSidType]::WorldSid,
+    $null
+)
+$AccessRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+    $EveryoneSid,
+    "Read",
+    "Allow"
+)
 $Acl.SetAccessRule($AccessRule)
 Set-Acl $OutputPath $Acl
 

--- a/python/private/build_data_writer.ps1
+++ b/python/private/build_data_writer.ps1
@@ -21,6 +21,7 @@ $Utf8NoBom = New-Object System.Text.UTF8Encoding $False
 [System.IO.File]::WriteAllLines($OutputPath, $Lines, $Utf8NoBom)
 
 $Acl = Get-Acl $OutputPath
+# We use WorldSid because the "Everyone" name is locale-dependent.
 $EveryoneSid = New-Object System.Security.Principal.SecurityIdentifier(
     [System.Security.Principal.WellKnownSidType]::WorldSid,
     $null


### PR DESCRIPTION
On localized Windows installations, `build_data_writer.ps1` could fail when
creating the output file ACL because it used the English localized `Everyone`
principal name.

This changes the ACL rule to use the language-neutral `WorldSid` identity
instead, preserving the existing Everyone read permission without depending on
the display language of Windows.

Before: German and other localized Windows installs could fail with
`IdentityMappedException` / `IdentityNotMappedException`.

After: build data generation succeeds on localized Windows installs.

Fixes #3886

Tests:
`bazelisk test //tests/build_data:build_data_test --config=fast-tests`