### PR TITLE
chore(release): make promote_rc workflow call publish_release workflow to finish publishing

### DIFF
--- a/.github/workflows/release_promote_rc.yaml
+++ b/.github/workflows/release_promote_rc.yaml
@@ -25,6 +25,8 @@ permissions:
 jobs:
   promote:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.promote.outputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -42,6 +44,7 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Run Promote RC
+        id: promote
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ inputs.version }}
@@ -58,3 +61,11 @@ jobs:
           ARGS+=("--no-dry-run")
           
           bazel run //tools/private/release -- promote-rc "${ARGS[@]}"
+
+  publish:
+    needs: promote
+    uses: ./.github/workflows/release_publish.yaml
+    with:
+      tag_name: ${{ needs.promote.outputs.version }}
+      publish_to_pypi: true
+    secrets: inherit

--- a/tests/tools/private/release/promote_rc_test.py
+++ b/tests/tools/private/release/promote_rc_test.py
@@ -83,7 +83,7 @@ class CmdPromoteRcTest(unittest.TestCase):
         # Assert
         self.assertEqual(result, 0)
         self.assertTrue(os.path.exists(github_output_path))
-        content = Path(github_output_path).read_text()
+        content = Path(github_output_path).read_text(encoding="utf-8")
         self.assertEqual(content, "version=2.0.0\n")
 
     def test_promote_rc_resolve_issue_success(self):

--- a/tests/tools/private/release/promote_rc_test.py
+++ b/tests/tools/private/release/promote_rc_test.py
@@ -1,5 +1,8 @@
 import argparse
+import os
+import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import call, patch
 
 from tests.tools.private.release.release_test_helper import _mock_git_and_gh
@@ -10,6 +13,8 @@ from tools.private.release.promote_rc import PromoteRc
 class CmdPromoteRcTest(unittest.TestCase):
     def setUp(self):
         _mock_git_and_gh(self)
+        self.test_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.test_dir.cleanup)
 
     def test_promote_rc_success(self):
         # Arrange
@@ -58,6 +63,28 @@ class CmdPromoteRcTest(unittest.TestCase):
             "- [Release workflow status](https://github.com/bazel-contrib/rules_python/actions/workflows/release_promote_rc.yaml)"
         )
         self.mock_gh.post_issue_comment.assert_called_once_with(123, expected_comment)
+
+    def test_promote_rc_writes_github_output(self):
+        # Arrange
+        github_output_path = os.path.join(self.test_dir.name, "github_output")
+        args = argparse.Namespace(
+            version="2.0.0", issue=123, dry_run=False, remote="my-remote"
+        )
+        self.mock_git.get_remote_tags.return_value = ["2.0.0-rc0", "2.0.0-rc1"]
+        self.mock_git.get_commit_sha.return_value = "abcdef123456"
+        self.mock_git.tag_exists.return_value = False
+        initial_body = "- [ ] Tag Final"
+        self.mock_gh.get_issue_body.return_value = initial_body
+
+        # Act
+        with patch.dict("os.environ", {"GITHUB_OUTPUT": github_output_path}):
+            result = PromoteRc(args, self.mock_git, self.mock_gh).run()
+
+        # Assert
+        self.assertEqual(result, 0)
+        self.assertTrue(os.path.exists(github_output_path))
+        content = Path(github_output_path).read_text()
+        self.assertEqual(content, "version=2.0.0\n")
 
     def test_promote_rc_resolve_issue_success(self):
         # Arrange

--- a/tools/private/release/promote_rc.py
+++ b/tools/private/release/promote_rc.py
@@ -157,6 +157,10 @@ class PromoteRc:
         self.git.tag(version, commit_sha)
         self.git.push(args.remote, version)
 
+        if github_output := os.environ.get("GITHUB_OUTPUT"):
+            with open(github_output, "a") as f:
+                f.write(f"version={version}\n")
+
         print(f"Updating tracking issue #{issue_num} checklist...")
         self.gh.update_issue_body(issue_num, updated_body)
 

--- a/tools/private/release/promote_rc.py
+++ b/tools/private/release/promote_rc.py
@@ -158,7 +158,7 @@ class PromoteRc:
         self.git.push(args.remote, version)
 
         if github_output := os.environ.get("GITHUB_OUTPUT"):
-            with open(github_output, "a") as f:
+            with open(github_output, "a", encoding="utf-8") as f:
                 f.write(f"version={version}\n")
 
         print(f"Updating tracking issue #{issue_num} checklist...")


### PR DESCRIPTION
Why: The tagging done by promote_rc doesn't trigger the on-tag trigger of the publish workflow (due to GITHUB_TOKEN restriction).

How:
- Modified promote_rc.py to output the promoted version to GITHUB_OUTPUT.
- Modified release_promote_rc.yaml to capture this version and chain the release_publish workflow.
- Added unit tests for GITHUB_OUTPUT writing in promote_rc_test.py.