### PR TITLE
build(release): support triggering release workflows via comments

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_tracking_template.md
+++ b/.github/ISSUE_TEMPLATE/release_tracking_template.md
@@ -50,7 +50,8 @@ Maintainers can trigger automation by:
   - `/process-backports` at the beginning of a line to trigger the Process
     Backports workflow.
 
+</details>
+
 [process_backports]: https://github.com/bazel-contrib/rules_python/actions/workflows/release_process_backports.yaml
 [create_rc]: https://github.com/bazel-contrib/rules_python/actions/workflows/release_create_rc.yaml
 [promote_rc]: https://github.com/bazel-contrib/rules_python/actions/workflows/release_promote_rc.yaml
-</details>

--- a/.github/ISSUE_TEMPLATE/release_tracking_template.md
+++ b/.github/ISSUE_TEMPLATE/release_tracking_template.md
@@ -18,7 +18,7 @@ labels: ['type: release']
 To request a backport:
 1. Add a new checklist item under the `## Backports` section.
 2. The format must be: `- [ ] #<PR_NUMBER>` (e.g., `- [ ] #1234`).
-3. Trigger the [Process Backports Workflow](https://github.com/bazel-contrib/rules_python/actions/workflows/process_backports.yml).
+3. Trigger the [Process Backports Workflow][process_backports].
 </details>
 
 ---
@@ -36,8 +36,21 @@ The checklist items use metadata suffix: `| key=value key2=value2`.
 <details>
 <summary><b>Available Commands</b></summary>
 
-Maintainers can trigger automation by running manual workflows:
-- [Process Backports Workflow](https://github.com/bazel-contrib/rules_python/actions/workflows/process_backports.yml)
-- [Generate RC Tag Workflow](https://github.com/bazel-contrib/rules_python/actions/workflows/generate_rc.yml)
-- [Promote RC to Final Release Workflow](https://github.com/bazel-contrib/rules_python/actions/workflows/promote_rc.yml)
+Maintainers can trigger automation by:
+- Running manual workflows:
+  - [Process Backports Workflow][process_backports]
+  - [Create RC Workflow][create_rc]
+  - [Promote RC to Final Release Workflow][promote_rc]
+- Commenting on this issue (requires the issue to have the `type: release`
+  label):
+  - `/prepare` at the beginning of a line to trigger the Release Prepare
+    workflow.
+  - `/create-rc` at the beginning of a line to trigger the Create RC
+    workflow.
+  - `/process-backports` at the beginning of a line to trigger the Process
+    Backports workflow.
+
+[process_backports]: https://github.com/bazel-contrib/rules_python/actions/workflows/release_process_backports.yaml
+[create_rc]: https://github.com/bazel-contrib/rules_python/actions/workflows/release_create_rc.yaml
+[promote_rc]: https://github.com/bazel-contrib/rules_python/actions/workflows/release_promote_rc.yaml
 </details>

--- a/.github/workflows/on_issue_comment.yaml
+++ b/.github/workflows/on_issue_comment.yaml
@@ -1,0 +1,68 @@
+name: "On Issue Comment"
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  # This job always runs to prevent GHA from marking the run as failed when
+  # all other jobs are skipped.
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No-op"
+
+  parse_comment:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.issue.pull_request == null &&
+      contains(github.event.issue.labels.*.name, 'type: release') &&
+      (github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'COLLABORATOR')
+    outputs:
+      command: ${{ steps.parse.outputs.command }}
+      issue_number: ${{ github.event.issue.number }}
+    steps:
+      - name: Parse comment
+        id: parse
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          if echo "$COMMENT_BODY" | grep -qE '^[[:space:]]*/create-rc([[:space:]]|$)'; then
+            echo "command=create-rc" >> "$GITHUB_OUTPUT"
+          elif echo "$COMMENT_BODY" | grep -qE '^[[:space:]]*/prepare([[:space:]]|$)'; then
+            echo "command=prepare" >> "$GITHUB_OUTPUT"
+          elif echo "$COMMENT_BODY" | grep -qE '^[[:space:]]*/process-backports([[:space:]]|$)'; then
+            echo "command=process-backports" >> "$GITHUB_OUTPUT"
+          else
+            echo "command=none" >> "$GITHUB_OUTPUT"
+          fi
+
+  call_create_rc:
+    needs: parse_comment
+    if: needs.parse_comment.outputs.command == 'create-rc'
+    uses: ./.github/workflows/release_create_rc.yaml
+    with:
+      issue: ${{ needs.parse_comment.outputs.issue_number }}
+    secrets: inherit
+
+  call_prepare:
+    needs: parse_comment
+    if: needs.parse_comment.outputs.command == 'prepare'
+    uses: ./.github/workflows/release_prepare.yaml
+    with:
+      issue: ${{ needs.parse_comment.outputs.issue_number }}
+    secrets: inherit
+
+  call_process_backports:
+    needs: parse_comment
+    if: needs.parse_comment.outputs.command == 'process-backports'
+    uses: ./.github/workflows/release_process_backports.yaml
+    with:
+      issue: ${{ needs.parse_comment.outputs.issue_number }}
+    secrets: inherit

--- a/.github/workflows/release_create_rc.yaml
+++ b/.github/workflows/release_create_rc.yaml
@@ -7,6 +7,12 @@ on:
         description: 'The Release Tracking Issue Number (e.g., 142)'
         required: true
         type: string
+  workflow_call:
+    inputs:
+      issue:
+        description: 'The Release Tracking Issue Number (e.g., 142)'
+        required: true
+        type: string
 
 permissions:
   contents: write

--- a/.github/workflows/release_prepare.yaml
+++ b/.github/workflows/release_prepare.yaml
@@ -2,7 +2,17 @@ name: "Release: Prepare"
 
 on:
   workflow_dispatch:
-    # Allow manual triggering to prepare the release immediately
+    inputs:
+      issue:
+        description: 'The Release Tracking Issue Number (e.g., 142)'
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      issue:
+        description: 'The Release Tracking Issue Number (e.g., 142)'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -30,7 +40,7 @@ jobs:
 
       - name: Run Release Preparation Pipeline
         run: |
-          # Manual trigger: run full preparation
-          bazel run //tools/private/release -- prepare --no-dry-run
+          bazel run //tools/private/release -- \
+            prepare ${{ inputs.issue && format('--issue={0}', inputs.issue) || '' }} --no-dry-run
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_process_backports.yaml
+++ b/.github/workflows/release_process_backports.yaml
@@ -7,6 +7,12 @@ on:
         description: 'The Release Tracking Issue Number (e.g., 142)'
         required: true
         type: string
+  workflow_call:
+    inputs:
+      issue:
+        description: 'The Release Tracking Issue Number (e.g., 142)'
+        required: true
+        type: string
 
 permissions:
   contents: write


### PR DESCRIPTION
Allows maintainers to trigger release workflows (prepare, create-rc, process-backports) by commenting on the release tracking issue. This automates the release process further and reduces the need to manually trigger workflows from the GitHub Actions UI.

- Created a central `on_issue_comment.yaml` workflow to parse comments.
- Updated `release_prepare.yaml`, `release_create_rc.yaml`, and `release_process_backports.yaml` to be reusable workflows.
- Updated the release tracking issue template to document the new comment commands.
