### PR TITLE
Fix release tool links and improve workflow robustness

### DIFF
--- a/.github/workflows/release_create_release_branch.yaml
+++ b/.github/workflows/release_create_release_branch.yaml
@@ -35,3 +35,12 @@ jobs:
             create-release-branch --issue ${{ github.event.issue.number }} --remote origin
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # A no-op job that always runs to prevent "no jobs ran" failures
+  # when the main job is skipped.
+  suppress-no-jobs-ran-error:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo Success
+        run: echo "Success"
+

--- a/tests/tools/private/release/create_rc_test.py
+++ b/tests/tools/private/release/create_rc_test.py
@@ -76,7 +76,6 @@ class CmdCreateRcTest(unittest.TestCase):
             "- [Release workflow status](https://github.com/bazel-contrib/rules_python/actions/workflows/release_create_rc.yaml)",
             comment_call_args[1],
         )
-        self.assertNotIn("🚀", comment_call_args[1])
 
     def test_create_rc_success_with_run_id(self):
         # Arrange
@@ -167,7 +166,6 @@ class CmdCreateRcTest(unittest.TestCase):
             "- [Release workflow status](https://github.com/bazel-contrib/rules_python/actions/workflows/release_create_rc.yaml)",
             comment_call_args[1],
         )
-        self.assertNotIn("🚀", comment_call_args[1])
 
     def test_create_rc_gating_on_backports(self):
         # Arrange

--- a/tests/tools/private/release/create_rc_test.py
+++ b/tests/tools/private/release/create_rc_test.py
@@ -57,22 +57,56 @@ class CmdCreateRcTest(unittest.TestCase):
             comment_call_args[1],
         )
         self.assertIn(
+            "tagged on branch [`release/2.0`](https://github.com/bazel-contrib/rules_python/tree/release/2.0)",
+            comment_call_args[1],
+        )
+        self.assertIn(
             "- [Github Release 2.0.0-rc0](https://github.com/bazel-contrib/rules_python/releases/tag/2.0.0-rc0)",
             comment_call_args[1],
         )
         self.assertIn(
-            "- BCR Entry: [rules_python@2.0.0](https://registry.bazel.build/modules/rules_python/2.0.0)",
+            "- [BCR Entry 2.0.0-rc0](https://registry.bazel.build/modules/rules_python/2.0.0-rc0)",
             comment_call_args[1],
         )
         self.assertIn(
-            "- [BCR PRs](https://github.com/bazelbuild/bazel-central-registry/pulls?q=is%3Apr+rules_python+2.0.0)",
+            "- [BCR PRs](https://github.com/bazelbuild/bazel-central-registry/pulls?q=is%3Apr+rules_python+2.0.0-rc0)",
             comment_call_args[1],
         )
         self.assertIn(
-            "- [Release workflow status](https://github.com/bazel-contrib/rules_python/actions/workflows/release_publish.yaml)",
+            "- [Release workflow status](https://github.com/bazel-contrib/rules_python/actions/workflows/release_create_rc.yaml)",
             comment_call_args[1],
         )
         self.assertNotIn("🚀", comment_call_args[1])
+
+    def test_create_rc_success_with_run_id(self):
+        # Arrange
+        args = MagicMock(issue=123, remote="my-remote")
+        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
+        self.mock_gh.get_issue_body.return_value = """
+## Checklist
+- [x] Prepare Release | status=done pr=#122 commit=abcdef12
+- [x] Create Release branch | status=done branch=release/2.0 commit=abcdef12
+- [ ] Tag RC0 | status=pending
+"""
+        self.mock_git.get_remote_tags.return_value = []
+        self.mock_git.get_commit_sha.return_value = "1234567890"
+
+        # Act
+        with patch.dict(os.environ, {"GITHUB_RUN_ID": "987654321"}):
+            result = CreateRc(args, self.mock_git, self.mock_gh).run()
+
+        # Assert
+        self.assertEqual(result, 0)
+        self.mock_gh.post_issue_comment.assert_called_once()
+        comment_call_args = self.mock_gh.post_issue_comment.call_args[0]
+        self.assertIn(
+            "- [Release workflow status](https://github.com/bazel-contrib/rules_python/actions/runs/987654321)",
+            comment_call_args[1],
+        )
+        self.assertIn(
+            "tagged on branch [`release/2.0`](https://github.com/bazel-contrib/rules_python/tree/release/2.0)",
+            comment_call_args[1],
+        )
 
     def test_create_rc_success_next_rc(self):
         # Arrange
