### PR TITLE
chore(reviewbot): fix antigravity_review execution and configuration

### DIFF
--- a/.github/workflows/automated_pr_review.yaml
+++ b/.github/workflows/automated_pr_review.yaml
@@ -50,15 +50,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v8.3.0
 
-      - name: Set up Python and Virtual Environment
-        run: |
-          uv python install 3.13
-          uv venv --python 3.13
-
-      - name: Install Dependencies
-        run: |
-          uv pip install google-antigravity requests
-
       - name: Run Antigravity Review
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/tools/private/reviewbot/antigravity_review.py
+++ b/tools/private/reviewbot/antigravity_review.py
@@ -34,7 +34,7 @@ async def main():
     # Register the review-pr skill from the local reviewbot folder.
     config = LocalAgentConfig(
         system_instructions=system_instructions,
-        skills_paths=["tools/private/reviewbot/skills/review-pr/SKILL.md"],
+        skills_paths=[str(Path(__file__).parent / "skills" / "review-pr" / "SKILL.md")],
         capabilities=CapabilitiesConfig(
             allow_filesystem_read=True,
             allow_filesystem_write=False,

--- a/tools/private/reviewbot/antigravity_review.py
+++ b/tools/private/reviewbot/antigravity_review.py
@@ -24,10 +24,17 @@ async def main():
     # Read prompt file
     prompt = Path(args.prompt).read_text()
 
+    # General coordinator instructions for the reviewer agent.
+    system_instructions = (
+        "You are a code review assistant. Use your available skills to perform "
+        "reviews on pull requests."
+    )
+
     # Initialize the Antigravity Agent in read-only mode for security.
     # Register the review-pr skill from the local reviewbot folder.
     config = LocalAgentConfig(
-        skills_paths=["tools/private/reviewbot/skills/review-pr"],
+        system_instructions=system_instructions,
+        skills_paths=["tools/private/reviewbot/skills/review-pr/SKILL.md"],
         capabilities=CapabilitiesConfig(
             allow_filesystem_read=True,
             allow_filesystem_write=False,
@@ -35,13 +42,7 @@ async def main():
         ),
     )
 
-    # General coordinator instructions for the reviewer agent.
-    system_instructions = (
-        "You are a code review assistant. Use your available skills to perform "
-        "reviews on pull requests."
-    )
-
-    async with Agent(config, system_instructions=system_instructions) as agent:
+    async with Agent(config) as agent:
         response = await agent.chat(prompt)
         report = await response.text()
 

--- a/tools/private/reviewbot/antigravity_review.py
+++ b/tools/private/reviewbot/antigravity_review.py
@@ -1,3 +1,10 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "google-antigravity",
+#     "requests",
+# ]
+# ///
 import argparse
 import asyncio
 from pathlib import Path


### PR DESCRIPTION
Currently, running `antigravity_review.py` with `uv run` fails because it lacks PEP 723 dependency metadata and passes `system_instructions` to `Agent` instead of `LocalAgentConfig`. Also, `skills_paths` points to the skill directory rather than the `SKILL.md` file.

To fix, add inline PEP 723 script metadata declaring dependencies, pass `system_instructions` to `LocalAgentConfig`, and target `SKILL.md` directly in `skills_paths`.