### PR TITLE
feat: add flag aliases to Starlark-defined flags

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -326,25 +326,22 @@ uv_dev.configure(
     version = "0.11.2",
 )
 
-# Temporarily comment out these flag aliases because they break Bazel 9
-# when transitions are also used with a target.
-#
-# flag_alias(
-#     name = "build_python_zip",
-#     starlark_flag = "//python/config_settings:build_python_zip",
-# )
+flag_alias(
+    name = "build_python_zip",
+    starlark_flag = "//python/config_settings:build_python_zip",
+)
 
-# flag_alias(
-#     name = "incompatible_default_to_explicit_init_py",
-#     starlark_flag = "//python/config_settings:incompatible_default_to_explicit_init_py",
-# )
+flag_alias(
+    name = "incompatible_default_to_explicit_init_py",
+    starlark_flag = "//python/config_settings:incompatible_default_to_explicit_init_py",
+)
 
-# flag_alias(
-#     name = "python_path",
-#     starlark_flag = "//python/config_settings:python_path",
-# )
+flag_alias(
+    name = "python_path",
+    starlark_flag = "//python/config_settings:python_path",
+)
 
-# flag_alias(
-#     name = "experimental_python_import_all_repositories",
-#     starlark_flag = "//python/config_settings:experimental_python_import_all_repositories",
-# )
+flag_alias(
+    name = "experimental_python_import_all_repositories",
+    starlark_flag = "//python/config_settings:experimental_python_import_all_repositories",
+)

--- a/news/3932.added.md
+++ b/news/3932.added.md
@@ -1,0 +1,3 @@
+(bzlmod) Added MODULE.bazel flag aliases for Starlark-defined flags:
+`build_python_zip`, `incompatible_default_to_explicit_init_py`,
+`python_path`, and `experimental_python_import_all_repositories`.


### PR DESCRIPTION
This was breaking rules_python CI with Bazel 9.0.0. 

@aranguyen and I made some changes that we thought would resolve in 9.1.0 or 9.2.0. 

The repro I tried on 9.0.0 now passes:

Tested:

```
USE_BAZEL_VERSION=9.0.0 bazelisk build --nobuild //tests/py_zipapp:system_python_zipapp
ERROR: Analysis of target '//tests/py_zipapp:system_python_zipapp' failed; build aborted: no such package '@@rules_python//python/config_settings': The repository '@@rules_python' could not be resolved: Repository '@@rules_python' is not defined
```

```
USE_BAZEL_VERSION=9.2.0 bazelisk build --nobuild //tests/py_zipapp:system_python_zipapp
INFO: Build completed successfully, 0 total actions
```

References:

- https://github.com/bazel-contrib/rules_python/pull/3450#issuecomment-3974932245
- https://github.com/bazel-contrib/rules_python/pull/3450#issuecomment-3986798612