@@ -114,19 +148,23 @@ class CmdCreateRcTest(unittest.TestCase):
             comment_call_args[1],
         )
         self.assertIn(
+            "tagged on branch [`release/2.0`](https://github.com/bazel-contrib/rules_python/tree/release/2.0)",
+            comment_call_args[1],
+        )
+        self.assertIn(
             "- [Github Release 2.0.0-rc1](https://github.com/bazel-contrib/rules_python/releases/tag/2.0.0-rc1)",
             comment_call_args[1],
         )
         self.assertIn(
-            "- BCR Entry: [rules_python@2.0.0](https://registry.bazel.build/modules/rules_python/2.0.0)",
+            "- [BCR Entry 2.0.0-rc1](https://registry.bazel.build/modules/rules_python/2.0.0-rc1)",
             comment_call_args[1],
         )
         self.assertIn(
-            "- [BCR PRs](https://github.com/bazelbuild/bazel-central-registry/pulls?q=is%3Apr+rules_python+2.0.0)",
+            "- [BCR PRs](https://github.com/bazelbuild/bazel-central-registry/pulls?q=is%3Apr+rules_python+2.0.0-rc1)",
             comment_call_args[1],
         )
         self.assertIn(
-            "- [Release workflow status](https://github.com/bazel-contrib/rules_python/actions/workflows/release_publish.yaml)",
+            "- [Release workflow status](https://github.com/bazel-contrib/rules_python/actions/workflows/release_create_rc.yaml)",
             comment_call_args[1],
         )
         self.assertNotIn("🚀", comment_call_args[1])

--- a/tools/private/release/create_rc.py
+++ b/tools/private/release/create_rc.py
@@ -114,15 +114,21 @@ class CreateRc:
         self.gh.update_issue_body(args.issue, updated_body)
 
         tag_url = f"{REPO_URL}/releases/tag/{next_rc}"
-        bcr_entry_url = f"https://registry.bazel.build/modules/rules_python/{version}"
-        bcr_search_url = f"https://github.com/bazelbuild/bazel-central-registry/pulls?q=is%3Apr+rules_python+{version}"
-        release_workflow_url = f"{REPO_URL}/actions/workflows/release_publish.yaml"
+        bcr_entry_url = f"https://registry.bazel.build/modules/rules_python/{next_rc}"
+        bcr_search_url = f"https://github.com/bazelbuild/bazel-central-registry/pulls?q=is%3Apr+rules_python+{next_rc}"
+        if run_id := os.environ.get("GITHUB_RUN_ID"):
+            release_workflow_url = f"{REPO_URL}/actions/runs/{run_id}"
+        else:
+            release_workflow_url = (
+                f"{REPO_URL}/actions/workflows/release_create_rc.yaml"
+            )
+        branch_url = f"{REPO_URL}/tree/{branch_name}"
         comment_body = f"""**New Release Candidate Tagged!** 🐍🌿
 
-Release Candidate **{next_rc}** has been successfully generated and tagged on branch `{branch_name}`.
+Release Candidate **{next_rc}** has been successfully generated and tagged on branch [`{branch_name}`]({branch_url}).
 
 - [Github Release {next_rc}]({tag_url})
-- BCR Entry: [rules_python@{version}]({bcr_entry_url})
+- [BCR Entry {next_rc}]({bcr_entry_url})
 - [BCR PRs]({bcr_search_url})
 - [Release workflow status]({release_workflow_url})"""
         self.gh.post_issue_comment(args.issue, comment_body)


### PR DESCRIPTION
Fixes release tool bugs and improves workflow robustness.

- Fix BCR entry link in create-rc to use RC version instead of final version.
- Format BCR entry link as 'BCR Entry <version>'.
- Fix release workflow status link to use release_create_rc.yaml.
- Use GITHUB_RUN_ID to link directly to the workflow run if available.
- Link the branch name in the create-rc comment.
- Add a always-running job to release_create_release_branch.yaml to suppress 'no jobs ran' errors.
- Remove obsolete rocket assertions in create_rc tests.