### PR TITLE
chore(release): secure workflows against shell injection

### DIFF
--- a/.github/workflows/release_create_rc.yaml
+++ b/.github/workflows/release_create_rc.yaml
@@ -41,11 +41,12 @@ jobs:
 
       - name: Attempt RC Tagging
         id: tagger
-        run: |
-          bazel run //tools/private/release -- \
-            create-rc --issue ${{ inputs.issue }} --remote origin
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ inputs.issue }}
+        run: |
+          bazel run //tools/private/release -- \
+            create-rc --issue "$ISSUE" --remote origin
 
   call_release:
     needs: tag_rc

--- a/.github/workflows/release_prepare.yaml
+++ b/.github/workflows/release_prepare.yaml
@@ -39,8 +39,13 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Run Release Preparation Pipeline
-        run: |
-          bazel run //tools/private/release -- \
-            prepare ${{ inputs.issue && format('--issue={0}', inputs.issue) || '' }} --no-dry-run
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ inputs.issue }}
+        run: |
+          ARGS=()
+          if [ -n "$ISSUE" ]; then
+            ARGS+=("--issue=$ISSUE")
+          fi
+          bazel run //tools/private/release -- \
+            prepare "${ARGS[@]}" --no-dry-run

--- a/.github/workflows/release_process_backports.yaml
+++ b/.github/workflows/release_process_backports.yaml
@@ -55,19 +55,22 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Process Pending Backports
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ADD_BACKPORTS: ${{ inputs.add_backports }}
+          COMMENT_ID: ${{ inputs.comment_id }}
+          ISSUE: ${{ inputs.issue }}
         run: |
           ARGS=()
-          if [ -n "${{ inputs.add_backports }}" ]; then
-            ARGS+=("--add=${{ inputs.add_backports }}")
+          if [ -n "$ADD_BACKPORTS" ]; then
+            ARGS+=("--add=$ADD_BACKPORTS")
           fi
-          if [ -n "${{ inputs.comment_id }}" ]; then
-            ARGS+=("--triggering-comment=${{ inputs.comment_id }}")
+          if [ -n "$COMMENT_ID" ]; then
+            ARGS+=("--triggering-comment=$COMMENT_ID")
           fi
           
           bazel run //tools/private/release -- process-backports \
-            --issue ${{ inputs.issue }} \
+            --issue "$ISSUE" \
             --remote origin \
             --no-dry-run \
             "${ARGS[@]}"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_promote_rc.yaml
+++ b/.github/workflows/release_promote_rc.yaml
@@ -42,17 +42,19 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Run Promote RC
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          ISSUE: ${{ inputs.issue }}
         run: |
           ARGS=()
-          if [ -n "${{ inputs.version }}" ]; then
-            ARGS+=("${{ inputs.version }}")
+          if [ -n "$VERSION" ]; then
+            ARGS+=("$VERSION")
           fi
-          if [ -n "${{ inputs.issue }}" ]; then
-            ARGS+=("--issue" "${{ inputs.issue }}")
+          if [ -n "$ISSUE" ]; then
+            ARGS+=("--issue" "$ISSUE")
           fi
           ARGS+=("--remote" "origin")
           ARGS+=("--no-dry-run")
           
           bazel run //tools/private/release -- promote-rc "${ARGS[@]}"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Pass workflow inputs as environment variables instead of expanding them directly in run scripts to prevent shell injection.

The shell expansions were guarded by collaborator checks, but best to prevent
any type of injection.