### PR TITLE
chore(release): grant write permissions to on_issue_comment workflow

### DIFF
--- a/.github/workflows/on_issue_comment.yaml
+++ b/.github/workflows/on_issue_comment.yaml
@@ -5,8 +5,8 @@ on:
     types: [created]
 
 permissions:
-  contents: read
-  issues: read
+  contents: write
+  issues: write
 
 jobs:
   # This job always runs to prevent GHA from marking the run as failed when


### PR DESCRIPTION
Update on_issue_comment.yaml to request contents: write and issues: write permissions, which are required for the called reusable workflows.