### PR TITLE
fix: make executable implicit defaults public so other modules can use rule builders

### DIFF
--- a/.bazelrc.deleted_packages
+++ b/.bazelrc.deleted_packages
@@ -7,6 +7,7 @@ common --deleted_packages=examples/bzlmod/entry_points/tests
 common --deleted_packages=examples/bzlmod/libs/my_lib
 common --deleted_packages=examples/bzlmod/other_module
 common --deleted_packages=examples/bzlmod/other_module/other_module/pkg
+common --deleted_packages=examples/bzlmod/other_module/other_module/rule_builder
 common --deleted_packages=examples/bzlmod/patches
 common --deleted_packages=examples/bzlmod/runfiles
 common --deleted_packages=examples/bzlmod/tests

--- a/examples/bzlmod/other_module/other_module/rule_builder/BUILD.bazel
+++ b/examples/bzlmod/other_module/other_module/rule_builder/BUILD.bazel
@@ -1,0 +1,13 @@
+load(":rule.bzl", "custom_py_binary")
+
+# This target's mere existence is the regression test: analyzing it exercises
+# the implicit attr defaults (build_data_writer, debugger_if_target_config,
+# uncachable_version_file) that py_binary_rule_builder() bundles from
+# rules_python's private package, from a rule() call made in this external
+# module.
+custom_py_binary(
+    name = "app",
+    srcs = ["app.py"],
+    main = "app.py",
+    visibility = ["//visibility:public"],
+)

--- a/examples/bzlmod/other_module/other_module/rule_builder/app.py
+++ b/examples/bzlmod/other_module/other_module/rule_builder/app.py
@@ -1,0 +1,1 @@
+print("hello from a rule built via py_binary_rule_builder()")

--- a/examples/bzlmod/other_module/other_module/rule_builder/rule.bzl
+++ b/examples/bzlmod/other_module/other_module/rule_builder/rule.bzl
@@ -1,0 +1,17 @@
+"""A minimal custom py_binary built via the executables rule builder API.
+
+Regression coverage for https://github.com/bazel-contrib/rules_python/pull/3919:
+py_binary_rule_builder()'s implicit attr defaults (build_data_writer,
+debugger_if_target_config, uncachable_version_file) previously had no
+visibility outside of rules_python, so any external module (like this one)
+constructing a rule via the builder failed at analysis time with a
+visibility error.
+"""
+
+load("@rules_python//python/api:executables.bzl", "executables")
+
+def _make_rule():
+    builder = executables.py_binary_rule_builder()
+    return builder.build()
+
+custom_py_binary = _make_rule()

--- a/examples/bzlmod/tests/other_module/BUILD.bazel
+++ b/examples/bzlmod/tests/other_module/BUILD.bazel
@@ -14,6 +14,17 @@ build_test(
     ],
 )
 
+# Regression test for https://github.com/bazel-contrib/rules_python/pull/3919: py_binary_rule_builder()'s implicit
+# attr defaults previously had no visibility outside of rules_python, so
+# building this target (defined via the builder from an external module)
+# failed at analysis time with a visibility error.
+build_test(
+    name = "other_module_rule_builder_build_test",
+    targets = [
+        "@our_other_module//other_module/rule_builder:app",
+    ],
+)
+
 py_test(
     name = "other_module_import_test",
     srcs = ["other_module_import_test.py"],

--- a/news/3919.fixed.md
+++ b/news/3919.fixed.md
@@ -1,0 +1,3 @@
+Fixed `py_binary_rule_builder()` / `py_test_rule_builder()` (from `python/api/executables.bzl`)
+failing at analysis time with a visibility error when used to construct a custom rule from an
+external module.

--- a/python/private/BUILD.bazel
+++ b/python/private/BUILD.bazel
@@ -69,10 +69,16 @@ alias(
         "@platforms//os:windows": ":build_data_writer.ps1",
         "//conditions:default": ":build_data_writer.sh",
     }),
+    # Not actually public. Only public because it's an implicit dependency of
+    # rules built via py_binary_rule_builder() / py_test_rule_builder().
+    visibility = ["//visibility:public"],
 )
 
 define_uncachable_version_file(
     name = "uncachable_version_file",
+    # Not actually public. Only public because it's an implicit dependency of
+    # rules built via py_binary_rule_builder() / py_test_rule_builder().
+    visibility = ["//visibility:public"],
 )
 
 # Needed to define bzl_library targets for docgen. (We don't define the
@@ -159,6 +165,9 @@ alias(
         ":is_bazel_config_mode_target": "//python/config_settings:debugger",
         "//conditions:default": "//python/private:empty",
     }),
+    # Not actually public. Only public because it's an implicit dependency of
+    # rules built via py_binary_rule_builder() / py_test_rule_builder().
+    visibility = ["//visibility:public"],
 )
 
 bazel_config_mode(name = "bazel_config_mode")
@@ -208,10 +217,18 @@ current_interpreter_executable(
 
 py_library(
     name = "empty",
+    # Not actually public. Only public because it's the resolved default of
+    # debugger_if_target_config, an implicit dependency of rules built via
+    # py_binary_rule_builder() / py_test_rule_builder().
+    visibility = ["//visibility:public"],
 )
 
 sentinel(
     name = "sentinel",
+    # Not actually public. Only public because it's the resolved default of
+    # uncachable_version_file, an implicit dependency of rules built via
+    # py_binary_rule_builder() / py_test_rule_builder().
+    visibility = ["//visibility:public"],
 )
 
 py_binary(

--- a/python/private/uncachable_version_file.bzl
+++ b/python/private/uncachable_version_file.bzl
@@ -28,12 +28,13 @@ actions depending on this file will always re-run.
     implementation = _uncachable_version_file_impl,
 )
 
-def define_uncachable_version_file(name):
+def define_uncachable_version_file(name, visibility = None):
     native.alias(
         name = name,
         actual = select({
             ":stamp_detect": ":uncachable_version_file_impl",
             "//conditions:default": ":sentinel",
         }),
+        visibility = visibility,
     )
     uncachable_version_file(name = "uncachable_version_file_impl")


### PR DESCRIPTION
`create_executable_rule_builder()` (used by `py_binary_rule_builder()` /
`py_test_rule_builder()`, the public `python/api/executables.bzl` API)
bundles three implicit attrs whose defaults point at private targets
under `//python/private`: `build_data_writer`,
`debugger_if_target_config`, and `uncachable_version_file`. These
targets had no explicit visibility, so they inherited the package's
`default_visibility` (`//:__subpackages__`), which only covers packages
inside the rules_python repo itself.

Because the builder API is designed to let external modules call
`rule()` themselves (via `builder.build()`), Bazel checks visibility of
these attr defaults from the *calling* module's package, not from
rules_python's. Any external repo constructing a rule via
`py_binary_rule_builder()` / `py_test_rule_builder()` therefore fails at
analysis time with a visibility error.

This has been broken since the builder API's introduction; there's prior
art in this same file for exactly this situation (e.g.
`stage1_bootstrap_template`, among others)