### PR TITLE
chore(release): fix promote-rc command and update workflow args

### DIFF
--- a/.github/workflows/release_promote_rc.yaml
+++ b/.github/workflows/release_promote_rc.yaml
@@ -52,9 +52,9 @@ jobs:
             ARGS+=("$VERSION")
           fi
           if [ -n "$ISSUE" ]; then
-            ARGS+=("--issue" "$ISSUE")
+            ARGS+=("--issue=$ISSUE")
           fi
-          ARGS+=("--remote" "origin")
+          ARGS+=("--remote=origin")
           ARGS+=("--no-dry-run")
           
           bazel run //tools/private/release -- promote-rc "${ARGS[@]}"

--- a/tests/tools/private/release/promote_rc_test.py
+++ b/tests/tools/private/release/promote_rc_test.py
@@ -34,7 +34,7 @@ class CmdPromoteRcTest(unittest.TestCase):
             ]
         )
         self.mock_git.get_commit_sha.assert_has_calls(
-            [call("2.0.0-rc1"), call(remote_ref="my-remote/release/2.0")]
+            [call("2.0.0-rc1"), call("my-remote/release/2.0")]
         )
         self.mock_git.checkout.assert_not_called()
         self.mock_git.tag_exists.assert_called_once_with("2.0.0")
@@ -85,7 +85,7 @@ class CmdPromoteRcTest(unittest.TestCase):
         )
         self.mock_gh.get_release_tracking_issue.assert_called_once_with("2.0.0")
         self.mock_git.get_commit_sha.assert_has_calls(
-            [call("2.0.0-rc1"), call(remote_ref="my-remote/release/2.0")]
+            [call("2.0.0-rc1"), call("my-remote/release/2.0")]
         )
         self.mock_git.checkout.assert_not_called()
         self.mock_git.tag.assert_called_once_with("2.0.0", "abcdef123456")
@@ -136,7 +136,7 @@ class CmdPromoteRcTest(unittest.TestCase):
 
         self.mock_git.checkout.assert_not_called()
         self.mock_git.get_commit_sha.assert_has_calls(
-            [call("2.0.1-rc0"), call(remote_ref="my-remote/release/2.0")]
+            [call("2.0.1-rc0"), call("my-remote/release/2.0")]
         )
         self.mock_git.tag.assert_called_once_with("2.0.1", "12345678")
         self.mock_git.push.assert_called_once_with("my-remote", "2.0.1")
@@ -181,7 +181,7 @@ class CmdPromoteRcTest(unittest.TestCase):
             ]
         )
         self.mock_git.get_commit_sha.assert_has_calls(
-            [call("2.0.0-rc1"), call(remote_ref="my-remote/release/2.0")]
+            [call("2.0.0-rc1"), call("my-remote/release/2.0")]
         )
         self.mock_git.tag_exists.assert_called_once_with("2.0.0")
 

--- a/tools/private/release/promote_rc.py
+++ b/tools/private/release/promote_rc.py
@@ -89,7 +89,7 @@ class PromoteRc:
         print(f"Fetching remote branch {remote_branch}...")
         self.git.fetch(args.remote, refspec=branch_name)
         try:
-            branch_sha = self.git.get_commit_sha(remote_ref=remote_branch)
+            branch_sha = self.git.get_commit_sha(remote_branch)
         except Exception as e:
             print(
                 f"Error: Could not get commit SHA for remote branch"


### PR DESCRIPTION
Currently, the `promote-rc` command fails because it calls `Git.get_commit_sha` with an invalid keyword argument `remote_ref`. Additionally, we want to align argument passing in the workflow with the `=` style.

To fix this:
- Remove the invalid `remote_ref` keyword argument from `Git.get_commit_sha` call in `promote_rc.py`.
- Update `promote_rc_test.py` mock assertions to match the corrected call.
- Update `release_promote_rc.yaml` to pass `--issue` and `--remote` arguments using `=`.