### PR TITLE
chore(release): fix invalid workflow file syntax

### DIFF
--- a/.github/workflows/release_create_release_branch.yaml
+++ b/.github/workflows/release_create_release_branch.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   cut_branch:
     # Run only if the issue has the type: release label
-    if: contains(github.event.issue.labels.*.name, 'type: release')
+    if: "contains(github.event.issue.labels.*.name, 'type: release')"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Quote the 'if' condition in release_create_release_branch.yaml to fix YAML syntax error.