### PR TITLE
chore: remove stale process-backports-before-rc news file

### DIFF
--- a/news/process-backports-before-rc.changed.md
+++ b/news/process-backports-before-rc.changed.md
@@ -1,3 +1,0 @@
-Changed `/create-rc` command to automatically process pending backports before
-creating the RC, and react with a thumbs-down emoji on failure if triggered by
-a comment.


### PR DESCRIPTION
This news file was left over from a previous release process and is no longer needed.

Removed the file `news/process-backports-before-rc.changed.md`.