### PR TITLE
refactor(tools): migrate private release tool tests to pytest and pytest-mock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,8 +50,6 @@ become the commit message upon merge.
   and pass the public fixture name using the `name` parameter in
   `@pytest.fixture(name="foo")`.
 
-
-
 ### Starlark style
 
 For doc strings, using triple quoted strings when the doc string is more than
@@ -107,7 +105,6 @@ def _test_foo_impl(env, target):
 def foo_test_suite(name):
     test_suite(name=name, tests=_tests)
 ```
-
 
 #### Repository rules
 
@@ -166,7 +163,6 @@ This repository contains 3 Bazel bzlmod modules.
  * All other code is part of `@rules_python`.
 
 `tests/support/` contains utility code and helpers for testing.
-
 
 `python/config_settings/BUILD.bazel` contains build flags that are part of the
 public API. DO NOT add, remove, or modify these build flags unless specifically

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,16 @@ because it interferes with code review comments.
 Follow the advice in `CONTRIBUTING.md` for PR descriptions. PR descriptions
 become the commit message upon merge.
 
+### Python pytest conventions
+
+* When registering pytest fixtures from helper modules in test files, use
+  `pytest_plugins = ["<module_path>"]`.
+* Name fixture functions with a `fixture_` prefix (e.g. `def fixture_foo():`),
+  and pass the public fixture name using the `name` parameter in
+  `@pytest.fixture(name="foo")`.
+
+
+
 ### Starlark style
 
 For doc strings, using triple quoted strings when the doc string is more than

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -19,4 +19,5 @@ dependencies = [
     "markupsafe",
     "pytest",
     "pytest-bazel",
+    "pytest-mock",
 ]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -309,9 +309,9 @@ myst-parser==3.0.1 ; python_full_version < '3.10' \
     --hash=sha256:6457aaa33a5d474aca678b8ead9b3dc298e89c68e67012e73146ea6fd54babf1 \
     --hash=sha256:88f0cb406cb363b077d176b51c476f62d60604d68a8dcdf4832e080441301a87
     # via rules-python-docs (docs/pyproject.toml)
-myst-parser==5.1.0 ; python_full_version == '3.10.*' \
-    --hash=sha256:9c91c52b3cdb4d94a6506e4fab4e2f296c7623a0da0dcbe6de1565c3dad67a8a \
-    --hash=sha256:ab69322dc6719dcc7f296479dbb70181b66df6ed315064f92dbc85c0e1bf2f02
+myst-parser==4.0.1 ; python_full_version == '3.10.*' \
+    --hash=sha256:5cfea715e4f3574138aecbf7d54132296bfd72bb614d31168f48c477a830a7c4 \
+    --hash=sha256:9134e88959ec3b5780aedf8a99680ea242869d012e8821db3126d427edc9c95d
     # via rules-python-docs (docs/pyproject.toml)
 myst-parser==5.1.0 ; python_full_version >= '3.11' \
     --hash=sha256:9c91c52b3cdb4d94a6506e4fab4e2f296c7623a0da0dcbe6de1565c3dad67a8a \
@@ -352,14 +352,20 @@ pytest==8.4.2 ; python_full_version < '3.10' \
     # via
     #   rules-python-docs (docs/pyproject.toml)
     #   pytest-bazel
+    #   pytest-mock
 pytest==9.1.1 ; python_full_version >= '3.10' \
     --hash=sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313 \
     --hash=sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c
     # via
     #   rules-python-docs (docs/pyproject.toml)
     #   pytest-bazel
+    #   pytest-mock
 pytest-bazel==0.1.6 \
     --hash=sha256:a29e80e1d67c3db801bdd4d0b6b742f2bfb48cd6841caa33401458e5c4e29c21
+    # via rules-python-docs (docs/pyproject.toml)
+pytest-mock==3.15.1 \
+    --hash=sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d \
+    --hash=sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f
     # via rules-python-docs (docs/pyproject.toml)
 pyyaml==6.0.3 \
     --hash=sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c \

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -718,6 +718,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -871,6 +884,7 @@ dependencies = [
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest-bazel" },
+    { name = "pytest-mock" },
     { name = "readthedocs-sphinx-ext" },
     { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
@@ -893,6 +907,7 @@ requires-dist = [
     { name = "pyelftools" },
     { name = "pytest" },
     { name = "pytest-bazel" },
+    { name = "pytest-mock" },
     { name = "readthedocs-sphinx-ext" },
     { name = "sphinx" },
     { name = "sphinx-autodoc2" },

--- a/tests/tools/private/release/BUILD.bazel
+++ b/tests/tools/private/release/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_python//python:defs.bzl", "py_library", "py_test")
+load("//python:py_library.bzl", "py_library")
+load("//tests/support/pytest_test:pytest_test.bzl", "pytest_test")
 
 py_library(
     name = "release_test_helper",
@@ -9,7 +10,7 @@ py_library(
     ],
 )
 
-py_test(
+pytest_test(
     name = "add_backports_test",
     srcs = ["add_backports_test.py"],
     deps = [
@@ -18,7 +19,7 @@ py_test(
     ],
 )
 
-py_test(
+pytest_test(
     name = "changelog_news_test",
     srcs = ["changelog_news_test.py"],
     deps = [
@@ -27,7 +28,7 @@ py_test(
     ],
 )
 
-py_test(
+pytest_test(
     name = "complete_sync_changelog_test",
     srcs = ["complete_sync_changelog_test.py"],
     deps = [
@@ -36,7 +37,7 @@ py_test(
     ],
 )
 
-py_test(
+pytest_test(
     name = "create_rc_test",
     srcs = ["create_rc_test.py"],
     deps = [
@@ -45,7 +46,7 @@ py_test(
     ],
 )
 
-py_test(
+pytest_test(
     name = "create_release_branch_test",
     srcs = ["create_release_branch_test.py"],
     deps = [
@@ -54,7 +55,7 @@ py_test(
     ],
 )
 
-py_test(
+pytest_test(
     name = "gh_test",
     srcs = ["gh_test.py"],
     deps = [
@@ -62,7 +63,7 @@ py_test(
     ],
 )
 
-py_test(
+pytest_test(
     name = "git_test",
     srcs = ["git_test.py"],
     deps = [
@@ -70,7 +71,7 @@ py_test(
     ],
 )
 
-py_test(
+pytest_test(
     name = "on_pr_merged_test",
     srcs = ["on_pr_merged_test.py"],
     deps = [
@@ -79,7 +80,7 @@ py_test(
     ],
 )
 
-py_test(
+pytest_test(
     name = "prepare_test",
     srcs = ["prepare_test.py"],
     deps = [
@@ -88,7 +89,7 @@ py_test(
     ],
 )
 
-py_test(
+pytest_test(
     name = "process_backports_test",
     srcs = ["process_backports_test.py"],
     deps = [
@@ -97,7 +98,7 @@ py_test(
     ],
 )
 
-py_test(
+pytest_test(
     name = "promote_test",
     srcs = ["promote_test.py"],
     deps = [
@@ -106,7 +107,7 @@ py_test(
     ],
 )
 
-py_test(
+pytest_test(
     name = "release_issue_test",
     srcs = ["release_issue_test.py"],
     deps = [
@@ -114,7 +115,7 @@ py_test(
     ],
 )
 
-py_test(
+pytest_test(
     name = "release_test",
     srcs = ["release_test.py"],
     deps = [
@@ -122,7 +123,7 @@ py_test(
     ],
 )
 
-py_test(
+pytest_test(
     name = "utils_test",
     srcs = ["utils_test.py"],
     deps = [
@@ -132,7 +133,7 @@ py_test(
     ],
 )
 
-py_test(
+pytest_test(
     name = "backport_prepare_test",
     srcs = ["backport_prepare_test.py"],
     deps = [
@@ -141,7 +142,7 @@ py_test(
     ],
 )
 
-py_test(
+pytest_test(
     name = "backport_create_releases_test",
     srcs = ["backport_create_releases_test.py"],
     deps = [

--- a/tests/tools/private/release/BUILD.bazel
+++ b/tests/tools/private/release/BUILD.bazel
@@ -7,7 +7,7 @@ py_library(
     deps = [
         "//tools/private/release:mock_gh",
         "//tools/private/release:release_lib",
-        "@pypi//pytest_mock",
+        "@dev_pip//pytest_mock",
     ],
 )
 

--- a/tests/tools/private/release/BUILD.bazel
+++ b/tests/tools/private/release/BUILD.bazel
@@ -7,6 +7,7 @@ py_library(
     deps = [
         "//tools/private/release:mock_gh",
         "//tools/private/release:release_lib",
+        "@pypi//pytest_mock",
     ],
 )
 
@@ -59,6 +60,7 @@ pytest_test(
     name = "gh_test",
     srcs = ["gh_test.py"],
     deps = [
+        ":release_test_helper",
         "//tools/private/release:release_lib",
     ],
 )
@@ -67,6 +69,7 @@ pytest_test(
     name = "git_test",
     srcs = ["git_test.py"],
     deps = [
+        ":release_test_helper",
         "//tools/private/release:release_lib",
     ],
 )

--- a/tests/tools/private/release/BUILD.bazel
+++ b/tests/tools/private/release/BUILD.bazel
@@ -1,19 +1,22 @@
 load("//python:py_library.bzl", "py_library")
+load("//tests/support:support.bzl", "SUPPORTS_BZLMOD")
 load("//tests/support/pytest_test:pytest_test.bzl", "pytest_test")
 
 py_library(
     name = "release_test_helper",
     srcs = ["release_test_helper.py"],
+    target_compatible_with = SUPPORTS_BZLMOD,
     deps = [
         "//tools/private/release:mock_gh",
         "//tools/private/release:release_lib",
-        "@dev_pip//pytest_mock",
+        "@pypi//pytest_mock",
     ],
 )
 
 pytest_test(
     name = "add_backports_test",
     srcs = ["add_backports_test.py"],
+    target_compatible_with = SUPPORTS_BZLMOD,
     deps = [
         ":release_test_helper",
         "//tools/private/release:release_lib",
@@ -23,6 +26,7 @@ pytest_test(
 pytest_test(
     name = "changelog_news_test",
     srcs = ["changelog_news_test.py"],
+    target_compatible_with = SUPPORTS_BZLMOD,
     deps = [
         ":release_test_helper",
         "//tools/private/release:release_lib",
@@ -32,15 +36,7 @@ pytest_test(
 pytest_test(
     name = "complete_sync_changelog_test",
     srcs = ["complete_sync_changelog_test.py"],
-    deps = [
-        ":release_test_helper",
-        "//tools/private/release:release_lib",
-    ],
-)
-
-pytest_test(
-    name = "create_rc_test",
-    srcs = ["create_rc_test.py"],
+    target_compatible_with = SUPPORTS_BZLMOD,
     deps = [
         ":release_test_helper",
         "//tools/private/release:release_lib",
@@ -50,15 +46,7 @@ pytest_test(
 pytest_test(
     name = "create_release_branch_test",
     srcs = ["create_release_branch_test.py"],
-    deps = [
-        ":release_test_helper",
-        "//tools/private/release:release_lib",
-    ],
-)
-
-pytest_test(
-    name = "gh_test",
-    srcs = ["gh_test.py"],
+    target_compatible_with = SUPPORTS_BZLMOD,
     deps = [
         ":release_test_helper",
         "//tools/private/release:release_lib",
@@ -68,6 +56,7 @@ pytest_test(
 pytest_test(
     name = "git_test",
     srcs = ["git_test.py"],
+    target_compatible_with = SUPPORTS_BZLMOD,
     deps = [
         ":release_test_helper",
         "//tools/private/release:release_lib",
@@ -77,24 +66,7 @@ pytest_test(
 pytest_test(
     name = "on_pr_merged_test",
     srcs = ["on_pr_merged_test.py"],
-    deps = [
-        ":release_test_helper",
-        "//tools/private/release:release_lib",
-    ],
-)
-
-pytest_test(
-    name = "prepare_test",
-    srcs = ["prepare_test.py"],
-    deps = [
-        ":release_test_helper",
-        "//tools/private/release:release_lib",
-    ],
-)
-
-pytest_test(
-    name = "process_backports_test",
-    srcs = ["process_backports_test.py"],
+    target_compatible_with = SUPPORTS_BZLMOD,
     deps = [
         ":release_test_helper",
         "//tools/private/release:release_lib",
@@ -104,6 +76,7 @@ pytest_test(
 pytest_test(
     name = "promote_test",
     srcs = ["promote_test.py"],
+    target_compatible_with = SUPPORTS_BZLMOD,
     deps = [
         ":release_test_helper",
         "//tools/private/release:release_lib",
@@ -113,7 +86,9 @@ pytest_test(
 pytest_test(
     name = "release_issue_test",
     srcs = ["release_issue_test.py"],
+    target_compatible_with = SUPPORTS_BZLMOD,
     deps = [
+        ":release_test_helper",
         "//tools/private/release:release_lib",
     ],
 )
@@ -121,24 +96,7 @@ pytest_test(
 pytest_test(
     name = "release_test",
     srcs = ["release_test.py"],
-    deps = [
-        "//tools/private/release:release_lib",
-    ],
-)
-
-pytest_test(
-    name = "utils_test",
-    srcs = ["utils_test.py"],
-    deps = [
-        ":release_test_helper",
-        "//tools/private/release:release_lib",
-        "@dev_pip//packaging",
-    ],
-)
-
-pytest_test(
-    name = "backport_prepare_test",
-    srcs = ["backport_prepare_test.py"],
+    target_compatible_with = SUPPORTS_BZLMOD,
     deps = [
         ":release_test_helper",
         "//tools/private/release:release_lib",
@@ -148,6 +106,67 @@ pytest_test(
 pytest_test(
     name = "backport_create_releases_test",
     srcs = ["backport_create_releases_test.py"],
+    target_compatible_with = SUPPORTS_BZLMOD,
+    deps = [
+        ":release_test_helper",
+        "//tools/private/release:release_lib",
+    ],
+)
+
+pytest_test(
+    name = "prepare_test",
+    srcs = ["prepare_test.py"],
+    target_compatible_with = SUPPORTS_BZLMOD,
+    deps = [
+        ":release_test_helper",
+        "//tools/private/release:release_lib",
+    ],
+)
+
+pytest_test(
+    name = "gh_test",
+    srcs = ["gh_test.py"],
+    target_compatible_with = SUPPORTS_BZLMOD,
+    deps = [
+        ":release_test_helper",
+        "//tools/private/release:release_lib",
+    ],
+)
+
+pytest_test(
+    name = "backport_prepare_test",
+    srcs = ["backport_prepare_test.py"],
+    target_compatible_with = SUPPORTS_BZLMOD,
+    deps = [
+        ":release_test_helper",
+        "//tools/private/release:release_lib",
+    ],
+)
+
+pytest_test(
+    name = "process_backports_test",
+    srcs = ["process_backports_test.py"],
+    target_compatible_with = SUPPORTS_BZLMOD,
+    deps = [
+        ":release_test_helper",
+        "//tools/private/release:release_lib",
+    ],
+)
+
+pytest_test(
+    name = "create_rc_test",
+    srcs = ["create_rc_test.py"],
+    target_compatible_with = SUPPORTS_BZLMOD,
+    deps = [
+        ":release_test_helper",
+        "//tools/private/release:release_lib",
+    ],
+)
+
+pytest_test(
+    name = "utils_test",
+    srcs = ["utils_test.py"],
+    target_compatible_with = SUPPORTS_BZLMOD,
     deps = [
         ":release_test_helper",
         "//tools/private/release:release_lib",

--- a/tests/tools/private/release/add_backports_test.py
+++ b/tests/tools/private/release/add_backports_test.py
@@ -1,89 +1,85 @@
 import argparse
-import unittest
-from unittest.mock import patch
 
-from tests.tools.private.release.release_test_helper import _mock_git_and_gh
 from tools.private.release.add_backports import AddBackports
 
+pytest_plugins = ["tests.tools.private.release.release_test_helper"]
 
-class CmdAddBackportsTest(unittest.TestCase):
-    def setUp(self):
-        _mock_git_and_gh(self)
-        self.addCleanup(patch.stopall)
-        self.mock_gh.resolve_pr_number.side_effect = lambda x: int(
-            x.lstrip("#").split("/")[-1]
-        )
 
-    def test_add_backports_explicit_issue(self):
-        args = argparse.Namespace(issue=123, prs=["124", "125"])
-        self.mock_gh.get_issue_body.return_value = """
+def test_add_backports_explicit_issue(mock_gh):
+    args = argparse.Namespace(issue=123, prs=["124", "125"])
+    mock_gh.issues[123] = {
+        "title": "Release 2.1.0",
+        "body": """
 ## Checklist
 - [ ] Prepare Release
 - [ ] Create Release branch
 - [ ] Tag Final
 
 ## Backports
-"""
-        result = AddBackports(args, self.mock_gh).run()
+""",
+        "labels": ["type: release"],
+        "number": 123,
+        "url": "https://github.com/bazel-contrib/rules_python/issues/123",
+    }
+    result = AddBackports(args, mock_gh).run()
 
-        self.assertEqual(result, 0)
-        self.mock_gh.get_issue_body.assert_called_once_with(123)
-        self.mock_gh.update_issue_body.assert_called_once()
-        call_args = self.mock_gh.update_issue_body.call_args[0]
-        self.assertEqual(call_args[0], 123)
-        self.assertIn("- [ ] #124", call_args[1])
-        self.assertIn("- [ ] #125", call_args[1])
-        # Should also auto-add Tag RC0
-        self.assertIn("- [ ] Tag RC0", call_args[1])
-        self.assertIn("- [ ] Sync Changelog #124", call_args[1])
-        self.assertIn("- [ ] Sync Changelog #125", call_args[1])
+    assert result == 0
+    updated_body = mock_gh.get_issue_body(123)
+    assert "- [ ] #124" in updated_body
+    assert "- [ ] #125" in updated_body
+    assert "- [ ] Tag RC0" in updated_body
+    assert "- [ ] Sync Changelog #124" in updated_body
+    assert "- [ ] Sync Changelog #125" in updated_body
 
-    def test_add_backports_auto_discover_success(self):
-        args = argparse.Namespace(issue=None, prs=["124"])
-        self.mock_gh.get_open_tracking_issues.return_value = [
-            {"number": 456, "title": "Release 2.1.0", "url": "http://..."}
-        ]
-        self.mock_gh.get_issue_body.return_value = """
+
+def test_add_backports_auto_discover_success(mock_gh):
+    args = argparse.Namespace(issue=None, prs=["124"])
+    issue_num = mock_gh.create_issue(
+        title="Release 2.1.0",
+        body="""
 ## Checklist
 - [ ] Prepare Release
 - [ ] Create Release branch
 - [ ] Tag Final
 
 ## Backports
-"""
-        result = AddBackports(args, self.mock_gh).run()
+""",
+        labels=["type: release"],
+    )
+    result = AddBackports(args, mock_gh).run()
 
-        self.assertEqual(result, 0)
-        self.mock_gh.get_open_tracking_issues.assert_called_once()
-        self.mock_gh.get_issue_body.assert_called_once_with(456)
-        self.mock_gh.update_issue_body.assert_called_once_with(456, unittest.mock.ANY)
+    assert result == 0
+    updated_body = mock_gh.get_issue_body(issue_num)
+    assert "- [ ] #124" in updated_body
 
-    def test_add_backports_auto_discover_no_issues(self):
-        args = argparse.Namespace(issue=None, prs=["124"])
-        self.mock_gh.get_open_tracking_issues.return_value = []
 
-        result = AddBackports(args, self.mock_gh).run()
+def test_add_backports_auto_discover_no_issues(mock_gh):
+    args = argparse.Namespace(issue=None, prs=["124"])
 
-        self.assertEqual(result, 1)
-        self.mock_gh.get_open_tracking_issues.assert_called_once()
-        self.mock_gh.get_issue_body.assert_not_called()
+    result = AddBackports(args, mock_gh).run()
 
-    def test_add_backports_auto_discover_multiple_issues(self):
-        args = argparse.Namespace(issue=None, prs=["124"])
-        self.mock_gh.get_open_tracking_issues.return_value = [
-            {"number": 456, "title": "Release 2.1.0", "url": "http://..."},
-            {"number": 789, "title": "Release 2.2.0", "url": "http://..."},
-        ]
+    assert result == 1
 
-        result = AddBackports(args, self.mock_gh).run()
 
-        self.assertEqual(result, 1)
-        self.mock_gh.get_open_tracking_issues.assert_called_once()
-        self.mock_gh.get_issue_body.assert_not_called()
+def test_add_backports_auto_discover_multiple_issues(mock_gh):
+    args = argparse.Namespace(issue=None, prs=["124"])
+    mock_gh.create_issue(
+        title="Release 2.1.0", body="## Backports\n", labels=["type: release"]
+    )
+    mock_gh.create_issue(
+        title="Release 2.2.0", body="## Backports\n", labels=["type: release"]
+    )
 
-    def test_add_backports_no_auto_add_rc_if_pending(self):
-        args = argparse.Namespace(issue=123, prs=["124"])
-        self.mock_gh.get_issue_body.return_value = """
+    result = AddBackports(args, mock_gh).run()
+
+    assert result == 1
+
+
+def test_add_backports_no_auto_add_rc_if_pending(mock_gh):
+    args = argparse.Namespace(issue=123, prs=["124"])
+    mock_gh.issues[123] = {
+        "title": "Release 2.1.0",
+        "body": """
 ## Checklist
 - [ ] Prepare Release
 - [ ] Create Release branch
@@ -91,17 +87,15 @@ class CmdAddBackportsTest(unittest.TestCase):
 - [ ] Tag Final
 
 ## Backports
-"""
-        result = AddBackports(args, self.mock_gh).run()
+""",
+        "labels": ["type: release"],
+        "number": 123,
+        "url": "https://github.com/bazel-contrib/rules_python/issues/123",
+    }
+    result = AddBackports(args, mock_gh).run()
 
-        self.assertEqual(result, 0)
-        self.mock_gh.update_issue_body.assert_called_once()
-        call_args = self.mock_gh.update_issue_body.call_args[0]
-        self.assertNotIn("Tag RC1", call_args[1])
-        # Tag RC0 should still be there
-        self.assertIn("- [ ] Tag RC0", call_args[1])
-        self.assertIn("- [ ] Sync Changelog #124", call_args[1])
-
-
-if __name__ == "__main__":
-    unittest.main()
+    assert result == 0
+    updated_body = mock_gh.get_issue_body(123)
+    assert "Tag RC1" not in updated_body
+    assert "- [ ] Tag RC0" in updated_body
+    assert "- [ ] Sync Changelog #124" in updated_body

--- a/tests/tools/private/release/backport_create_releases_test.py
+++ b/tests/tools/private/release/backport_create_releases_test.py
@@ -1,18 +1,18 @@
 import argparse
-import unittest
 
-from tests.tools.private.release.release_test_helper import ReleaseToolTestCase
 from tools.private.release.backport_create_releases import BackportCreateReleases
 
+# Register pytest fixtures (such as release_tool_env) from release_test_helper
+pytest_plugins = ["tests.tools.private.release.release_test_helper"]
 
-class CmdBackportCreateReleasesTest(ReleaseToolTestCase):
-    def test_create_releases_all_success(self):
-        # Arrange
-        args = argparse.Namespace(issue=123, dry_run=False)
-        gh = self.gh
 
-        # Setup backport issue in mock GH
-        backport_body = """* PR: #456
+def test_create_releases_all_success(release_tool_env, mock_gh):
+    # Arrange
+    args = argparse.Namespace(issue=123, dry_run=False)
+    gh = mock_gh
+
+    # Setup backport issue in mock GH
+    backport_body = """* PR: #456
 * From version: 1.7
 * To version: 1.9
 
@@ -25,36 +25,36 @@ class CmdBackportCreateReleasesTest(ReleaseToolTestCase):
 - [ ] Track Release 1.8.1
 - [ ] Track Release 1.9.0"""
 
-        gh.issues[123] = {
-            "title": "Backport: #456",
-            "body": backport_body,
-            "labels": ["type:backport-pr"],
-            "number": 123,
-            "url": "https://github.com/.../issues/123",
-        }
+    gh.issues[123] = {
+        "title": "Backport: #456",
+        "body": backport_body,
+        "labels": ["type:backport-pr"],
+        "number": 123,
+        "url": "https://github.com/.../issues/123",
+    }
 
-        # Act
-        result = BackportCreateReleases(args, gh).run()
+    # Act
+    result = BackportCreateReleases(args, gh).run()
 
-        # Assert
-        self.assertEqual(result, 0)
+    # Assert
+    assert result == 0
 
-        # Verify release issues created (IDs 1001, 1002, 1003)
-        self.assertIn(1001, gh.issues)
-        self.assertIn(1002, gh.issues)
-        self.assertIn(1003, gh.issues)
+    # Verify release issues created (IDs 1001, 1002, 1003)
+    assert 1001 in gh.issues
+    assert 1002 in gh.issues
+    assert 1003 in gh.issues
 
-        # 1.7.2 (patch) should not have Tag RC0
-        self.assertEqual(gh.issues[1001]["title"], "Release 1.7.2")
-        self.assertNotIn("Tag RC0", gh.issues[1001]["body"])
-        self.assertIn("## Backports\n- [ ] #456", gh.issues[1001]["body"])
+    # 1.7.2 (patch) should not have Tag RC0
+    assert gh.issues[1001]["title"] == "Release 1.7.2"
+    assert "Tag RC0" not in gh.issues[1001]["body"]
+    assert "## Backports\n- [ ] #456" in gh.issues[1001]["body"]
 
-        # 1.9.0 (minor) should have Tag RC0
-        self.assertEqual(gh.issues[1003]["title"], "Release 1.9.0")
-        self.assertIn("Tag RC0", gh.issues[1003]["body"])
+    # 1.9.0 (minor) should have Tag RC0
+    assert gh.issues[1003]["title"] == "Release 1.9.0"
+    assert "Tag RC0" in gh.issues[1003]["body"]
 
-        # Verify backport issue updated
-        expected_updated_backport_body = """* PR: #456
+    # Verify backport issue updated
+    expected_updated_backport_body = """* PR: #456
 * From version: 1.7
 * To version: 1.9
 
@@ -67,15 +67,16 @@ class CmdBackportCreateReleasesTest(ReleaseToolTestCase):
 - [x] Track Release 1.8.1 | status=success release_issue=#1002
 - [x] Track Release 1.9.0 | status=success release_issue=#1003"""
 
-        self.assertEqual(gh.issues[123]["body"], expected_updated_backport_body)
+    assert gh.issues[123]["body"] == expected_updated_backport_body
 
-    def test_create_releases_dependency_blocking(self):
-        # Arrange
-        args = argparse.Namespace(issue=123, dry_run=False)
-        gh = self.gh
 
-        # 1.8 failed, 1.7 and 1.9 succeeded
-        backport_body = """* PR: #456
+def test_create_releases_dependency_blocking(release_tool_env, mock_gh):
+    # Arrange
+    args = argparse.Namespace(issue=123, dry_run=False)
+    gh = mock_gh
+
+    # 1.8 failed, 1.7 and 1.9 succeeded
+    backport_body = """* PR: #456
 * From version: 1.7
 * To version: 1.9
 
@@ -88,27 +89,27 @@ class CmdBackportCreateReleasesTest(ReleaseToolTestCase):
 - [ ] Track Release 1.8.1
 - [ ] Track Release 1.9.0"""
 
-        gh.issues[123] = {
-            "title": "Backport: #456",
-            "body": backport_body,
-            "labels": ["type:backport-pr"],
-            "number": 123,
-            "url": "https://github.com/.../issues/123",
-        }
+    gh.issues[123] = {
+        "title": "Backport: #456",
+        "body": backport_body,
+        "labels": ["type:backport-pr"],
+        "number": 123,
+        "url": "https://github.com/.../issues/123",
+    }
 
-        # Act
-        result = BackportCreateReleases(args, gh).run()
+    # Act
+    result = BackportCreateReleases(args, gh).run()
 
-        # Assert
-        self.assertEqual(result, 0)
+    # Assert
+    assert result == 0
 
-        # Only 1.9.0 (ID 1001) should be created. 1.7.2 and 1.8.1 are blocked by 1.8 failure.
-        self.assertEqual(len(gh.issues), 2)  # Backport issue + 1 release issue
-        self.assertIn(1001, gh.issues)
-        self.assertEqual(gh.issues[1001]["title"], "Release 1.9.0")
+    # Only 1.9.0 (ID 1001) should be created. 1.7.2 and 1.8.1 are blocked by 1.8 failure.
+    assert len(gh.issues) == 2  # Backport issue + 1 release issue
+    assert 1001 in gh.issues
+    assert gh.issues[1001]["title"] == "Release 1.9.0"
 
-        # Verify backport issue updated with block statuses
-        expected_updated_backport_body = """* PR: #456
+    # Verify backport issue updated with block statuses
+    expected_updated_backport_body = """* PR: #456
 * From version: 1.7
 * To version: 1.9
 
@@ -121,14 +122,15 @@ class CmdBackportCreateReleasesTest(ReleaseToolTestCase):
 - [ ] Track Release 1.8.1 | status=error-later-release-did-not-apply
 - [x] Track Release 1.9.0 | status=success release_issue=#1001"""
 
-        self.assertEqual(gh.issues[123]["body"], expected_updated_backport_body)
+    assert gh.issues[123]["body"] == expected_updated_backport_body
 
-    def test_create_releases_already_exists(self):
-        # Arrange
-        args = argparse.Namespace(issue=123, dry_run=False)
-        gh = self.gh
 
-        backport_body = """* PR: #456
+def test_create_releases_already_exists(release_tool_env, mock_gh):
+    # Arrange
+    args = argparse.Namespace(issue=123, dry_run=False)
+    gh = mock_gh
+
+    backport_body = """* PR: #456
 * From version: 1.7
 * To version: 1.7
 
@@ -137,30 +139,30 @@ class CmdBackportCreateReleasesTest(ReleaseToolTestCase):
 - [x] Verify apply 1.7 | status=success
 - [ ] Track Release 1.7.2"""
 
-        gh.issues[123] = {
-            "title": "Backport: #456",
-            "body": backport_body,
-            "labels": ["type:backport-pr"],
-            "number": 123,
-            "url": "https://github.com/.../issues/123",
-        }
+    gh.issues[123] = {
+        "title": "Backport: #456",
+        "body": backport_body,
+        "labels": ["type:backport-pr"],
+        "number": 123,
+        "url": "https://github.com/.../issues/123",
+    }
 
-        # Pre-create the release issue to simulate it already existing
-        gh.create_issue(
-            title="Release 1.7.2",
-            body="existing body\n## Backports\n",
-            labels=["type: release"],
-        )  # Will get ID 1001
+    # Pre-create the release issue to simulate it already existing
+    gh.create_issue(
+        title="Release 1.7.2",
+        body="existing body\n## Backports\n",
+        labels=["type: release"],
+    )  # Will get ID 1001
 
-        # Act
-        result = BackportCreateReleases(args, gh).run()
+    # Act
+    result = BackportCreateReleases(args, gh).run()
 
-        # Assert
-        self.assertEqual(result, 0)
-        self.assertEqual(len(gh.issues), 2)
+    # Assert
+    assert result == 0
+    assert len(gh.issues) == 2
 
-        # Should link existing issue 1001
-        expected_updated_backport_body = """* PR: #456
+    # Should link existing issue 1001
+    expected_updated_backport_body = """* PR: #456
 * From version: 1.7
 * To version: 1.7
 
@@ -169,8 +171,4 @@ class CmdBackportCreateReleasesTest(ReleaseToolTestCase):
 - [x] Verify apply 1.7 | status=success
 - [x] Track Release 1.7.2 | status=success release_issue=#1001"""
 
-        self.assertEqual(gh.issues[123]["body"], expected_updated_backport_body)
-
-
-if __name__ == "__main__":
-    unittest.main()
+    assert gh.issues[123]["body"] == expected_updated_backport_body

--- a/tests/tools/private/release/backport_prepare_test.py
+++ b/tests/tools/private/release/backport_prepare_test.py
@@ -1,83 +1,66 @@
 import argparse
-import unittest
-from unittest.mock import call, patch
+from unittest.mock import ANY, call, patch
 
-from tests.tools.private.release.release_test_helper import (
-    ReleaseToolTestCase,
-    _mock_git,
-)
 from tools.private.release.backport_prepare import BackportPrepare
 from tools.private.release.gh import BACKPORT_LABEL
 
+pytest_plugins = ["tests.tools.private.release.release_test_helper"]
 
-class CmdBackportPrepareTest(ReleaseToolTestCase):
-    def setUp(self):
-        super().setUp()
-        _mock_git(self)
-        # Mock changelog_news and determine_next_version
-        self.patcher_news = patch(
-            "tools.private.release.backport_prepare.changelog_news"
-        )
-        self.mock_news = self.patcher_news.start()
 
-        self.patcher_det = patch(
-            "tools.private.release.backport_prepare.determine_next_version"
-        )
-        self.mock_det = self.patcher_det.start()
+def test_prepare_from_issue_success(mock_git, mock_gh):
+    # Arrange
+    args = argparse.Namespace(
+        issue=123,
+        pr=None,
+        from_minor=None,
+        to_minor=None,
+        remote="my-remote",
+        dry_run=False,
+    )
 
-        self.addCleanup(self.patcher_news.stop)
-        self.addCleanup(self.patcher_det.stop)
+    # Setup backport issue in mock GH
+    backport_body = "* PR: #456\n* From version: 1.7\n* To version: 1.9\n"
+    mock_gh.issues[123] = {
+        "title": "Backport: #456",
+        "body": backport_body,
+        "labels": ["type: backport-pr"],
+        "number": 123,
+        "url": "https://github.com/.../issues/123",
+    }
 
-    def test_prepare_from_issue_success(self):
-        # Arrange
-        args = argparse.Namespace(
-            issue=123,
-            pr=None,
-            from_minor=None,
-            to_minor=None,
-            remote="my-remote",
-            dry_run=False,
-        )
+    # Setup PR info in mock GH
+    mock_gh.prs[456] = {
+        "state": "MERGED",
+        "mergeCommit": {"oid": "pr_merge_sha_12345"},
+    }
 
-        # Setup backport issue in mock GH
-        backport_body = "* PR: #456\n* From version: 1.7\n* To version: 1.9\n"
-        self.gh.issues[123] = {
-            "title": "Backport: #456",
-            "body": backport_body,
-            "labels": ["type: backport-pr"],
-            "number": 123,
-            "url": "https://github.com/.../issues/123",
-        }
+    # Mock remote branches
+    mock_git.get_remote_branches.return_value = [
+        "main",
+        "release/1.6",
+        "release/1.7",
+        "release/1.8",
+        "release/1.9",
+        "release/2.0",
+    ]
+    mock_git.get_current_branch.return_value = "work-branch"
 
-        # Setup PR info in mock GH
-        self.gh.prs[456] = {
-            "state": "MERGED",
-            "mergeCommit": {"oid": "pr_merge_sha_12345"},
-        }
-
-        # Mock remote branches
-        self.mock_git.get_remote_branches.return_value = [
-            "main",
-            "release/1.6",
-            "release/1.7",
-            "release/1.8",
-            "release/1.9",
-            "release/2.0",
-        ]
-        self.mock_git.get_current_branch.return_value = "work-branch"
-
-        # Mock next versions
-        self.mock_det.side_effect = ["1.7.2", "1.8.1", "1.9.0"]
+    with patch(
+        "tools.private.release.backport_prepare.changelog_news"
+    ) as mock_news, patch(
+        "tools.private.release.backport_prepare.determine_next_version"
+    ) as mock_det:
+        mock_det.side_effect = ["1.7.2", "1.8.1", "1.9.0"]
 
         # Act
-        result = BackportPrepare(args, self.mock_git, self.gh).run()
+        result = BackportPrepare(args, mock_git, mock_gh).run()
 
         # Assert
-        self.assertEqual(result, 0)
-        self.mock_git.fetch.assert_called_once_with("my-remote", tags=True, force=True)
+        assert result == 0
+        mock_git.fetch.assert_called_once_with("my-remote", tags=True, force=True)
 
         # Verify checkouts and cherry-picks
-        self.mock_git.checkout.assert_has_calls(
+        mock_git.checkout.assert_has_calls(
             [
                 call("release/1.7", track_remote="my-remote"),
                 call("release/1.8", track_remote="my-remote"),
@@ -86,7 +69,7 @@ class CmdBackportPrepareTest(ReleaseToolTestCase):
             ]
         )
 
-        self.mock_git.cherry_pick.assert_has_calls(
+        mock_git.cherry_pick.assert_has_calls(
             [
                 call("pr_merge_sha_12345"),
                 call("pr_merge_sha_12345"),
@@ -95,11 +78,11 @@ class CmdBackportPrepareTest(ReleaseToolTestCase):
         )
 
         # Verify changelog updates
-        self.mock_news.update_changelog.assert_has_calls(
+        mock_news.update_changelog.assert_has_calls(
             [
-                call("1.7.2", unittest.mock.ANY),
-                call("1.8.1", unittest.mock.ANY),
-                call("1.9.0", unittest.mock.ANY),
+                call("1.7.2", ANY),
+                call("1.8.1", ANY),
+                call("1.9.0", ANY),
             ]
         )
 
@@ -118,116 +101,128 @@ class CmdBackportPrepareTest(ReleaseToolTestCase):
             "- [ ] Track Release 1.8.1\n"
             "- [ ] Track Release 1.9.0"
         )
-        self.assertEqual(self.gh.issues[123]["body"], expected_body)
+        assert mock_gh.issues[123]["body"] == expected_body
 
-    def test_prepare_manual_success(self):
-        # Arrange
-        args = argparse.Namespace(
-            issue=None,
-            pr="#456",
-            from_minor="1.7",
-            to_minor="1.8",
-            remote="my-remote",
-            dry_run=False,
-        )
-        self.gh.prs[456] = {
-            "state": "MERGED",
-            "mergeCommit": {"oid": "pr_merge_sha_12345"},
-        }
-        self.mock_git.get_remote_branches.return_value = [
-            "release/1.7",
-            "release/1.8",
-        ]
-        self.mock_git.get_current_branch.return_value = "work-branch"
-        self.mock_det.side_effect = ["1.7.2", "1.8.1"]
+
+def test_prepare_manual_success(mock_git, mock_gh):
+    # Arrange
+    args = argparse.Namespace(
+        issue=None,
+        pr="#456",
+        from_minor="1.7",
+        to_minor="1.8",
+        remote="my-remote",
+        dry_run=False,
+    )
+    mock_gh.prs[456] = {
+        "state": "MERGED",
+        "mergeCommit": {"oid": "pr_merge_sha_12345"},
+    }
+    mock_git.get_remote_branches.return_value = [
+        "release/1.7",
+        "release/1.8",
+    ]
+    mock_git.get_current_branch.return_value = "work-branch"
+
+    with patch("tools.private.release.backport_prepare.changelog_news"), patch(
+        "tools.private.release.backport_prepare.determine_next_version"
+    ) as mock_det:
+        mock_det.side_effect = ["1.7.2", "1.8.1"]
 
         # Act
-        result = BackportPrepare(args, self.mock_git, self.gh).run()
+        result = BackportPrepare(args, mock_git, mock_gh).run()
 
         # Assert
-        self.assertEqual(result, 0)
-        self.assertIn(1001, self.gh.issues)
-        issue = self.gh.issues[1001]
-        self.assertEqual(issue["title"], "Backport: #456")
-        self.assertEqual(issue["labels"], [BACKPORT_LABEL])
+        assert result == 0
+        assert 1001 in mock_gh.issues
+        issue = mock_gh.issues[1001]
+        assert issue["title"] == "Backport: #456"
+        assert issue["labels"] == [BACKPORT_LABEL]
         body = issue["body"]
-        self.assertIn("- [x] Verify apply 1.7 | status=success", body)
-        self.assertIn("- [x] Verify apply 1.8 | status=success", body)
-        self.assertIn("- [ ] Track Release 1.7.2", body)
-        self.assertIn("- [ ] Track Release 1.8.1", body)
+        assert "- [x] Verify apply 1.7 | status=success" in body
+        assert "- [x] Verify apply 1.8 | status=success" in body
+        assert "- [ ] Track Release 1.7.2" in body
+        assert "- [ ] Track Release 1.8.1" in body
 
-    def test_prepare_manual_with_patch_versions(self):
-        # Arrange
-        args = argparse.Namespace(
-            issue=None,
-            pr="#456",
-            from_minor="1.7.0",
-            to_minor="1.8.0",
-            remote="my-remote",
-            dry_run=False,
-        )
-        self.gh.prs[456] = {
-            "state": "MERGED",
-            "mergeCommit": {"oid": "pr_merge_sha_12345"},
-        }
-        self.mock_git.get_remote_branches.return_value = [
-            "release/1.7",
-            "release/1.8",
-        ]
-        self.mock_git.get_current_branch.return_value = "work-branch"
-        self.mock_det.side_effect = ["1.7.2", "1.8.1"]
 
-        # Act
-        result = BackportPrepare(args, self.mock_git, self.gh).run()
+def test_prepare_manual_with_patch_versions(mock_git, mock_gh):
+    # Arrange
+    args = argparse.Namespace(
+        issue=None,
+        pr="#456",
+        from_minor="1.7.0",
+        to_minor="1.8.0",
+        remote="my-remote",
+        dry_run=False,
+    )
+    mock_gh.prs[456] = {
+        "state": "MERGED",
+        "mergeCommit": {"oid": "pr_merge_sha_12345"},
+    }
+    mock_git.get_remote_branches.return_value = [
+        "release/1.7",
+        "release/1.8",
+    ]
+    mock_git.get_current_branch.return_value = "work-branch"
 
-        # Assert
-        self.assertEqual(result, 0)
-        self.assertIn(1001, self.gh.issues)
-        body = self.gh.issues[1001]["body"]
-        self.assertIn("- [x] Verify apply 1.7 | status=success", body)
-        self.assertIn("- [x] Verify apply 1.8 | status=success", body)
-
-    def test_prepare_verify_failed(self):
-        # Arrange
-        args = argparse.Namespace(
-            issue=123,
-            pr=None,
-            from_minor=None,
-            to_minor=None,
-            remote="my-remote",
-            dry_run=False,
-        )
-        issue_body = "* PR: #456\n* From version: 1.7\n* To version: 1.8\n"
-        self.gh.issues[123] = {
-            "title": "Backport: #456",
-            "body": issue_body,
-            "labels": ["type: backport-pr"],
-            "number": 123,
-            "url": "https://github.com/.../issues/123",
-        }
-        self.gh.prs[456] = {
-            "state": "MERGED",
-            "mergeCommit": {"oid": "pr_merge_sha_12345"},
-        }
-        self.mock_git.get_remote_branches.return_value = [
-            "release/1.7",
-            "release/1.8",
-        ]
-        self.mock_git.get_current_branch.return_value = "work-branch"
-        self.mock_det.side_effect = ["1.7.2", "1.8.1"]
-
-        # Mock cherry-pick failure on 1.7 and changelog failure on 1.8
-        self.mock_git.cherry_pick.side_effect = [Exception("Conflict"), None]
-        self.mock_news.update_changelog.side_effect = [Exception("Changelog error")]
+    with patch("tools.private.release.backport_prepare.changelog_news"), patch(
+        "tools.private.release.backport_prepare.determine_next_version"
+    ) as mock_det:
+        mock_det.side_effect = ["1.7.2", "1.8.1"]
 
         # Act
-        result = BackportPrepare(args, self.mock_git, self.gh).run()
+        result = BackportPrepare(args, mock_git, mock_gh).run()
 
         # Assert
-        self.assertEqual(
-            result, 0
-        )  # Returns 0 even if verification fails, it just updates tasks
+        assert result == 0
+        assert 1001 in mock_gh.issues
+        body = mock_gh.issues[1001]["body"]
+        assert "- [x] Verify apply 1.7 | status=success" in body
+        assert "- [x] Verify apply 1.8 | status=success" in body
 
+
+def test_prepare_verify_failed(mock_git, mock_gh):
+    # Arrange
+    args = argparse.Namespace(
+        issue=123,
+        pr=None,
+        from_minor=None,
+        to_minor=None,
+        remote="my-remote",
+        dry_run=False,
+    )
+    issue_body = "* PR: #456\n* From version: 1.7\n* To version: 1.8\n"
+    mock_gh.issues[123] = {
+        "title": "Backport: #456",
+        "body": issue_body,
+        "labels": ["type: backport-pr"],
+        "number": 123,
+        "url": "https://github.com/.../issues/123",
+    }
+    mock_gh.prs[456] = {
+        "state": "MERGED",
+        "mergeCommit": {"oid": "pr_merge_sha_12345"},
+    }
+    mock_git.get_remote_branches.return_value = [
+        "release/1.7",
+        "release/1.8",
+    ]
+    mock_git.get_current_branch.return_value = "work-branch"
+
+    with patch(
+        "tools.private.release.backport_prepare.changelog_news"
+    ) as mock_news, patch(
+        "tools.private.release.backport_prepare.determine_next_version"
+    ) as mock_det:
+        mock_det.side_effect = ["1.7.2", "1.8.1"]
+        mock_git.cherry_pick.side_effect = [Exception("Conflict"), None]
+        mock_news.update_changelog.side_effect = [Exception("Changelog error")]
+
+        # Act
+        result = BackportPrepare(args, mock_git, mock_gh).run()
+
+        # Assert
+        assert result == 0
         expected_body = (
             "* PR: #456\n"
             "* From version: 1.7\n"
@@ -240,8 +235,4 @@ class CmdBackportPrepareTest(ReleaseToolTestCase):
             "- [ ] Track Release 1.7.2\n"
             "- [ ] Track Release 1.8.1"
         )
-        self.assertEqual(self.gh.issues[123]["body"], expected_body)
-
-
-if __name__ == "__main__":
-    unittest.main()
+        assert mock_gh.issues[123]["body"] == expected_body

--- a/tests/tools/private/release/backport_prepare_test.py
+++ b/tests/tools/private/release/backport_prepare_test.py
@@ -1,5 +1,5 @@
 import argparse
-from unittest.mock import ANY, call, patch
+from unittest.mock import ANY, call
 
 from tools.private.release.backport_prepare import BackportPrepare
 from tools.private.release.gh import BACKPORT_LABEL
@@ -7,7 +7,7 @@ from tools.private.release.gh import BACKPORT_LABEL
 pytest_plugins = ["tests.tools.private.release.release_test_helper"]
 
 
-def test_prepare_from_issue_success(mock_git, mock_gh):
+def test_prepare_from_issue_success(mocker, mock_git, mock_gh):
     # Arrange
     args = argparse.Namespace(
         issue=123,
@@ -45,66 +45,65 @@ def test_prepare_from_issue_success(mock_git, mock_gh):
     ]
     mock_git.get_current_branch.return_value = "work-branch"
 
-    with patch(
-        "tools.private.release.backport_prepare.changelog_news"
-    ) as mock_news, patch(
+    mock_news = mocker.patch("tools.private.release.backport_prepare.changelog_news")
+    mock_det = mocker.patch(
         "tools.private.release.backport_prepare.determine_next_version"
-    ) as mock_det:
-        mock_det.side_effect = ["1.7.2", "1.8.1", "1.9.0"]
+    )
+    mock_det.side_effect = ["1.7.2", "1.8.1", "1.9.0"]
 
-        # Act
-        result = BackportPrepare(args, mock_git, mock_gh).run()
+    # Act
+    result = BackportPrepare(args, mock_git, mock_gh).run()
 
-        # Assert
-        assert result == 0
-        mock_git.fetch.assert_called_once_with("my-remote", tags=True, force=True)
+    # Assert
+    assert result == 0
+    mock_git.fetch.assert_called_once_with("my-remote", tags=True, force=True)
 
-        # Verify checkouts and cherry-picks
-        mock_git.checkout.assert_has_calls(
-            [
-                call("release/1.7", track_remote="my-remote"),
-                call("release/1.8", track_remote="my-remote"),
-                call("release/1.9", track_remote="my-remote"),
-                call("work-branch"),  # Restored branch
-            ]
-        )
+    # Verify checkouts and cherry-picks
+    mock_git.checkout.assert_has_calls(
+        [
+            call("release/1.7", track_remote="my-remote"),
+            call("release/1.8", track_remote="my-remote"),
+            call("release/1.9", track_remote="my-remote"),
+            call("work-branch"),  # Restored branch
+        ]
+    )
 
-        mock_git.cherry_pick.assert_has_calls(
-            [
-                call("pr_merge_sha_12345"),
-                call("pr_merge_sha_12345"),
-                call("pr_merge_sha_12345"),
-            ]
-        )
+    mock_git.cherry_pick.assert_has_calls(
+        [
+            call("pr_merge_sha_12345"),
+            call("pr_merge_sha_12345"),
+            call("pr_merge_sha_12345"),
+        ]
+    )
 
-        # Verify changelog updates
-        mock_news.update_changelog.assert_has_calls(
-            [
-                call("1.7.2", ANY),
-                call("1.8.1", ANY),
-                call("1.9.0", ANY),
-            ]
-        )
+    # Verify changelog updates
+    mock_news.update_changelog.assert_has_calls(
+        [
+            call("1.7.2", ANY),
+            call("1.8.1", ANY),
+            call("1.9.0", ANY),
+        ]
+    )
 
-        # Verify issue body update
-        expected_body = (
-            "* PR: #456\n"
-            "* From version: 1.7\n"
-            "* To version: 1.9\n"
-            "\n"
-            "## Tasks\n"
-            "\n"
-            "- [x] Verify apply 1.7 | status=success\n"
-            "- [x] Verify apply 1.8 | status=success\n"
-            "- [x] Verify apply 1.9 | status=success\n"
-            "- [ ] Track Release 1.7.2\n"
-            "- [ ] Track Release 1.8.1\n"
-            "- [ ] Track Release 1.9.0"
-        )
-        assert mock_gh.issues[123]["body"] == expected_body
+    # Verify issue body update
+    expected_body = (
+        "* PR: #456\n"
+        "* From version: 1.7\n"
+        "* To version: 1.9\n"
+        "\n"
+        "## Tasks\n"
+        "\n"
+        "- [x] Verify apply 1.7 | status=success\n"
+        "- [x] Verify apply 1.8 | status=success\n"
+        "- [x] Verify apply 1.9 | status=success\n"
+        "- [ ] Track Release 1.7.2\n"
+        "- [ ] Track Release 1.8.1\n"
+        "- [ ] Track Release 1.9.0"
+    )
+    assert mock_gh.issues[123]["body"] == expected_body
 
 
-def test_prepare_manual_success(mock_git, mock_gh):
+def test_prepare_manual_success(mocker, mock_git, mock_gh):
     # Arrange
     args = argparse.Namespace(
         issue=None,
@@ -124,28 +123,29 @@ def test_prepare_manual_success(mock_git, mock_gh):
     ]
     mock_git.get_current_branch.return_value = "work-branch"
 
-    with patch("tools.private.release.backport_prepare.changelog_news"), patch(
+    mocker.patch("tools.private.release.backport_prepare.changelog_news")
+    mock_det = mocker.patch(
         "tools.private.release.backport_prepare.determine_next_version"
-    ) as mock_det:
-        mock_det.side_effect = ["1.7.2", "1.8.1"]
+    )
+    mock_det.side_effect = ["1.7.2", "1.8.1"]
 
-        # Act
-        result = BackportPrepare(args, mock_git, mock_gh).run()
+    # Act
+    result = BackportPrepare(args, mock_git, mock_gh).run()
 
-        # Assert
-        assert result == 0
-        assert 1001 in mock_gh.issues
-        issue = mock_gh.issues[1001]
-        assert issue["title"] == "Backport: #456"
-        assert issue["labels"] == [BACKPORT_LABEL]
-        body = issue["body"]
-        assert "- [x] Verify apply 1.7 | status=success" in body
-        assert "- [x] Verify apply 1.8 | status=success" in body
-        assert "- [ ] Track Release 1.7.2" in body
-        assert "- [ ] Track Release 1.8.1" in body
+    # Assert
+    assert result == 0
+    assert 1001 in mock_gh.issues
+    issue = mock_gh.issues[1001]
+    assert issue["title"] == "Backport: #456"
+    assert issue["labels"] == [BACKPORT_LABEL]
+    body = issue["body"]
+    assert "- [x] Verify apply 1.7 | status=success" in body
+    assert "- [x] Verify apply 1.8 | status=success" in body
+    assert "- [ ] Track Release 1.7.2" in body
+    assert "- [ ] Track Release 1.8.1" in body
 
 
-def test_prepare_manual_with_patch_versions(mock_git, mock_gh):
+def test_prepare_manual_with_patch_versions(mocker, mock_git, mock_gh):
     # Arrange
     args = argparse.Namespace(
         issue=None,
@@ -165,23 +165,24 @@ def test_prepare_manual_with_patch_versions(mock_git, mock_gh):
     ]
     mock_git.get_current_branch.return_value = "work-branch"
 
-    with patch("tools.private.release.backport_prepare.changelog_news"), patch(
+    mocker.patch("tools.private.release.backport_prepare.changelog_news")
+    mock_det = mocker.patch(
         "tools.private.release.backport_prepare.determine_next_version"
-    ) as mock_det:
-        mock_det.side_effect = ["1.7.2", "1.8.1"]
+    )
+    mock_det.side_effect = ["1.7.2", "1.8.1"]
 
-        # Act
-        result = BackportPrepare(args, mock_git, mock_gh).run()
+    # Act
+    result = BackportPrepare(args, mock_git, mock_gh).run()
 
-        # Assert
-        assert result == 0
-        assert 1001 in mock_gh.issues
-        body = mock_gh.issues[1001]["body"]
-        assert "- [x] Verify apply 1.7 | status=success" in body
-        assert "- [x] Verify apply 1.8 | status=success" in body
+    # Assert
+    assert result == 0
+    assert 1001 in mock_gh.issues
+    body = mock_gh.issues[1001]["body"]
+    assert "- [x] Verify apply 1.7 | status=success" in body
+    assert "- [x] Verify apply 1.8 | status=success" in body
 
 
-def test_prepare_verify_failed(mock_git, mock_gh):
+def test_prepare_verify_failed(mocker, mock_git, mock_gh):
     # Arrange
     args = argparse.Namespace(
         issue=123,
@@ -209,30 +210,29 @@ def test_prepare_verify_failed(mock_git, mock_gh):
     ]
     mock_git.get_current_branch.return_value = "work-branch"
 
-    with patch(
-        "tools.private.release.backport_prepare.changelog_news"
-    ) as mock_news, patch(
+    mock_news = mocker.patch("tools.private.release.backport_prepare.changelog_news")
+    mock_det = mocker.patch(
         "tools.private.release.backport_prepare.determine_next_version"
-    ) as mock_det:
-        mock_det.side_effect = ["1.7.2", "1.8.1"]
-        mock_git.cherry_pick.side_effect = [Exception("Conflict"), None]
-        mock_news.update_changelog.side_effect = [Exception("Changelog error")]
+    )
+    mock_det.side_effect = ["1.7.2", "1.8.1"]
+    mock_git.cherry_pick.side_effect = [Exception("Conflict"), None]
+    mock_news.update_changelog.side_effect = [Exception("Changelog error")]
 
-        # Act
-        result = BackportPrepare(args, mock_git, mock_gh).run()
+    # Act
+    result = BackportPrepare(args, mock_git, mock_gh).run()
 
-        # Assert
-        assert result == 0
-        expected_body = (
-            "* PR: #456\n"
-            "* From version: 1.7\n"
-            "* To version: 1.8\n"
-            "\n"
-            "## Tasks\n"
-            "\n"
-            "- [ ] Verify apply 1.7 | status=failed-conflict\n"
-            "- [ ] Verify apply 1.8 | status=failed-changelog\n"
-            "- [ ] Track Release 1.7.2\n"
-            "- [ ] Track Release 1.8.1"
-        )
-        assert mock_gh.issues[123]["body"] == expected_body
+    # Assert
+    assert result == 0
+    expected_body = (
+        "* PR: #456\n"
+        "* From version: 1.7\n"
+        "* To version: 1.8\n"
+        "\n"
+        "## Tasks\n"
+        "\n"
+        "- [ ] Verify apply 1.7 | status=failed-conflict\n"
+        "- [ ] Verify apply 1.8 | status=failed-changelog\n"
+        "- [ ] Track Release 1.7.2\n"
+        "- [ ] Track Release 1.8.1"
+    )
+    assert mock_gh.issues[123]["body"] == expected_body

--- a/tests/tools/private/release/changelog_news_test.py
+++ b/tests/tools/private/release/changelog_news_test.py
@@ -1,14 +1,171 @@
 import pathlib
-import unittest
 from unittest.mock import patch
 
-from tests.tools.private.release.release_test_helper import TempDirTestCase
+import pytest
+
 from tools.private.release import changelog_news
 
 
-class ChangelogNewsTest(TempDirTestCase):
-    def test_update_changelog_with_news(self):
-        # Arrange
+def test_update_changelog_with_news(tmp_path):
+    # Arrange
+    changelog = """# Changelog
+
+{#unreleased}
+## Unreleased
+
+[unreleased]: https://github.com/bazel-contrib/rules_python/releases/tag/unreleased
+
+Unreleased changes are tracked as individual files in the [news/](./news)
+directory, or view the [latest generated
+changelog](https://rules-python.readthedocs.io/en/latest/changelog.html).
+
+{#v2-0-2}
+## [2.0.2] - 2026-05-14
+
+[2.0.2]: https://github.com/bazel-contrib/rules_python/releases/tag/2.0.2
+
+{#v2-0-2-added}
+### Added
+* (toolchains) Some older change.
+"""
+    changelog_path = tmp_path / "CHANGELOG.md"
+    changelog_path.write_text(changelog)
+
+    news_dir = tmp_path / "news"
+    news_dir.mkdir()
+
+    # Create news files
+    (news_dir / "123.fixed.md").write_text("Fixed a bug in the compiler")
+    # Test that it handles prefixing "* " if not present
+    (news_dir / "456.added.md").write_text("* Added a new feature for Python 3.13")
+    # Empty file should be ignored
+    (news_dir / "789.changed.md").write_text("")
+    # Invalid name should be ignored
+    (news_dir / "invalid_name.md").write_text("Should be ignored")
+
+    # Act
+    changelog_news.update_changelog(
+        "3.0.0",
+        "2026-06-16",
+        changelog_path=changelog_path,
+        news_dir=news_dir,
+    )
+
+    # Assert
+    # 1. News files matching the pattern should be deleted (even empty ones)
+    assert not (news_dir / "123.fixed.md").exists()
+    assert not (news_dir / "456.added.md").exists()
+    assert not (news_dir / "789.changed.md").exists()
+    # Invalid name does not match pattern -> NOT deleted
+    assert (news_dir / "invalid_name.md").exists()
+
+    new_content = changelog_path.read_text()
+
+    # 2. A fresh active Unreleased section should be present
+    assert "{#unreleased}" in new_content
+    assert "## Unreleased" in new_content
+    assert (
+        "Unreleased changes are tracked as individual files in the [news/](./news)\n"
+        "directory, or view the [latest generated\n"
+        "changelog](https://rules-python.readthedocs.io/en/latest/changelog.html)."
+        in new_content
+    )
+
+    # 3. The new release section should be present
+    assert "{#v3-0-0}" in new_content
+    assert "## [3.0.0] - 2026-06-16" in new_content
+    assert (
+        "[3.0.0]: https://github.com/bazel-contrib/rules_python/releases/tag/3.0.0"
+        in new_content
+    )
+
+    # 4. Correct categories and content
+    assert "{#v3-0-0-fixed}\n### Fixed\n* Fixed a bug in the compiler" in new_content
+    assert (
+        "{#v3-0-0-added}\n### Added\n* Added a new feature for Python 3.13"
+        in new_content
+    )
+
+    # 5. Omitted categories should NOT be present in the new release
+    assert "{#v3-0-0-removed}" not in new_content
+    assert "{#v3-0-0-changed}" not in new_content
+
+    # 6. Old release should still be there
+    assert "{#v2-0-2}" in new_content
+    assert "## [2.0.2] - 2026-05-14" in new_content
+
+
+def test_update_changelog_sorting(tmp_path):
+    # Arrange
+    changelog = """# Changelog
+
+{#unreleased}
+## Unreleased
+
+[unreleased]: https://github.com/bazel-contrib/rules_python/releases/tag/unreleased
+
+Unreleased changes are tracked as individual files in the [news/](./news)
+directory, or view the [latest generated
+changelog](https://rules-python.readthedocs.io/en/latest/changelog.html).
+
+{#v2-0-2}
+## [2.0.2] - 2026-05-14
+
+[2.0.2]: https://github.com/bazel-contrib/rules_python/releases/tag/2.0.2
+
+{#v2-0-2-added}
+### Added
+* (toolchains) Some older change.
+"""
+    changelog_path = tmp_path / "CHANGELOG.md"
+    changelog_path.write_text(changelog)
+
+    news_dir = tmp_path / "news"
+    news_dir.mkdir()
+
+    # Create news files with different sub-categories and some without
+    (news_dir / "1.fixed.md").write_text("* (zebra) Zebra fix")
+    (news_dir / "2.fixed.md").write_text("* (apple) Apple fix")
+    (news_dir / "3.fixed.md").write_text("No subcategory B")
+    (news_dir / "4.fixed.md").write_text("* (apple) Another apple fix")
+    (news_dir / "5.fixed.md").write_text("No subcategory A")
+
+    # Act
+    changelog_news.update_changelog(
+        "3.0.0",
+        "2026-06-16",
+        changelog_path=changelog_path,
+        news_dir=news_dir,
+    )
+
+    # Assert
+    new_content = changelog_path.read_text()
+
+    expected_fixed_section = (
+        "### Fixed\n"
+        "* No subcategory A\n"
+        "* No subcategory B\n"
+        "* (apple) Another apple fix\n"
+        "* (apple) Apple fix\n"
+        "* (zebra) Zebra fix\n"
+    )
+
+    assert expected_fixed_section in new_content
+
+
+def test_update_changelog_read_failure(tmp_path):
+    # Arrange
+    original_read_text = pathlib.Path.read_text
+
+    with patch("pathlib.Path.read_text", autospec=True) as mock_read_text:
+
+        def side_effect(path_self, *args, **kwargs):
+            if "bad_file.fixed.md" in str(path_self):
+                raise IOError("Simulated read error")
+            return original_read_text(path_self, *args, **kwargs)
+
+        mock_read_text.side_effect = side_effect
+
         changelog = """# Changelog
 
 {#unreleased}
@@ -29,207 +186,41 @@ changelog](https://rules-python.readthedocs.io/en/latest/changelog.html).
 ### Added
 * (toolchains) Some older change.
 """
-        changelog_path = self.tmpdir / "CHANGELOG.md"
+        changelog_path = tmp_path / "CHANGELOG.md"
         changelog_path.write_text(changelog)
 
-        news_dir = self.tmpdir / "news"
+        news_dir = tmp_path / "news"
         news_dir.mkdir()
 
-        # Create news files
-        (news_dir / "123.fixed.md").write_text("Fixed a bug in the compiler")
-        # Test that it handles prefixing "* " if not present
-        (news_dir / "456.added.md").write_text("* Added a new feature for Python 3.13")
-        # Empty file should be ignored
-        (news_dir / "789.changed.md").write_text("")
-        # Invalid name should be ignored
-        (news_dir / "invalid_name.md").write_text("Should be ignored")
+        # Create the bad file (must exist so it is found by iterdir)
+        bad_file = news_dir / "bad_file.fixed.md"
+        bad_file.write_text("some content that won't be read")
 
-        # Act
-        changelog_news.update_changelog(
-            "3.0.0",
-            "2026-06-16",
-            changelog_path=changelog_path,
-            news_dir=news_dir,
-        )
+        # Create a good file too
+        good_file = news_dir / "good_file.fixed.md"
+        good_file.write_text("* (sub) Good fix")
 
-        # Assert
-        # 1. News files matching the pattern should be deleted (even empty ones)
-        self.assertFalse((news_dir / "123.fixed.md").exists())
-        self.assertFalse((news_dir / "456.added.md").exists())
-        self.assertFalse((news_dir / "789.changed.md").exists())
-        # Invalid name does not match pattern -> NOT deleted
-        self.assertTrue((news_dir / "invalid_name.md").exists())
+        # Act & Assert
+        with pytest.raises(IOError):
+            changelog_news.update_changelog(
+                "3.0.0",
+                "2026-06-16",
+                changelog_path=changelog_path,
+                news_dir=news_dir,
+            )
 
+        # Both files should still exist (no deletion on failure!)
+        assert bad_file.exists()
+        assert good_file.exists()
+
+        # Changelog should not be modified
         new_content = changelog_path.read_text()
+        assert changelog == new_content
 
-        # 2. A fresh active Unreleased section should be present
-        self.assertIn("{#unreleased}", new_content)
-        self.assertIn("## Unreleased", new_content)
-        self.assertIn(
-            "Unreleased changes are tracked as individual files in the [news/](./news)\n"
-            "directory, or view the [latest generated\n"
-            "changelog](https://rules-python.readthedocs.io/en/latest/changelog.html).",
-            new_content,
-        )
 
-        # 3. The new release section should be present
-        self.assertIn("{#v3-0-0}", new_content)
-        self.assertIn("## [3.0.0] - 2026-06-16", new_content)
-        self.assertIn(
-            "[3.0.0]: https://github.com/bazel-contrib/rules_python/releases/tag/3.0.0",
-            new_content,
-        )
-
-        # 4. Correct categories and content
-        self.assertIn(
-            "{#v3-0-0-fixed}\n### Fixed\n* Fixed a bug in the compiler",
-            new_content,
-        )
-        self.assertIn(
-            "{#v3-0-0-added}\n### Added\n* Added a new feature for Python 3.13",
-            new_content,
-        )
-
-        # 5. Omitted categories should NOT be present in the new release
-        self.assertNotIn("{#v3-0-0-removed}", new_content)
-        self.assertNotIn("{#v3-0-0-changed}", new_content)
-
-        # 6. Old release should still be there
-        self.assertIn("{#v2-0-2}", new_content)
-        self.assertIn("## [2.0.2] - 2026-05-14", new_content)
-
-    def test_update_changelog_sorting(self):
-        # Arrange
-        changelog = """# Changelog
-
-{#unreleased}
-## Unreleased
-
-[unreleased]: https://github.com/bazel-contrib/rules_python/releases/tag/unreleased
-
-Unreleased changes are tracked as individual files in the [news/](./news)
-directory, or view the [latest generated
-changelog](https://rules-python.readthedocs.io/en/latest/changelog.html).
-
-{#v2-0-2}
-## [2.0.2] - 2026-05-14
-
-[2.0.2]: https://github.com/bazel-contrib/rules_python/releases/tag/2.0.2
-
-{#v2-0-2-added}
-### Added
-* (toolchains) Some older change.
-"""
-        changelog_path = self.tmpdir / "CHANGELOG.md"
-        changelog_path.write_text(changelog)
-
-        news_dir = self.tmpdir / "news"
-        news_dir.mkdir()
-
-        # Create news files with different sub-categories and some without
-        (news_dir / "1.fixed.md").write_text("* (zebra) Zebra fix")
-        (news_dir / "2.fixed.md").write_text("* (apple) Apple fix")
-        (news_dir / "3.fixed.md").write_text("No subcategory B")
-        (news_dir / "4.fixed.md").write_text("* (apple) Another apple fix")
-        (news_dir / "5.fixed.md").write_text("No subcategory A")
-
-        # Act
-        changelog_news.update_changelog(
-            "3.0.0",
-            "2026-06-16",
-            changelog_path=changelog_path,
-            news_dir=news_dir,
-        )
-
-        # Assert
-        new_content = changelog_path.read_text()
-
-        # Expected order in Fixed section:
-        # 1. No subcategory A
-        # 2. No subcategory B
-        # 3. (apple) Another apple fix
-        # 4. (apple) Apple fix
-        # 5. (zebra) Zebra fix
-
-        expected_fixed_section = (
-            "### Fixed\n"
-            "* No subcategory A\n"
-            "* No subcategory B\n"
-            "* (apple) Another apple fix\n"
-            "* (apple) Apple fix\n"
-            "* (zebra) Zebra fix\n"
-        )
-
-        self.assertIn(expected_fixed_section, new_content)
-
-    def test_update_changelog_read_failure(self):
-        # Arrange
-        original_read_text = pathlib.Path.read_text
-
-        with patch("pathlib.Path.read_text", autospec=True) as mock_read_text:
-
-            def side_effect(path_self, *args, **kwargs):
-                if "bad_file.fixed.md" in str(path_self):
-                    raise IOError("Simulated read error")
-                return original_read_text(path_self, *args, **kwargs)
-
-            mock_read_text.side_effect = side_effect
-
-            changelog = """# Changelog
-
-{#unreleased}
-## Unreleased
-
-[unreleased]: https://github.com/bazel-contrib/rules_python/releases/tag/unreleased
-
-Unreleased changes are tracked as individual files in the [news/](./news)
-directory, or view the [latest generated
-changelog](https://rules-python.readthedocs.io/en/latest/changelog.html).
-
-{#v2-0-2}
-## [2.0.2] - 2026-05-14
-
-[2.0.2]: https://github.com/bazel-contrib/rules_python/releases/tag/2.0.2
-
-{#v2-0-2-added}
-### Added
-* (toolchains) Some older change.
-"""
-            changelog_path = self.tmpdir / "CHANGELOG.md"
-            changelog_path.write_text(changelog)
-
-            news_dir = self.tmpdir / "news"
-            news_dir.mkdir()
-
-            # Create the bad file (must exist so it is found by iterdir)
-            bad_file = news_dir / "bad_file.fixed.md"
-            bad_file.write_text("some content that won't be read")
-
-            # Create a good file too
-            good_file = news_dir / "good_file.fixed.md"
-            good_file.write_text("* (sub) Good fix")
-
-            # Act & Assert
-            # It should raise IOError
-            with self.assertRaises(IOError):
-                changelog_news.update_changelog(
-                    "3.0.0",
-                    "2026-06-16",
-                    changelog_path=changelog_path,
-                    news_dir=news_dir,
-                )
-
-            # Both files should still exist (no deletion on failure!)
-            self.assertTrue(bad_file.exists())
-            self.assertTrue(good_file.exists())
-
-            # Changelog should not be modified
-            new_content = changelog_path.read_text()
-            self.assertEqual(changelog, new_content)
-
-    def test_update_changelog_merge_existing(self):
-        # Arrange
-        changelog = """# Changelog
+def test_update_changelog_merge_existing(tmp_path):
+    # Arrange
+    changelog = """# Changelog
 
 {#unreleased}
 ## Unreleased
@@ -252,57 +243,48 @@ changelog](https://rules-python.readthedocs.io/en/latest/changelog.html).
   * nested bullet item
 * (pypi) Z old fix
 """
-        changelog_path = self.tmpdir / "CHANGELOG.md"
-        changelog_path.write_text(changelog)
+    changelog_path = tmp_path / "CHANGELOG.md"
+    changelog_path.write_text(changelog)
 
-        news_dir = self.tmpdir / "news"
-        news_dir.mkdir()
+    news_dir = tmp_path / "news"
+    news_dir.mkdir()
 
-        # Create news files to merge
-        # 1. New fix in same category (should merge and sort)
-        (news_dir / "1.fixed.md").write_text("(pypi) New fix")
-        # 2. New entry in new category (should create category)
-        (news_dir / "2.added.md").write_text("(toolchains) New feature")
+    # Create news files to merge
+    (news_dir / "1.fixed.md").write_text("(pypi) New fix")
+    (news_dir / "2.added.md").write_text("(toolchains) New feature")
 
-        # Act
-        changelog_news.update_changelog(
-            "2.0.3",
-            "2026-06-15",
-            changelog_path=changelog_path,
-            news_dir=news_dir,
-        )
+    # Act
+    changelog_news.update_changelog(
+        "2.0.3",
+        "2026-06-15",
+        changelog_path=changelog_path,
+        news_dir=news_dir,
+    )
 
-        # Assert
-        # News files should be deleted
-        self.assertFalse((news_dir / "1.fixed.md").exists())
-        self.assertFalse((news_dir / "2.added.md").exists())
+    # Assert
+    assert not (news_dir / "1.fixed.md").exists()
+    assert not (news_dir / "2.added.md").exists()
 
-        new_content = changelog_path.read_text()
+    new_content = changelog_path.read_text()
 
-        # Expected merged and sorted Fixed section:
-        # 1. (pypi) New fix (New < Old)
-        # 2. (pypi) Old fix (with its multi-line detail!)
-        # 3. (pypi) Z old fix
-        expected_fixed_section = (
-            "### Fixed\n"
-            "* (pypi) New fix\n"
-            "* (pypi) Old fix\n"
-            "  multi-line detail\n"
-            "  * nested bullet item\n"
-            "* (pypi) Z old fix\n"
-        )
-        self.assertIn(expected_fixed_section, new_content)
+    expected_fixed_section = (
+        "### Fixed\n"
+        "* (pypi) New fix\n"
+        "* (pypi) Old fix\n"
+        "  multi-line detail\n"
+        "  * nested bullet item\n"
+        "* (pypi) Z old fix\n"
+    )
+    assert expected_fixed_section in new_content
 
-        # Expected created Added section:
-        expected_added_section = "### Added\n* (toolchains) New feature\n"
-        self.assertIn(expected_added_section, new_content)
+    expected_added_section = "### Added\n* (toolchains) New feature\n"
+    assert expected_added_section in new_content
+    assert "Unreleased changes are tracked as individual files" in new_content
 
-        # Active Unreleased section should NOT be touched (should still be empty/pointing to news)
-        self.assertIn("Unreleased changes are tracked as individual files", new_content)
 
-    def test_update_changelog_does_not_leak(self):
-        # Arrange
-        changelog = """# Changelog
+def test_update_changelog_does_not_leak(tmp_path):
+    # Arrange
+    changelog = """# Changelog
 
 {#unreleased}
 ## Unreleased
@@ -320,33 +302,32 @@ changelog](https://rules-python.readthedocs.io/en/latest/changelog.html).
 
 This release body mentions the word unreleased and {#unreleased} anchor to test leaks.
 """
-        changelog_path = self.tmpdir / "CHANGELOG.md"
-        changelog_path.write_text(changelog)
+    changelog_path = tmp_path / "CHANGELOG.md"
+    changelog_path.write_text(changelog)
 
-        news_dir = self.tmpdir / "news"
-        news_dir.mkdir()
-        (news_dir / "1.fixed.md").write_text("Some fix")
+    news_dir = tmp_path / "news"
+    news_dir.mkdir()
+    (news_dir / "1.fixed.md").write_text("Some fix")
 
-        # Act
-        changelog_news.update_changelog(
-            "3.0.0",
-            "2026-06-16",
-            changelog_path=changelog_path,
-            news_dir=news_dir,
-        )
+    # Act
+    changelog_news.update_changelog(
+        "3.0.0",
+        "2026-06-16",
+        changelog_path=changelog_path,
+        news_dir=news_dir,
+    )
 
-        # Assert
-        new_content = changelog_path.read_text()
+    # Assert
+    new_content = changelog_path.read_text()
+    assert (
+        "This release body mentions the word unreleased and {#unreleased} anchor to test leaks."
+        in new_content
+    )
 
-        # The 2.0.2 body should NOT be modified
-        self.assertIn(
-            "This release body mentions the word unreleased and {#unreleased} anchor to test leaks.",
-            new_content,
-        )
 
-    def test_update_changelog_empty_news(self):
-        # Arrange
-        changelog = """# Changelog
+def test_update_changelog_empty_news(tmp_path):
+    # Arrange
+    changelog = """# Changelog
 
 {#unreleased}
 ## Unreleased
@@ -366,39 +347,37 @@ changelog](https://rules-python.readthedocs.io/en/latest/changelog.html).
 ### Added
 * (toolchains) Some older change.
 """
-        changelog_path = self.tmpdir / "CHANGELOG.md"
-        changelog_path.write_text(changelog)
+    changelog_path = tmp_path / "CHANGELOG.md"
+    changelog_path.write_text(changelog)
 
-        news_dir = self.tmpdir / "news"
-        news_dir.mkdir()
+    news_dir = tmp_path / "news"
+    news_dir.mkdir()
 
-        # Act
-        changelog_news.update_changelog(
-            "3.0.0",
-            "2026-06-16",
-            changelog_path=changelog_path,
-            news_dir=news_dir,
-        )
+    # Act
+    changelog_news.update_changelog(
+        "3.0.0",
+        "2026-06-16",
+        changelog_path=changelog_path,
+        news_dir=news_dir,
+    )
 
-        # Assert
-        new_content = changelog_path.read_text()
+    # Assert
+    new_content = changelog_path.read_text()
 
-        # The new release section should be present and contain "No notable changes."
-        self.assertIn("{#v3-0-0}", new_content)
-        self.assertIn("## [3.0.0] - 2026-06-16", new_content)
-        self.assertIn(
-            "[3.0.0]: https://github.com/bazel-contrib/rules_python/releases/tag/3.0.0",
-            new_content,
-        )
-        self.assertIn("No notable changes.", new_content)
+    assert "{#v3-0-0}" in new_content
+    assert "## [3.0.0] - 2026-06-16" in new_content
+    assert (
+        "[3.0.0]: https://github.com/bazel-contrib/rules_python/releases/tag/3.0.0"
+        in new_content
+    )
+    assert "No notable changes." in new_content
+    assert "{#v3-0-0-fixed}" not in new_content
+    assert "{#v3-0-0-added}" not in new_content
 
-        # Verify that we didn't accidentally create any categories
-        self.assertNotIn("{#v3-0-0-fixed}", new_content)
-        self.assertNotIn("{#v3-0-0-added}", new_content)
 
-    def test_update_changelog_selective_news_files(self):
-        # Arrange
-        changelog = """# Changelog
+def test_update_changelog_selective_news_files(tmp_path):
+    # Arrange
+    changelog = """# Changelog
 
 {#unreleased}
 ## Unreleased
@@ -410,39 +389,37 @@ changelog](https://rules-python.readthedocs.io/en/latest/changelog.html).
 
 [2.0.2]: https://github.com/bazel-contrib/rules_python/releases/tag/2.0.2
 """
-        changelog_path = self.tmpdir / "CHANGELOG.md"
-        changelog_path.write_text(changelog)
+    changelog_path = tmp_path / "CHANGELOG.md"
+    changelog_path.write_text(changelog)
 
-        news_dir = self.tmpdir / "news"
-        news_dir.mkdir()
+    news_dir = tmp_path / "news"
+    news_dir.mkdir()
 
-        # Create news files
-        (news_dir / "123.fixed.md").write_text("Fix A")
-        (news_dir / "456.fixed.md").write_text("Fix B")
+    # Create news files
+    (news_dir / "123.fixed.md").write_text("Fix A")
+    (news_dir / "456.fixed.md").write_text("Fix B")
 
-        # Act: Only process 123.fixed.md
-        changelog_news.update_changelog(
-            "2.0.3",
-            "2026-06-16",
-            changelog_path=changelog_path,
-            news_dir=news_dir,
-            news_files=[news_dir / "123.fixed.md"],
-        )
+    # Act: Only process 123.fixed.md
+    changelog_news.update_changelog(
+        "2.0.3",
+        "2026-06-16",
+        changelog_path=changelog_path,
+        news_dir=news_dir,
+        news_files=[news_dir / "123.fixed.md"],
+    )
 
-        # Assert
-        # 1. Only 123.fixed.md should be deleted
-        self.assertFalse((news_dir / "123.fixed.md").exists())
-        self.assertTrue((news_dir / "456.fixed.md").exists())
+    # Assert
+    assert not (news_dir / "123.fixed.md").exists()
+    assert (news_dir / "456.fixed.md").exists()
 
-        new_content = changelog_path.read_text()
+    new_content = changelog_path.read_text()
+    assert "Fix A" in new_content
+    assert "Fix B" not in new_content
 
-        # 2. Only Fix A should be in the changelog
-        self.assertIn("Fix A", new_content)
-        self.assertNotIn("Fix B", new_content)
 
-    def test_update_changelog_insertion_point(self):
-        # Arrange
-        changelog = """# Changelog
+def test_update_changelog_insertion_point(tmp_path):
+    # Arrange
+    changelog = """# Changelog
 
 {#unreleased}
 ## Unreleased
@@ -459,35 +436,35 @@ changelog](https://rules-python.readthedocs.io/en/latest/changelog.html).
 
 [2.0.0]: https://github.com/bazel-contrib/rules_python/releases/tag/2.0.0
 """
-        changelog_path = self.tmpdir / "CHANGELOG.md"
-        changelog_path.write_text(changelog)
+    changelog_path = tmp_path / "CHANGELOG.md"
+    changelog_path.write_text(changelog)
 
-        news_dir = self.tmpdir / "news"
-        news_dir.mkdir()
-        (news_dir / "123.fixed.md").write_text("Fix in 2.1.0")
+    news_dir = tmp_path / "news"
+    news_dir.mkdir()
+    (news_dir / "123.fixed.md").write_text("Fix in 2.1.0")
 
-        # Act: Insert 2.1.0
-        changelog_news.update_changelog(
-            "2.1.0",
-            "2026-06-17",
-            changelog_path=changelog_path,
-            news_dir=news_dir,
-        )
+    # Act: Insert 2.1.0
+    changelog_news.update_changelog(
+        "2.1.0",
+        "2026-06-17",
+        changelog_path=changelog_path,
+        news_dir=news_dir,
+    )
 
-        # Assert
-        new_content = changelog_path.read_text()
+    # Assert
+    new_content = changelog_path.read_text()
 
-        # Verify 2.1.0 is inserted BEFORE 2.0.0 but AFTER 2.2.0
-        idx_2_2_0 = new_content.index("{#v2-2-0}")
-        idx_2_1_0 = new_content.index("{#v2-1-0}")
-        idx_2_0_0 = new_content.index("{#v2-0-0}")
+    idx_2_2_0 = new_content.index("{#v2-2-0}")
+    idx_2_1_0 = new_content.index("{#v2-1-0}")
+    idx_2_0_0 = new_content.index("{#v2-0-0}")
 
-        self.assertTrue(idx_2_2_0 < idx_2_1_0 < idx_2_0_0)
-        self.assertIn("Fix in 2.1.0", new_content)
+    assert idx_2_2_0 < idx_2_1_0 < idx_2_0_0
+    assert "Fix in 2.1.0" in new_content
 
-    def test_update_changelog_insertion_point_too_small(self):
-        # Arrange
-        changelog = """# Changelog
+
+def test_update_changelog_insertion_point_too_small(tmp_path):
+    # Arrange
+    changelog = """# Changelog
 
 {#unreleased}
 ## Unreleased
@@ -499,26 +476,20 @@ changelog](https://rules-python.readthedocs.io/en/latest/changelog.html).
 
 [2.0.0]: https://github.com/bazel-contrib/rules_python/releases/tag/2.0.0
 """
-        changelog_path = self.tmpdir / "CHANGELOG.md"
-        changelog_path.write_text(changelog)
+    changelog_path = tmp_path / "CHANGELOG.md"
+    changelog_path.write_text(changelog)
 
-        news_dir = self.tmpdir / "news"
-        news_dir.mkdir()
-        (news_dir / "123.fixed.md").write_text("Fix in 1.0.0")
+    news_dir = tmp_path / "news"
+    news_dir.mkdir()
+    (news_dir / "123.fixed.md").write_text("Fix in 1.0.0")
 
-        # Act & Assert
-        with self.assertRaises(ValueError) as ctx:
-            changelog_news.update_changelog(
-                "1.0.0",
-                "2026-01-01",
-                changelog_path=changelog_path,
-                news_dir=news_dir,
-            )
-        self.assertIn(
-            "Could not find a version in CHANGELOG.md smaller than 1.0.0",
-            str(ctx.exception),
+    # Act & Assert
+    with pytest.raises(
+        ValueError, match="Could not find a version in CHANGELOG.md smaller than 1.0.0"
+    ):
+        changelog_news.update_changelog(
+            "1.0.0",
+            "2026-01-01",
+            changelog_path=changelog_path,
+            news_dir=news_dir,
         )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/tools/private/release/changelog_news_test.py
+++ b/tests/tools/private/release/changelog_news_test.py
@@ -1,5 +1,4 @@
 import pathlib
-from unittest.mock import patch
 
 import pytest
 
@@ -153,20 +152,23 @@ changelog](https://rules-python.readthedocs.io/en/latest/changelog.html).
     assert expected_fixed_section in new_content
 
 
-def test_update_changelog_read_failure(tmp_path):
+pytest_plugins = ["tests.tools.private.release.release_test_helper"]
+
+
+def test_update_changelog_read_failure(mocker, tmp_path):
     # Arrange
     original_read_text = pathlib.Path.read_text
 
-    with patch("pathlib.Path.read_text", autospec=True) as mock_read_text:
+    mock_read_text = mocker.patch.object(pathlib.Path, "read_text", autospec=True)
 
-        def side_effect(path_self, *args, **kwargs):
-            if "bad_file.fixed.md" in str(path_self):
-                raise IOError("Simulated read error")
-            return original_read_text(path_self, *args, **kwargs)
+    def side_effect(path_self, *args, **kwargs):
+        if "bad_file.fixed.md" in str(path_self):
+            raise IOError("Simulated read error")
+        return original_read_text(path_self, *args, **kwargs)
 
-        mock_read_text.side_effect = side_effect
+    mock_read_text.side_effect = side_effect
 
-        changelog = """# Changelog
+    changelog = """# Changelog
 
 {#unreleased}
 ## Unreleased
@@ -186,36 +188,36 @@ changelog](https://rules-python.readthedocs.io/en/latest/changelog.html).
 ### Added
 * (toolchains) Some older change.
 """
-        changelog_path = tmp_path / "CHANGELOG.md"
-        changelog_path.write_text(changelog)
+    changelog_path = tmp_path / "CHANGELOG.md"
+    changelog_path.write_text(changelog)
 
-        news_dir = tmp_path / "news"
-        news_dir.mkdir()
+    news_dir = tmp_path / "news"
+    news_dir.mkdir()
 
-        # Create the bad file (must exist so it is found by iterdir)
-        bad_file = news_dir / "bad_file.fixed.md"
-        bad_file.write_text("some content that won't be read")
+    # Create the bad file (must exist so it is found by iterdir)
+    bad_file = news_dir / "bad_file.fixed.md"
+    bad_file.write_text("some content that won't be read")
 
-        # Create a good file too
-        good_file = news_dir / "good_file.fixed.md"
-        good_file.write_text("* (sub) Good fix")
+    # Create a good file too
+    good_file = news_dir / "good_file.fixed.md"
+    good_file.write_text("* (sub) Good fix")
 
-        # Act & Assert
-        with pytest.raises(IOError):
-            changelog_news.update_changelog(
-                "3.0.0",
-                "2026-06-16",
-                changelog_path=changelog_path,
-                news_dir=news_dir,
-            )
+    # Act & Assert
+    with pytest.raises(IOError):
+        changelog_news.update_changelog(
+            "3.0.0",
+            "2026-06-16",
+            changelog_path=changelog_path,
+            news_dir=news_dir,
+        )
 
-        # Both files should still exist (no deletion on failure!)
-        assert bad_file.exists()
-        assert good_file.exists()
+    # Both files should still exist (no deletion on failure!)
+    assert bad_file.exists()
+    assert good_file.exists()
 
-        # Changelog should not be modified
-        new_content = changelog_path.read_text()
-        assert changelog == new_content
+    # Changelog should not be modified
+    new_content = changelog_path.read_text()
+    assert changelog == new_content
 
 
 def test_update_changelog_merge_existing(tmp_path):

--- a/tests/tools/private/release/complete_sync_changelog_test.py
+++ b/tests/tools/private/release/complete_sync_changelog_test.py
@@ -1,36 +1,18 @@
 import argparse
-import unittest
-from unittest.mock import patch
 
-from tests.tools.private.release.release_test_helper import _mock_git_and_gh
 from tools.private.release.complete_sync_changelog import CompleteSyncChangelog
 
+pytest_plugins = ["tests.tools.private.release.release_test_helper"]
 
-class CompleteSyncChangelogTest(unittest.TestCase):
-    def setUp(self):
-        _mock_git_and_gh(self)
-        self.addCleanup(patch.stopall)
 
-        # Dynamic mock for issue body
-        self.issue_body = ""
-
-        def mock_get_body(issue_num):
-            return self.issue_body
-
-        def mock_update_body(issue_num, body):
-            self.issue_body = body
-
-        self.mock_gh.get_issue_body.side_effect = mock_get_body
-        self.mock_gh.update_issue_body.side_effect = mock_update_body
-
-    def test_complete_sync_changelog_success(self):
-        args = argparse.Namespace(pr=999)
-        self.mock_gh.get_pr_info.return_value = {
-            "state": "MERGED",
-            "body": "Updates CHANGELOG.md\n\nRelease-Tracking-Issue: #123",
-            "mergeCommit": {"oid": "abcdef1234567890"},
-        }
-        self.issue_body = """
+def test_complete_sync_changelog_success(mock_gh):
+    args = argparse.Namespace(pr=999)
+    mock_gh.prs[999] = {
+        "state": "MERGED",
+        "body": "Updates CHANGELOG.md\n\nRelease-Tracking-Issue: #123",
+        "mergeCommit": {"oid": "abcdef1234567890"},
+    }
+    issue_body = """
 ## Checklist
 - [ ] Prepare Release
 - [ ] Create Release branch
@@ -41,64 +23,66 @@ class CompleteSyncChangelogTest(unittest.TestCase):
 
 ## Backports
 """
-        result = CompleteSyncChangelog(args, self.mock_gh).run()
+    mock_gh.issues[123] = {
+        "title": "Release 2.1.0",
+        "body": issue_body,
+        "labels": ["type: release"],
+        "number": 123,
+        "url": "https://github.com/bazel-contrib/rules_python/issues/123",
+    }
 
-        self.assertEqual(result, 0)
-        self.mock_gh.get_pr_info.assert_called_once_with(999)
-        self.mock_gh.get_issue_body.assert_called_once_with(123)
-        self.mock_gh.update_issue_body.assert_called_once()
+    result = CompleteSyncChangelog(args, mock_gh).run()
 
-        # Check that only tasks pointing to #999 were marked checked=True and status=done
-        self.assertIn(
-            "- [x] Sync Changelog #124 | status=done pr=#999 commit= abcdef12",
-            self.issue_body,
-        )
-        self.assertIn(
-            "- [x] Sync Changelog #125 | status=done pr=#999 commit= abcdef12",
-            self.issue_body,
-        )
-        # Task pointing to #888 should remain unchanged
-        self.assertIn(
-            "- [ ] Sync Changelog #126 | status=pending pr=#888",
-            self.issue_body,
-        )
+    assert result == 0
+    updated_body = mock_gh.get_issue_body(123)
 
-    def test_complete_sync_changelog_not_merged(self):
-        args = argparse.Namespace(pr=999)
-        self.mock_gh.get_pr_info.return_value = {
-            "state": "OPEN",
-            "body": "Updates CHANGELOG.md\n\nRelease-Tracking-Issue: #123",
-        }
+    # Check that only tasks pointing to #999 were marked checked=True and status=done
+    assert (
+        "- [x] Sync Changelog #124 | status=done pr=#999 commit= abcdef12"
+        in updated_body
+    )
+    assert (
+        "- [x] Sync Changelog #125 | status=done pr=#999 commit= abcdef12"
+        in updated_body
+    )
+    # Task pointing to #888 should remain unchanged
+    assert "- [ ] Sync Changelog #126 | status=pending pr=#888" in updated_body
 
-        result = CompleteSyncChangelog(args, self.mock_gh).run()
 
-        self.assertEqual(result, 1)
-        self.mock_gh.get_pr_info.assert_called_once_with(999)
-        self.mock_gh.update_issue_body.assert_not_called()
+def test_complete_sync_changelog_not_merged(mock_gh):
+    args = argparse.Namespace(pr=999)
+    mock_gh.prs[999] = {
+        "state": "OPEN",
+        "body": "Updates CHANGELOG.md\n\nRelease-Tracking-Issue: #123",
+    }
 
-    def test_complete_sync_changelog_missing_tracking_issue_link(self):
-        args = argparse.Namespace(pr=999)
-        self.mock_gh.get_pr_info.return_value = {
-            "state": "MERGED",
-            "body": "Updates CHANGELOG.md without tracking issue link",
-            "mergeCommit": {"oid": "abcdef1234567890"},
-        }
+    result = CompleteSyncChangelog(args, mock_gh).run()
 
-        result = CompleteSyncChangelog(args, self.mock_gh).run()
+    assert result == 1
 
-        self.assertEqual(result, 1)
-        self.mock_gh.get_pr_info.assert_called_once_with(999)
-        self.mock_gh.update_issue_body.assert_not_called()
 
-    def test_complete_sync_changelog_no_matching_tasks(self):
-        args = argparse.Namespace(pr=999)
-        self.mock_gh.get_pr_info.return_value = {
-            "state": "MERGED",
-            "body": "Updates CHANGELOG.md\n\nRelease-Tracking-Issue: #123",
-            "mergeCommit": {"oid": "abcdef1234567890"},
-        }
-        # Checklist has no tasks pointing to #999
-        self.issue_body = """
+def test_complete_sync_changelog_missing_tracking_issue_link(mock_gh):
+    args = argparse.Namespace(pr=999)
+    mock_gh.prs[999] = {
+        "state": "MERGED",
+        "body": "Updates CHANGELOG.md without tracking issue link",
+        "mergeCommit": {"oid": "abcdef1234567890"},
+    }
+
+    result = CompleteSyncChangelog(args, mock_gh).run()
+
+    assert result == 1
+
+
+def test_complete_sync_changelog_no_matching_tasks(mock_gh):
+    args = argparse.Namespace(pr=999)
+    mock_gh.prs[999] = {
+        "state": "MERGED",
+        "body": "Updates CHANGELOG.md\n\nRelease-Tracking-Issue: #123",
+        "mergeCommit": {"oid": "abcdef1234567890"},
+    }
+    # Checklist has no tasks pointing to #999
+    issue_body = """
 ## Checklist
 - [ ] Prepare Release
 - [ ] Create Release branch
@@ -107,14 +91,15 @@ class CompleteSyncChangelogTest(unittest.TestCase):
 
 ## Backports
 """
-        result = CompleteSyncChangelog(args, self.mock_gh).run()
+    mock_gh.issues[123] = {
+        "title": "Release 2.1.0",
+        "body": issue_body,
+        "labels": ["type: release"],
+        "number": 123,
+        "url": "https://github.com/bazel-contrib/rules_python/issues/123",
+    }
 
-        # Should log warning but return 0 (success/noop)
-        self.assertEqual(result, 0)
-        self.mock_gh.get_pr_info.assert_called_once_with(999)
-        self.mock_gh.get_issue_body.assert_called_once_with(123)
-        self.mock_gh.update_issue_body.assert_not_called()
+    result = CompleteSyncChangelog(args, mock_gh).run()
 
-
-if __name__ == "__main__":
-    unittest.main()
+    assert result == 0
+    assert mock_gh.get_issue_body(123) == issue_body

--- a/tests/tools/private/release/create_rc_test.py
+++ b/tests/tools/private/release/create_rc_test.py
@@ -2,14 +2,14 @@ import argparse
 import os
 import pathlib
 import tempfile
-from unittest.mock import call, patch
+from unittest.mock import call
 
 from tools.private.release.create_rc import CreateRc
 
 pytest_plugins = ["tests.tools.private.release.release_test_helper"]
 
 
-def test_create_rc_success_first_rc(mock_git, mock_gh):
+def test_create_rc_success_first_rc(mocker, mock_git, mock_gh):
     # Arrange
     args = argparse.Namespace(
         issue=123, remote="my-remote", triggering_comment=None, dry_run=False
@@ -30,8 +30,8 @@ def test_create_rc_success_first_rc(mock_git, mock_gh):
     # Act
     with tempfile.TemporaryDirectory() as tmpdir:
         github_output_file = pathlib.Path(tmpdir) / "github_output"
-        with patch.dict(os.environ, {"GITHUB_OUTPUT": str(github_output_file)}):
-            result = CreateRc(args, mock_git, mock_gh).run()
+        mocker.patch.dict(os.environ, {"GITHUB_OUTPUT": str(github_output_file)})
+        result = CreateRc(args, mock_git, mock_gh).run()
 
         # Assert
         assert result == 0
@@ -75,7 +75,7 @@ def test_create_rc_success_first_rc(mock_git, mock_gh):
     )
 
 
-def test_create_rc_success_with_run_id(mock_git, mock_gh):
+def test_create_rc_success_with_run_id(mocker, mock_git, mock_gh):
     # Arrange
     args = argparse.Namespace(
         issue=123, remote="my-remote", triggering_comment=None, dry_run=False
@@ -94,8 +94,8 @@ def test_create_rc_success_with_run_id(mock_git, mock_gh):
     mock_git.get_commit_sha.return_value = "1234567890"
 
     # Act
-    with patch.dict(os.environ, {"GITHUB_RUN_ID": "987654321"}):
-        result = CreateRc(args, mock_git, mock_gh).run()
+    mocker.patch.dict(os.environ, {"GITHUB_RUN_ID": "987654321"})
+    result = CreateRc(args, mock_git, mock_gh).run()
 
     # Assert
     assert result == 0
@@ -269,9 +269,9 @@ def test_create_rc_auto_add_task(mock_git, mock_gh):
     assert "- [x] Tag RC1 | status=done tag=2.0.0-rc1 commit= 12345678" in updated_body
 
 
-@patch("tools.private.release.create_rc.ProcessBackports")
-def test_create_rc_calls_process_backports(mock_pb_class, mock_git, mock_gh):
+def test_create_rc_calls_process_backports(mocker, mock_git, mock_gh):
     # Arrange
+    mock_pb_class = mocker.patch("tools.private.release.create_rc.ProcessBackports")
     mock_pb = mock_pb_class.return_value
     mock_pb.run.return_value = 0
 
@@ -306,11 +306,9 @@ def test_create_rc_calls_process_backports(mock_pb_class, mock_git, mock_gh):
     mock_pb.run.assert_called_once()
 
 
-@patch("tools.private.release.create_rc.ProcessBackports")
-def test_create_rc_aborts_on_process_backports_failure(
-    mock_pb_class, mock_git, mock_gh
-):
+def test_create_rc_aborts_on_process_backports_failure(mocker, mock_git, mock_gh):
     # Arrange
+    mock_pb_class = mocker.patch("tools.private.release.create_rc.ProcessBackports")
     mock_pb = mock_pb_class.return_value
     mock_pb.run.return_value = 1
 
@@ -328,9 +326,9 @@ def test_create_rc_aborts_on_process_backports_failure(
     mock_git.tag.assert_not_called()
 
 
-@patch("tools.private.release.create_rc.ProcessBackports")
-def test_create_rc_failure_reacts_to_comment(mock_pb_class, mock_git, mock_gh):
+def test_create_rc_failure_reacts_to_comment(mocker, mock_git, mock_gh):
     # Arrange
+    mock_pb_class = mocker.patch("tools.private.release.create_rc.ProcessBackports")
     mock_pb = mock_pb_class.return_value
     mock_pb.run.return_value = 1  # Simulate failure
 
@@ -346,9 +344,9 @@ def test_create_rc_failure_reacts_to_comment(mock_pb_class, mock_git, mock_gh):
     assert mock_gh.reactions.get(456) == ["-1"]
 
 
-@patch("tools.private.release.create_rc.ProcessBackports")
-def test_create_rc_failure_no_comment_no_reaction(mock_pb_class, mock_git, mock_gh):
+def test_create_rc_failure_no_comment_no_reaction(mocker, mock_git, mock_gh):
     # Arrange
+    mock_pb_class = mocker.patch("tools.private.release.create_rc.ProcessBackports")
     mock_pb = mock_pb_class.return_value
     mock_pb.run.return_value = 1  # Simulate failure
 
@@ -364,9 +362,9 @@ def test_create_rc_failure_no_comment_no_reaction(mock_pb_class, mock_git, mock_
     assert 456 not in mock_gh.reactions
 
 
-@patch("tools.private.release.create_rc.ProcessBackports")
-def test_create_rc_success_with_comment_no_reaction(mock_pb_class, mock_git, mock_gh):
+def test_create_rc_success_with_comment_no_reaction(mocker, mock_git, mock_gh):
     # Arrange
+    mock_pb_class = mocker.patch("tools.private.release.create_rc.ProcessBackports")
     mock_pb = mock_pb_class.return_value
     mock_pb.run.return_value = 0
 
@@ -394,11 +392,9 @@ def test_create_rc_success_with_comment_no_reaction(mock_pb_class, mock_git, moc
     assert 456 not in mock_gh.reactions
 
 
-@patch("tools.private.release.create_rc.ProcessBackports")
-def test_create_rc_precondition_failure_reacts_to_comment(
-    mock_pb_class, mock_git, mock_gh
-):
+def test_create_rc_precondition_failure_reacts_to_comment(mocker, mock_git, mock_gh):
     # Arrange
+    mock_pb_class = mocker.patch("tools.private.release.create_rc.ProcessBackports")
     mock_pb = mock_pb_class.return_value
     mock_pb.run.return_value = 0  # Backports succeed
 

--- a/tests/tools/private/release/create_rc_test.py
+++ b/tests/tools/private/release/create_rc_test.py
@@ -2,177 +2,163 @@ import argparse
 import os
 import pathlib
 import tempfile
-import unittest
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import call, patch
 
-from tests.tools.private.release.release_test_helper import _mock_git_and_gh
 from tools.private.release.create_rc import CreateRc
 
+pytest_plugins = ["tests.tools.private.release.release_test_helper"]
 
-class CmdCreateRcTest(unittest.TestCase):
-    def setUp(self):
-        _mock_git_and_gh(self)
 
-    def test_create_rc_success_first_rc(self):
-        # Arrange
-        args = MagicMock(issue=123, remote="my-remote")
-        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
-        self.mock_gh.get_issue_body.return_value = """
+def test_create_rc_success_first_rc(mock_git, mock_gh):
+    # Arrange
+    args = argparse.Namespace(
+        issue=123, remote="my-remote", triggering_comment=None, dry_run=False
+    )
+    mock_gh.issues[123] = {
+        "title": "Release 2.0.0",
+        "body": """
 ## Checklist
 - [x] Prepare Release | status=done pr=#122 commit=abcdef12
 - [x] Create Release branch | status=done branch=release/2.0 commit=abcdef12
 - [ ] Tag RC0 | status=pending
-"""
-        self.mock_git.get_remote_tags.return_value = []
-        self.mock_git.get_commit_sha.return_value = "1234567890"
+""",
+        "labels": ["type: release"],
+    }
+    mock_git.get_remote_tags.return_value = []
+    mock_git.get_commit_sha.return_value = "1234567890"
 
-        # Act
-        with tempfile.TemporaryDirectory() as tmpdir:
-            github_output_file = pathlib.Path(tmpdir) / "github_output"
-            with patch.dict(os.environ, {"GITHUB_OUTPUT": str(github_output_file)}):
-                result = CreateRc(args, self.mock_git, self.mock_gh).run()
-
-            # Assert
-            self.assertEqual(result, 0)
-            self.assertTrue(github_output_file.exists())
-            self.assertEqual(github_output_file.read_text(), "tag_name=2.0.0-rc0\n")
-        self.mock_git.fetch.assert_has_calls(
-            [call("my-remote"), call("my-remote", tags=True, force=True)]
-        )
-        self.mock_git.checkout.assert_not_called()
-        self.mock_git.tag.assert_called_once_with("2.0.0-rc0", "my-remote/release/2.0")
-        self.mock_git.push.assert_called_once_with("my-remote", "2.0.0-rc0")
-        self.mock_git.get_commit_sha.assert_called_once_with("my-remote/release/2.0")
-
-        self.mock_gh.update_issue_body.assert_called_once()
-        call_args = self.mock_gh.update_issue_body.call_args[0]
-        self.assertEqual(call_args[0], 123)
-        self.assertIn("tag=2.0.0-rc0", call_args[1])
-        self.assertIn("commit= 12345678", call_args[1])
-
-        self.mock_gh.post_issue_comment.assert_called_once()
-        comment_call_args = self.mock_gh.post_issue_comment.call_args[0]
-        self.assertEqual(comment_call_args[0], 123)
-        self.assertIn(
-            "**New Release Candidate Tagged!** 🐍🌿",
-            comment_call_args[1],
-        )
-        self.assertIn(
-            "tagged on branch [`release/2.0`](https://github.com/bazel-contrib/rules_python/tree/release/2.0)",
-            comment_call_args[1],
-        )
-        self.assertIn(
-            "- [Github Release 2.0.0-rc0](https://github.com/bazel-contrib/rules_python/releases/tag/2.0.0-rc0)",
-            comment_call_args[1],
-        )
-        self.assertIn(
-            "- [BCR Entry 2.0.0-rc0](https://registry.bazel.build/modules/rules_python/2.0.0-rc0)",
-            comment_call_args[1],
-        )
-        self.assertIn(
-            "- [BCR PRs](https://github.com/bazelbuild/bazel-central-registry/pulls?q=is%3Apr+rules_python+2.0.0-rc0)",
-            comment_call_args[1],
-        )
-        self.assertIn(
-            "- [Release workflow status](https://github.com/bazel-contrib/rules_python/actions/workflows/release_create_rc.yaml)",
-            comment_call_args[1],
-        )
-
-    def test_create_rc_success_with_run_id(self):
-        # Arrange
-        args = MagicMock(issue=123, remote="my-remote")
-        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
-        self.mock_gh.get_issue_body.return_value = """
-## Checklist
-- [x] Prepare Release | status=done pr=#122 commit=abcdef12
-- [x] Create Release branch | status=done branch=release/2.0 commit=abcdef12
-- [ ] Tag RC0 | status=pending
-"""
-        self.mock_git.get_remote_tags.return_value = []
-        self.mock_git.get_commit_sha.return_value = "1234567890"
-
-        # Act
-        with patch.dict(os.environ, {"GITHUB_RUN_ID": "987654321"}):
-            result = CreateRc(args, self.mock_git, self.mock_gh).run()
+    # Act
+    with tempfile.TemporaryDirectory() as tmpdir:
+        github_output_file = pathlib.Path(tmpdir) / "github_output"
+        with patch.dict(os.environ, {"GITHUB_OUTPUT": str(github_output_file)}):
+            result = CreateRc(args, mock_git, mock_gh).run()
 
         # Assert
-        self.assertEqual(result, 0)
-        self.mock_gh.post_issue_comment.assert_called_once()
-        comment_call_args = self.mock_gh.post_issue_comment.call_args[0]
-        self.assertIn(
-            "- [Release workflow status](https://github.com/bazel-contrib/rules_python/actions/runs/987654321)",
-            comment_call_args[1],
-        )
-        self.assertIn(
-            "tagged on branch [`release/2.0`](https://github.com/bazel-contrib/rules_python/tree/release/2.0)",
-            comment_call_args[1],
-        )
+        assert result == 0
+        assert github_output_file.exists()
+        assert github_output_file.read_text() == "tag_name=2.0.0-rc0\n"
 
-    def test_create_rc_success_next_rc(self):
-        # Arrange
-        args = MagicMock(issue=123, remote="my-remote")
-        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
-        self.mock_gh.get_issue_body.return_value = """
+    mock_git.fetch.assert_has_calls(
+        [call("my-remote"), call("my-remote", tags=True, force=True)]
+    )
+    mock_git.checkout.assert_not_called()
+    mock_git.tag.assert_called_once_with("2.0.0-rc0", "my-remote/release/2.0")
+    mock_git.push.assert_called_once_with("my-remote", "2.0.0-rc0")
+    mock_git.get_commit_sha.assert_called_once_with("my-remote/release/2.0")
+
+    updated_body = mock_gh.get_issue_body(123)
+    assert "tag=2.0.0-rc0" in updated_body
+    assert "commit= 12345678" in updated_body
+
+    assert 123 in mock_gh.issue_comments
+    comment_text = mock_gh.issue_comments[123][0]
+    assert "**New Release Candidate Tagged!** 🐍🌿" in comment_text
+    assert (
+        "tagged on branch [`release/2.0`](https://github.com/bazel-contrib/rules_python/tree/release/2.0)"
+        in comment_text
+    )
+    assert (
+        "- [Github Release 2.0.0-rc0](https://github.com/bazel-contrib/rules_python/releases/tag/2.0.0-rc0)"
+        in comment_text
+    )
+    assert (
+        "- [BCR Entry 2.0.0-rc0](https://registry.bazel.build/modules/rules_python/2.0.0-rc0)"
+        in comment_text
+    )
+    assert (
+        "- [BCR PRs](https://github.com/bazelbuild/bazel-central-registry/pulls?q=is%3Apr+rules_python+2.0.0-rc0)"
+        in comment_text
+    )
+    assert (
+        "- [Release workflow status](https://github.com/bazel-contrib/rules_python/actions/workflows/release_create_rc.yaml)"
+        in comment_text
+    )
+
+
+def test_create_rc_success_with_run_id(mock_git, mock_gh):
+    # Arrange
+    args = argparse.Namespace(
+        issue=123, remote="my-remote", triggering_comment=None, dry_run=False
+    )
+    mock_gh.issues[123] = {
+        "title": "Release 2.0.0",
+        "body": """
+## Checklist
+- [x] Prepare Release | status=done pr=#122 commit=abcdef12
+- [x] Create Release branch | status=done branch=release/2.0 commit=abcdef12
+- [ ] Tag RC0 | status=pending
+""",
+        "labels": ["type: release"],
+    }
+    mock_git.get_remote_tags.return_value = []
+    mock_git.get_commit_sha.return_value = "1234567890"
+
+    # Act
+    with patch.dict(os.environ, {"GITHUB_RUN_ID": "987654321"}):
+        result = CreateRc(args, mock_git, mock_gh).run()
+
+    # Assert
+    assert result == 0
+    assert 123 in mock_gh.issue_comments
+    comment_text = mock_gh.issue_comments[123][0]
+    assert (
+        "- [Release workflow status](https://github.com/bazel-contrib/rules_python/actions/runs/987654321)"
+        in comment_text
+    )
+    assert (
+        "tagged on branch [`release/2.0`](https://github.com/bazel-contrib/rules_python/tree/release/2.0)"
+        in comment_text
+    )
+
+
+def test_create_rc_success_next_rc(mock_git, mock_gh):
+    # Arrange
+    args = argparse.Namespace(
+        issue=123, remote="my-remote", triggering_comment=None, dry_run=False
+    )
+    mock_gh.issues[123] = {
+        "title": "Release 2.0.0",
+        "body": """
 ## Checklist
 - [x] Prepare Release | status=done pr=#122 commit=abcdef12
 - [x] Create Release branch | status=done branch=release/2.0 commit=abcdef12
 - [x] Tag RC0 | status=done tag=2.0.0-rc0 commit=abcdef12
 - [ ] Tag RC1 | status=pending
-"""
-        self.mock_git.get_remote_tags.return_value = ["2.0.0-rc0"]
-        self.mock_git.get_commit_sha.return_value = "1234567890"
+""",
+        "labels": ["type: release"],
+    }
+    mock_git.get_remote_tags.return_value = ["2.0.0-rc0"]
+    mock_git.get_commit_sha.return_value = "1234567890"
 
-        # Act
-        result = CreateRc(args, self.mock_git, self.mock_gh).run()
+    # Act
+    result = CreateRc(args, mock_git, mock_gh).run()
 
-        # Assert
-        self.assertEqual(result, 0)
-        self.mock_git.fetch.assert_has_calls(
-            [call("my-remote"), call("my-remote", tags=True, force=True)]
-        )
-        self.mock_git.checkout.assert_not_called()
-        self.mock_git.tag.assert_called_once_with("2.0.0-rc1", "my-remote/release/2.0")
-        self.mock_git.push.assert_called_once_with("my-remote", "2.0.0-rc1")
-        self.mock_git.get_commit_sha.assert_called_once_with("my-remote/release/2.0")
+    # Assert
+    assert result == 0
+    mock_git.fetch.assert_has_calls(
+        [call("my-remote"), call("my-remote", tags=True, force=True)]
+    )
+    mock_git.checkout.assert_not_called()
+    mock_git.tag.assert_called_once_with("2.0.0-rc1", "my-remote/release/2.0")
+    mock_git.push.assert_called_once_with("my-remote", "2.0.0-rc1")
+    mock_git.get_commit_sha.assert_called_once_with("my-remote/release/2.0")
 
-        self.mock_gh.update_issue_body.assert_called_once()
-        call_args = self.mock_gh.update_issue_body.call_args[0]
-        self.assertEqual(call_args[0], 123)
-        self.assertIn("tag=2.0.0-rc1", call_args[1])
+    updated_body = mock_gh.get_issue_body(123)
+    assert "tag=2.0.0-rc1" in updated_body
 
-        self.mock_gh.post_issue_comment.assert_called_once()
-        comment_call_args = self.mock_gh.post_issue_comment.call_args[0]
-        self.assertEqual(comment_call_args[0], 123)
-        self.assertIn(
-            "**New Release Candidate Tagged!** 🐍🌿",
-            comment_call_args[1],
-        )
-        self.assertIn(
-            "tagged on branch [`release/2.0`](https://github.com/bazel-contrib/rules_python/tree/release/2.0)",
-            comment_call_args[1],
-        )
-        self.assertIn(
-            "- [Github Release 2.0.0-rc1](https://github.com/bazel-contrib/rules_python/releases/tag/2.0.0-rc1)",
-            comment_call_args[1],
-        )
-        self.assertIn(
-            "- [BCR Entry 2.0.0-rc1](https://registry.bazel.build/modules/rules_python/2.0.0-rc1)",
-            comment_call_args[1],
-        )
-        self.assertIn(
-            "- [BCR PRs](https://github.com/bazelbuild/bazel-central-registry/pulls?q=is%3Apr+rules_python+2.0.0-rc1)",
-            comment_call_args[1],
-        )
-        self.assertIn(
-            "- [Release workflow status](https://github.com/bazel-contrib/rules_python/actions/workflows/release_create_rc.yaml)",
-            comment_call_args[1],
-        )
+    assert 123 in mock_gh.issue_comments
+    comment_text = mock_gh.issue_comments[123][0]
+    assert "**New Release Candidate Tagged!** 🐍🌿" in comment_text
 
-    def test_create_rc_gating_on_backports(self):
-        # Arrange
-        args = MagicMock(issue=123, remote="my-remote")
-        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
-        self.mock_gh.get_issue_body.return_value = """
+
+def test_create_rc_gating_on_backports(mock_git, mock_gh):
+    # Arrange
+    args = argparse.Namespace(
+        issue=123, remote="my-remote", triggering_comment=None, dry_run=False
+    )
+    mock_gh.issues[123] = {
+        "title": "Release 2.0.0",
+        "body": """
 ## Checklist
 - [x] Prepare Release | status=done pr=#122 commit=abcdef12
 - [x] Create Release branch | status=done branch=release/2.0 commit=abcdef12
@@ -180,20 +166,26 @@ class CmdCreateRcTest(unittest.TestCase):
 
 ## Backports
 - [ ] #124 | status=pending
-"""
-        # Act
-        result = CreateRc(args, self.mock_git, self.mock_gh).run()
+""",
+        "labels": ["type: release"],
+    }
+    # Act
+    result = CreateRc(args, mock_git, mock_gh).run()
 
-        # Assert
-        self.assertEqual(result, 1)
-        self.mock_git.tag.assert_not_called()
-        self.mock_git.push.assert_not_called()
+    # Assert
+    assert result == 1
+    mock_git.tag.assert_not_called()
+    mock_git.push.assert_not_called()
 
-    def test_create_rc_not_blocked_by_ignored_backports(self):
-        # Arrange
-        args = MagicMock(issue=123, remote="my-remote")
-        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
-        self.mock_gh.get_issue_body.return_value = """
+
+def test_create_rc_not_blocked_by_ignored_backports(mock_git, mock_gh):
+    # Arrange
+    args = argparse.Namespace(
+        issue=123, remote="my-remote", triggering_comment=None, dry_run=False
+    )
+    mock_gh.issues[123] = {
+        "title": "Release 2.0.0",
+        "body": """
 ## Checklist
 - [x] Prepare Release | status=done pr=#122 commit=abcdef12
 - [x] Create Release branch | status=done branch=release/2.0 commit=abcdef12
@@ -201,23 +193,29 @@ class CmdCreateRcTest(unittest.TestCase):
 
 ## Backports
 - [ ] #124 | status=ignore
-"""
-        self.mock_git.get_remote_tags.return_value = []
-        self.mock_git.get_commit_sha.return_value = "1234567890"
+""",
+        "labels": ["type: release"],
+    }
+    mock_git.get_remote_tags.return_value = []
+    mock_git.get_commit_sha.return_value = "1234567890"
 
-        # Act
-        result = CreateRc(args, self.mock_git, self.mock_gh).run()
+    # Act
+    result = CreateRc(args, mock_git, mock_gh).run()
 
-        # Assert
-        self.assertEqual(result, 0)
-        self.mock_git.tag.assert_called_once_with("2.0.0-rc0", "my-remote/release/2.0")
-        self.mock_git.push.assert_called_once_with("my-remote", "2.0.0-rc0")
+    # Assert
+    assert result == 0
+    mock_git.tag.assert_called_once_with("2.0.0-rc0", "my-remote/release/2.0")
+    mock_git.push.assert_called_once_with("my-remote", "2.0.0-rc0")
 
-    def test_create_rc_with_finished_backports(self):
-        # Arrange
-        args = MagicMock(issue=123, remote="my-remote")
-        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
-        self.mock_gh.get_issue_body.return_value = """
+
+def test_create_rc_with_finished_backports(mock_git, mock_gh):
+    # Arrange
+    args = argparse.Namespace(
+        issue=123, remote="my-remote", triggering_comment=None, dry_run=False
+    )
+    mock_gh.issues[123] = {
+        "title": "Release 2.0.0",
+        "body": """
 ## Checklist
 - [x] Prepare Release | status=done pr=#122 commit=abcdef12
 - [x] Create Release branch | status=done branch=release/2.0 commit=abcdef12
@@ -225,182 +223,202 @@ class CmdCreateRcTest(unittest.TestCase):
 
 ## Backports
 - [x] #124 | status=done rc=rc0 commit=abcdef12
-"""
-        self.mock_git.get_remote_tags.return_value = []
-        self.mock_git.get_commit_sha.return_value = "1234567890"
+""",
+        "labels": ["type: release"],
+    }
+    mock_git.get_remote_tags.return_value = []
+    mock_git.get_commit_sha.return_value = "1234567890"
 
-        # Act
-        result = CreateRc(args, self.mock_git, self.mock_gh).run()
+    # Act
+    result = CreateRc(args, mock_git, mock_gh).run()
 
-        # Assert
-        self.assertEqual(result, 0)
-        self.mock_git.tag.assert_called_once_with("2.0.0-rc0", "my-remote/release/2.0")
-        self.mock_git.push.assert_called_once_with("my-remote", "2.0.0-rc0")
+    # Assert
+    assert result == 0
+    mock_git.tag.assert_called_once_with("2.0.0-rc0", "my-remote/release/2.0")
+    mock_git.push.assert_called_once_with("my-remote", "2.0.0-rc0")
 
-    def test_create_rc_auto_add_task(self):
-        # Arrange
-        args = argparse.Namespace(issue=123, remote="my-remote")
-        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
-        self.mock_gh.get_issue_body.return_value = """
+
+def test_create_rc_auto_add_task(mock_git, mock_gh):
+    # Arrange
+    args = argparse.Namespace(
+        issue=123, remote="my-remote", triggering_comment=None, dry_run=False
+    )
+    mock_gh.issues[123] = {
+        "title": "Release 2.0.0",
+        "body": """
 ## Checklist
 - [x] Prepare Release | status=done pr=#122 commit=abcdef12
 - [x] Create Release branch | status=done branch=release/2.0 commit=abcdef12
 - [x] Tag RC0 | status=done tag=2.0.0-rc0 commit=abcdef12
 - [ ] Tag Final
-"""
-        self.mock_git.get_remote_tags.return_value = ["2.0.0-rc0"]
-        self.mock_git.get_commit_sha.return_value = "1234567890"
+""",
+        "labels": ["type: release"],
+    }
+    mock_git.get_remote_tags.return_value = ["2.0.0-rc0"]
+    mock_git.get_commit_sha.return_value = "1234567890"
 
-        # Act
-        result = CreateRc(args, self.mock_git, self.mock_gh).run()
+    # Act
+    result = CreateRc(args, mock_git, mock_gh).run()
 
-        # Assert
-        self.assertEqual(result, 0)
-        self.mock_git.tag.assert_called_once_with("2.0.0-rc1", "my-remote/release/2.0")
-        self.mock_git.push.assert_called_once_with("my-remote", "2.0.0-rc1")
+    # Assert
+    assert result == 0
+    mock_git.tag.assert_called_once_with("2.0.0-rc1", "my-remote/release/2.0")
+    mock_git.push.assert_called_once_with("my-remote", "2.0.0-rc1")
 
-        self.assertEqual(self.mock_gh.update_issue_body.call_count, 2)
-        call1_args = self.mock_gh.update_issue_body.call_args_list[0][0]
-        call2_args = self.mock_gh.update_issue_body.call_args_list[1][0]
+    updated_body = mock_gh.get_issue_body(123)
+    assert "- [x] Tag RC1 | status=done tag=2.0.0-rc1 commit= 12345678" in updated_body
 
-        self.assertEqual(call1_args[0], 123)
-        self.assertIn("- [ ] Tag RC1", call1_args[1])
-        self.assertIn(
-            "- [x] Tag RC0 | status=done tag=2.0.0-rc0 commit=abcdef12\n- [ ]"
-            " Tag RC1\n- [ ] Tag Final",
-            call1_args[1].strip(),
-        )
 
-        self.assertEqual(call2_args[0], 123)
-        self.assertIn(
-            "- [x] Tag RC1 | status=done tag=2.0.0-rc1 commit= 12345678",
-            call2_args[1],
-        )
+@patch("tools.private.release.create_rc.ProcessBackports")
+def test_create_rc_calls_process_backports(mock_pb_class, mock_git, mock_gh):
+    # Arrange
+    mock_pb = mock_pb_class.return_value
+    mock_pb.run.return_value = 0
 
-    @patch("tools.private.release.create_rc.ProcessBackports")
-    def test_create_rc_calls_process_backports(self, mock_pb_class):
-        # Arrange
-        mock_pb = mock_pb_class.return_value
-        mock_pb.run.return_value = 0
-
-        args = MagicMock(issue=123, remote="my-remote")
-        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
-        self.mock_gh.get_issue_body.return_value = """
+    args = argparse.Namespace(
+        issue=123, remote="my-remote", triggering_comment=None, dry_run=False
+    )
+    mock_gh.issues[123] = {
+        "title": "Release 2.0.0",
+        "body": """
 ## Checklist
 - [x] Prepare Release | status=done pr=#122 commit=abcdef12
 - [x] Create Release branch | status=done branch=release/2.0 commit=abcdef12
 - [ ] Tag RC0 | status=pending
-"""
-        self.mock_git.get_remote_tags.return_value = []
-        self.mock_git.get_commit_sha.return_value = "1234567890"
+""",
+        "labels": ["type: release"],
+    }
+    mock_git.get_remote_tags.return_value = []
+    mock_git.get_commit_sha.return_value = "1234567890"
 
-        # Act
-        result = CreateRc(args, self.mock_git, self.mock_gh).run()
+    # Act
+    result = CreateRc(args, mock_git, mock_gh).run()
 
-        # Assert
-        self.assertEqual(result, 0)
-        mock_pb_class.assert_called_once()
-        called_args = mock_pb_class.call_args[0][0]
-        self.assertEqual(called_args.issue, 123)
-        self.assertEqual(called_args.remote, "my-remote")
-        self.assertFalse(called_args.dry_run)
-        self.assertIsNone(called_args.add)
-        self.assertIsNone(called_args.triggering_comment)
-        mock_pb.run.assert_called_once()
+    # Assert
+    assert result == 0
+    mock_pb_class.assert_called_once()
+    called_args = mock_pb_class.call_args[0][0]
+    assert called_args.issue == 123
+    assert called_args.remote == "my-remote"
+    assert not called_args.dry_run
+    assert called_args.add is None
+    assert called_args.triggering_comment is None
+    mock_pb.run.assert_called_once()
 
-    @patch("tools.private.release.create_rc.ProcessBackports")
-    def test_create_rc_aborts_on_process_backports_failure(self, mock_pb_class):
-        # Arrange
-        mock_pb = mock_pb_class.return_value
-        mock_pb.run.return_value = 1
 
-        args = MagicMock(issue=123, remote="my-remote")
+@patch("tools.private.release.create_rc.ProcessBackports")
+def test_create_rc_aborts_on_process_backports_failure(
+    mock_pb_class, mock_git, mock_gh
+):
+    # Arrange
+    mock_pb = mock_pb_class.return_value
+    mock_pb.run.return_value = 1
 
-        # Act
-        result = CreateRc(args, self.mock_git, self.mock_gh).run()
+    args = argparse.Namespace(
+        issue=123, remote="my-remote", triggering_comment=None, dry_run=False
+    )
 
-        # Assert
-        self.assertEqual(result, 1)
-        mock_pb_class.assert_called_once()
-        mock_pb.run.assert_called_once()
-        self.mock_gh.get_issue_body.assert_not_called()
-        self.mock_git.tag.assert_not_called()
+    # Act
+    result = CreateRc(args, mock_git, mock_gh).run()
 
-    @patch("tools.private.release.create_rc.ProcessBackports")
-    def test_create_rc_failure_reacts_to_comment(self, mock_pb_class):
-        # Arrange
-        mock_pb = mock_pb_class.return_value
-        mock_pb.run.return_value = 1  # Simulate failure
+    # Assert
+    assert result == 1
+    mock_pb_class.assert_called_once()
+    mock_pb.run.assert_called_once()
+    mock_git.tag.assert_not_called()
 
-        args = MagicMock(issue=123, remote="my-remote", triggering_comment=456)
 
-        # Act
-        result = CreateRc(args, self.mock_git, self.mock_gh).run()
+@patch("tools.private.release.create_rc.ProcessBackports")
+def test_create_rc_failure_reacts_to_comment(mock_pb_class, mock_git, mock_gh):
+    # Arrange
+    mock_pb = mock_pb_class.return_value
+    mock_pb.run.return_value = 1  # Simulate failure
 
-        # Assert
-        self.assertEqual(result, 1)
-        self.mock_gh.add_comment_reaction.assert_called_once_with(456, "-1")
+    args = argparse.Namespace(
+        issue=123, remote="my-remote", triggering_comment=456, dry_run=False
+    )
 
-    @patch("tools.private.release.create_rc.ProcessBackports")
-    def test_create_rc_failure_no_comment_no_reaction(self, mock_pb_class):
-        # Arrange
-        mock_pb = mock_pb_class.return_value
-        mock_pb.run.return_value = 1  # Simulate failure
+    # Act
+    result = CreateRc(args, mock_git, mock_gh).run()
 
-        args = MagicMock(issue=123, remote="my-remote", triggering_comment=None)
+    # Assert
+    assert result == 1
+    assert mock_gh.reactions.get(456) == ["-1"]
 
-        # Act
-        result = CreateRc(args, self.mock_git, self.mock_gh).run()
 
-        # Assert
-        self.assertEqual(result, 1)
-        self.mock_gh.add_comment_reaction.assert_not_called()
+@patch("tools.private.release.create_rc.ProcessBackports")
+def test_create_rc_failure_no_comment_no_reaction(mock_pb_class, mock_git, mock_gh):
+    # Arrange
+    mock_pb = mock_pb_class.return_value
+    mock_pb.run.return_value = 1  # Simulate failure
 
-    @patch("tools.private.release.create_rc.ProcessBackports")
-    def test_create_rc_success_with_comment_no_reaction(self, mock_pb_class):
-        # Arrange
-        mock_pb = mock_pb_class.return_value
-        mock_pb.run.return_value = 0
+    args = argparse.Namespace(
+        issue=123, remote="my-remote", triggering_comment=None, dry_run=False
+    )
 
-        args = MagicMock(issue=123, remote="my-remote", triggering_comment=456)
-        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
-        self.mock_gh.get_issue_body.return_value = """
+    # Act
+    result = CreateRc(args, mock_git, mock_gh).run()
+
+    # Assert
+    assert result == 1
+    assert 456 not in mock_gh.reactions
+
+
+@patch("tools.private.release.create_rc.ProcessBackports")
+def test_create_rc_success_with_comment_no_reaction(mock_pb_class, mock_git, mock_gh):
+    # Arrange
+    mock_pb = mock_pb_class.return_value
+    mock_pb.run.return_value = 0
+
+    args = argparse.Namespace(
+        issue=123, remote="my-remote", triggering_comment=456, dry_run=False
+    )
+    mock_gh.issues[123] = {
+        "title": "Release 2.0.0",
+        "body": """
 ## Checklist
 - [x] Prepare Release | status=done pr=#122 commit=abcdef12
 - [x] Create Release branch | status=done branch=release/2.0 commit=abcdef12
 - [ ] Tag RC0 | status=pending
-"""
-        self.mock_git.get_remote_tags.return_value = []
-        self.mock_git.get_commit_sha.return_value = "1234567890"
+""",
+        "labels": ["type: release"],
+    }
+    mock_git.get_remote_tags.return_value = []
+    mock_git.get_commit_sha.return_value = "1234567890"
 
-        # Act
-        result = CreateRc(args, self.mock_git, self.mock_gh).run()
+    # Act
+    result = CreateRc(args, mock_git, mock_gh).run()
 
-        # Assert
-        self.assertEqual(result, 0)
-        self.mock_gh.add_comment_reaction.assert_not_called()
+    # Assert
+    assert result == 0
+    assert 456 not in mock_gh.reactions
 
-    @patch("tools.private.release.create_rc.ProcessBackports")
-    def test_create_rc_precondition_failure_reacts_to_comment(self, mock_pb_class):
-        # Arrange
-        mock_pb = mock_pb_class.return_value
-        mock_pb.run.return_value = 0  # Backports succeed
 
-        args = MagicMock(issue=123, remote="my-remote", triggering_comment=456)
-        self.mock_gh.get_issue_body.return_value = """
+@patch("tools.private.release.create_rc.ProcessBackports")
+def test_create_rc_precondition_failure_reacts_to_comment(
+    mock_pb_class, mock_git, mock_gh
+):
+    # Arrange
+    mock_pb = mock_pb_class.return_value
+    mock_pb.run.return_value = 0  # Backports succeed
+
+    args = argparse.Namespace(
+        issue=123, remote="my-remote", triggering_comment=456, dry_run=False
+    )
+    mock_gh.issues[123] = {
+        "title": "Release 2.0.0",
+        "body": """
 ## Checklist
 - [ ] Prepare Release | status=pending
 - [ ] Create Release branch | status=pending
 - [ ] Tag RC0 | status=pending
-"""
+""",
+        "labels": ["type: release"],
+    }
 
-        # Act
-        result = CreateRc(args, self.mock_git, self.mock_gh).run()
+    # Act
+    result = CreateRc(args, mock_git, mock_gh).run()
 
-        # Assert
-        self.assertEqual(result, 1)
-        self.mock_gh.add_comment_reaction.assert_called_once_with(456, "-1")
-
-
-if __name__ == "__main__":
-    unittest.main()
+    # Assert
+    assert result == 1
+    assert mock_gh.reactions.get(456) == ["-1"]

--- a/tests/tools/private/release/create_release_branch_test.py
+++ b/tests/tools/private/release/create_release_branch_test.py
@@ -1,149 +1,157 @@
-import unittest
-from unittest.mock import MagicMock
+import argparse
 
-from tests.tools.private.release.release_test_helper import _mock_git_and_gh
 from tools.private.release.create_release_branch import CreateReleaseBranch
 
+pytest_plugins = ["tests.tools.private.release.release_test_helper"]
 
-class CmdCreateReleaseBranchTest(unittest.TestCase):
-    def setUp(self):
-        _mock_git_and_gh(self)
 
-    def test_create_release_branch_success(self):
-        # Arrange
-        args = MagicMock(issue=123, remote="my-remote")
-        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
-        self.mock_gh.get_issue_body.return_value = """
+def test_create_release_branch_success(mock_git, mock_gh):
+    # Arrange
+    args = argparse.Namespace(issue=123, remote="my-remote")
+    mock_gh.issues[123] = {
+        "title": "Release 2.0.0",
+        "body": """
 ## Checklist
 - [x] Prepare Release | status=done pr=#122 commit=abcdef12
 - [ ] Create Release branch | status=pending
-"""
-        self.mock_git.branch_exists.return_value = False
-        self.mock_git.remote_branch_exists.return_value = False
+""",
+        "labels": ["type: release"],
+    }
+    mock_git.branch_exists.return_value = False
+    mock_git.remote_branch_exists.return_value = False
 
-        # Act
-        result = CreateReleaseBranch(args, self.mock_git, self.mock_gh).run()
+    # Act
+    result = CreateReleaseBranch(args, mock_git, mock_gh).run()
 
-        # Assert
-        self.assertEqual(result, 0)
-        self.mock_git.fetch.assert_called_once_with("my-remote")
-        self.mock_git.checkout.assert_not_called()
-        self.mock_git.push.assert_called_once_with(
-            "my-remote", "abcdef12:refs/heads/release/2.0"
-        )
+    # Assert
+    assert result == 0
+    mock_git.fetch.assert_called_once_with("my-remote")
+    mock_git.checkout.assert_not_called()
+    mock_git.push.assert_called_once_with(
+        "my-remote", "abcdef12:refs/heads/release/2.0"
+    )
 
-        self.mock_gh.update_issue_body.assert_called_once()
-        call_args = self.mock_gh.update_issue_body.call_args[0]
-        self.assertEqual(call_args[0], 123)
-        self.assertIn(
-            "branch_url=https://github.com/bazel-contrib/rules_python/tree/release/2.0",
-            call_args[1],
-        )
-        self.assertIn("commit= abcdef12", call_args[1])
+    updated_body = mock_gh.get_issue_body(123)
+    assert (
+        "branch_url=https://github.com/bazel-contrib/rules_python/tree/release/2.0"
+        in updated_body
+    )
+    assert "commit= abcdef12" in updated_body
 
-    def test_create_release_branch_prepare_not_done(self):
-        # Arrange
-        args = MagicMock(issue=123, remote="my-remote")
-        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
-        self.mock_gh.get_issue_body.return_value = """
+
+def test_create_release_branch_prepare_not_done(mock_git, mock_gh):
+    # Arrange
+    args = argparse.Namespace(issue=123, remote="my-remote")
+    mock_gh.issues[123] = {
+        "title": "Release 2.0.0",
+        "body": """
 ## Checklist
 - [ ] Prepare Release | status=pending
 - [ ] Create Release branch | status=pending
-"""
-        # Act
-        result = CreateReleaseBranch(args, self.mock_git, self.mock_gh).run()
+""",
+        "labels": ["type: release"],
+    }
+    # Act
+    result = CreateReleaseBranch(args, mock_git, mock_gh).run()
 
-        # Assert
-        self.assertEqual(result, 1)
-        self.mock_git.fetch.assert_not_called()
-        self.mock_git.push.assert_not_called()
-        self.mock_gh.update_issue_body.assert_not_called()
+    # Assert
+    assert result == 1
+    mock_git.fetch.assert_not_called()
+    mock_git.push.assert_not_called()
 
-    def test_create_release_branch_already_checked(self):
-        # Arrange
-        args = MagicMock(issue=123, remote="my-remote")
-        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
-        self.mock_gh.get_issue_body.return_value = """
+
+def test_create_release_branch_already_checked(mock_git, mock_gh):
+    # Arrange
+    args = argparse.Namespace(issue=123, remote="my-remote")
+    mock_gh.issues[123] = {
+        "title": "Release 2.0.0",
+        "body": """
 ## Checklist
 - [x] Prepare Release | status=done pr=#122 commit=abcdef12
 - [x] Create Release branch | status=done branch=release/2.0 commit=abcdef12
-"""
-        # Act
-        result = CreateReleaseBranch(args, self.mock_git, self.mock_gh).run()
+""",
+        "labels": ["type: release"],
+    }
+    # Act
+    result = CreateReleaseBranch(args, mock_git, mock_gh).run()
 
-        # Assert
-        self.assertEqual(result, 0)
-        self.mock_git.fetch.assert_not_called()
-        self.mock_git.push.assert_not_called()
-        self.mock_gh.update_issue_body.assert_not_called()
+    # Assert
+    assert result == 0
+    mock_git.fetch.assert_not_called()
+    mock_git.push.assert_not_called()
 
-    def test_create_release_branch_already_exists_same_commit(self):
-        # Arrange
-        args = MagicMock(issue=123, remote="my-remote")
-        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
-        self.mock_gh.get_issue_body.return_value = """
+
+def test_create_release_branch_already_exists_same_commit(mock_git, mock_gh):
+    # Arrange
+    args = argparse.Namespace(issue=123, remote="my-remote")
+    mock_gh.issues[123] = {
+        "title": "Release 2.0.0",
+        "body": """
 ## Checklist
 - [x] Prepare Release | status=done pr=#122 commit=abcdef12
 - [ ] Create Release branch | status=pending
-"""
-        self.mock_git.remote_branch_exists.return_value = True
-        self.mock_git.get_commit_sha.return_value = "abcdef12"
+""",
+        "labels": ["type: release"],
+    }
+    mock_git.remote_branch_exists.return_value = True
+    mock_git.get_commit_sha.return_value = "abcdef12"
 
-        # Act
-        result = CreateReleaseBranch(args, self.mock_git, self.mock_gh).run()
+    # Act
+    result = CreateReleaseBranch(args, mock_git, mock_gh).run()
 
-        # Assert
-        self.assertEqual(result, 0)
-        self.mock_git.fetch.assert_called_once_with("my-remote")
-        self.mock_git.push.assert_not_called()
-        self.mock_gh.update_issue_body.assert_called_once()  # Should still update checklist
+    # Assert
+    assert result == 0
+    mock_git.fetch.assert_called_once_with("my-remote")
+    mock_git.push.assert_not_called()
 
-    def test_create_release_branch_already_exists_fast_forward(self):
-        # Arrange
-        args = MagicMock(issue=123, remote="my-remote")
-        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
-        self.mock_gh.get_issue_body.return_value = """
+
+def test_create_release_branch_already_exists_fast_forward(mock_git, mock_gh):
+    # Arrange
+    args = argparse.Namespace(issue=123, remote="my-remote")
+    mock_gh.issues[123] = {
+        "title": "Release 2.0.0",
+        "body": """
 ## Checklist
 - [x] Prepare Release | status=done pr=#122 commit=abcdef12
 - [ ] Create Release branch | status=pending
-"""
-        self.mock_git.remote_branch_exists.return_value = True
-        self.mock_git.get_commit_sha.return_value = "oldcommit"
-        self.mock_git.is_ancestor.return_value = True
+""",
+        "labels": ["type: release"],
+    }
+    mock_git.remote_branch_exists.return_value = True
+    mock_git.get_commit_sha.return_value = "oldcommit"
+    mock_git.is_ancestor.return_value = True
 
-        # Act
-        result = CreateReleaseBranch(args, self.mock_git, self.mock_gh).run()
+    # Act
+    result = CreateReleaseBranch(args, mock_git, mock_gh).run()
 
-        # Assert
-        self.assertEqual(result, 0)
-        self.mock_git.fetch.assert_called_once_with("my-remote")
-        self.mock_git.push.assert_called_once_with(
-            "my-remote", "abcdef12:refs/heads/release/2.0"
-        )
-        self.mock_gh.update_issue_body.assert_called_once()
+    # Assert
+    assert result == 0
+    mock_git.fetch.assert_called_once_with("my-remote")
+    mock_git.push.assert_called_once_with(
+        "my-remote", "abcdef12:refs/heads/release/2.0"
+    )
 
-    def test_create_release_branch_already_exists_non_ff(self):
-        # Arrange
-        args = MagicMock(issue=123, remote="my-remote")
-        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
-        self.mock_gh.get_issue_body.return_value = """
+
+def test_create_release_branch_already_exists_non_ff(mock_git, mock_gh):
+    # Arrange
+    args = argparse.Namespace(issue=123, remote="my-remote")
+    mock_gh.issues[123] = {
+        "title": "Release 2.0.0",
+        "body": """
 ## Checklist
 - [x] Prepare Release | status=done pr=#122 commit=abcdef12
 - [ ] Create Release branch | status=pending
-"""
-        self.mock_git.remote_branch_exists.return_value = True
-        self.mock_git.get_commit_sha.return_value = "othercommit"
-        self.mock_git.is_ancestor.return_value = False
+""",
+        "labels": ["type: release"],
+    }
+    mock_git.remote_branch_exists.return_value = True
+    mock_git.get_commit_sha.return_value = "othercommit"
+    mock_git.is_ancestor.return_value = False
 
-        # Act
-        result = CreateReleaseBranch(args, self.mock_git, self.mock_gh).run()
+    # Act
+    result = CreateReleaseBranch(args, mock_git, mock_gh).run()
 
-        # Assert
-        self.assertEqual(result, 1)
-        self.mock_git.fetch.assert_called_once_with("my-remote")
-        self.mock_git.push.assert_not_called()
-        self.mock_gh.update_issue_body.assert_not_called()
-
-
-if __name__ == "__main__":
-    unittest.main()
+    # Assert
+    assert result == 1
+    mock_git.fetch.assert_called_once_with("my-remote")
+    mock_git.push.assert_not_called()

--- a/tests/tools/private/release/gh_test.py
+++ b/tests/tools/private/release/gh_test.py
@@ -1,61 +1,62 @@
-import unittest
 from unittest.mock import patch
+
+import pytest
 
 from tools.private.release.gh import GitHub
 
 
-class GitHubTest(unittest.TestCase):
-    def setUp(self):
-        self.gh = GitHub("my-owner/my-repo")
-
-    @patch("tools.private.release.gh.run_cmd")
-    def test_resolve_pr_number_digit(self, mock_run_cmd):
-        # 124 and #125 should resolve immediately without running command
-        self.assertEqual(self.gh.resolve_pr_number("124"), 124)
-        self.assertEqual(self.gh.resolve_pr_number("#125"), 125)
-        mock_run_cmd.assert_not_called()
-
-    @patch("tools.private.release.gh.run_cmd")
-    def test_resolve_pr_number_url_simple(self, mock_run_cmd):
-        url = "https://github.com/my-owner/my-repo/pull/126"
-        # Should resolve via regex without calling gh
-        result = self.gh.resolve_pr_number(url)
-        self.assertEqual(result, 126)
-        mock_run_cmd.assert_not_called()
-
-    @patch("tools.private.release.gh.run_cmd")
-    def test_resolve_pr_number_url_with_subpath(self, mock_run_cmd):
-        url = "https://github.com/my-owner/my-repo/pull/126/files"
-        # Should resolve via regex without calling gh
-        result = self.gh.resolve_pr_number(url)
-        self.assertEqual(result, 126)
-        mock_run_cmd.assert_not_called()
-
-    @patch("tools.private.release.gh.run_cmd")
-    def test_resolve_pr_number_url_with_query(self, mock_run_cmd):
-        url = "https://github.com/my-owner/my-repo/pull/126/files?w=1"
-        # Should resolve via regex without calling gh
-        result = self.gh.resolve_pr_number(url)
-        self.assertEqual(result, 126)
-        mock_run_cmd.assert_not_called()
-
-    @patch("tools.private.release.gh.run_cmd")
-    def test_resolve_pr_number_url_other_repo(self, mock_run_cmd):
-        # URL for a different repo should fail immediately without calling gh
-        url = "https://github.com/other-owner/other-repo/pull/126"
-        with self.assertRaises(ValueError) as ctx:
-            self.gh.resolve_pr_number(url)
-        self.assertIn("URL is not for the configured repository", str(ctx.exception))
-        mock_run_cmd.assert_not_called()
-
-    @patch("tools.private.release.gh.run_cmd")
-    def test_resolve_pr_number_invalid_ref(self, mock_run_cmd):
-        # Invalid reference (not number, not URL) should fail
-        with self.assertRaises(ValueError) as ctx:
-            self.gh.resolve_pr_number("invalid-ref")
-        self.assertIn("Could not resolve PR reference", str(ctx.exception))
-        mock_run_cmd.assert_not_called()
+@pytest.fixture(name="gh")
+def fixture_gh():
+    return GitHub("my-owner/my-repo")
 
 
-if __name__ == "__main__":
-    unittest.main()
+@patch("tools.private.release.gh.run_cmd")
+def test_resolve_pr_number_digit(mock_run_cmd, gh):
+    # 124 and #125 should resolve immediately without running command
+    assert gh.resolve_pr_number("124") == 124
+    assert gh.resolve_pr_number("#125") == 125
+    mock_run_cmd.assert_not_called()
+
+
+@patch("tools.private.release.gh.run_cmd")
+def test_resolve_pr_number_url_simple(mock_run_cmd, gh):
+    url = "https://github.com/my-owner/my-repo/pull/126"
+    # Should resolve via regex without calling gh
+    result = gh.resolve_pr_number(url)
+    assert result == 126
+    mock_run_cmd.assert_not_called()
+
+
+@patch("tools.private.release.gh.run_cmd")
+def test_resolve_pr_number_url_with_subpath(mock_run_cmd, gh):
+    url = "https://github.com/my-owner/my-repo/pull/126/files"
+    # Should resolve via regex without calling gh
+    result = gh.resolve_pr_number(url)
+    assert result == 126
+    mock_run_cmd.assert_not_called()
+
+
+@patch("tools.private.release.gh.run_cmd")
+def test_resolve_pr_number_url_with_query(mock_run_cmd, gh):
+    url = "https://github.com/my-owner/my-repo/pull/126/files?w=1"
+    # Should resolve via regex without calling gh
+    result = gh.resolve_pr_number(url)
+    assert result == 126
+    mock_run_cmd.assert_not_called()
+
+
+@patch("tools.private.release.gh.run_cmd")
+def test_resolve_pr_number_url_other_repo(mock_run_cmd, gh):
+    # URL for a different repo should fail immediately without calling gh
+    url = "https://github.com/other-owner/other-repo/pull/126"
+    with pytest.raises(ValueError, match="URL is not for the configured repository"):
+        gh.resolve_pr_number(url)
+    mock_run_cmd.assert_not_called()
+
+
+@patch("tools.private.release.gh.run_cmd")
+def test_resolve_pr_number_invalid_ref(mock_run_cmd, gh):
+    # Invalid reference (not number, not URL) should fail
+    with pytest.raises(ValueError, match="Could not resolve PR reference"):
+        gh.resolve_pr_number("invalid-ref")
+    mock_run_cmd.assert_not_called()

--- a/tests/tools/private/release/gh_test.py
+++ b/tests/tools/private/release/gh_test.py
@@ -1,8 +1,8 @@
-from unittest.mock import patch
-
 import pytest
 
 from tools.private.release.gh import GitHub
+
+pytest_plugins = ["tests.tools.private.release.release_test_helper"]
 
 
 @pytest.fixture(name="gh")
@@ -10,16 +10,16 @@ def fixture_gh():
     return GitHub("my-owner/my-repo")
 
 
-@patch("tools.private.release.gh.run_cmd")
-def test_resolve_pr_number_digit(mock_run_cmd, gh):
+def test_resolve_pr_number_digit(mocker, gh):
+    mock_run_cmd = mocker.patch("tools.private.release.gh.run_cmd")
     # 124 and #125 should resolve immediately without running command
     assert gh.resolve_pr_number("124") == 124
     assert gh.resolve_pr_number("#125") == 125
     mock_run_cmd.assert_not_called()
 
 
-@patch("tools.private.release.gh.run_cmd")
-def test_resolve_pr_number_url_simple(mock_run_cmd, gh):
+def test_resolve_pr_number_url_simple(mocker, gh):
+    mock_run_cmd = mocker.patch("tools.private.release.gh.run_cmd")
     url = "https://github.com/my-owner/my-repo/pull/126"
     # Should resolve via regex without calling gh
     result = gh.resolve_pr_number(url)
@@ -27,8 +27,8 @@ def test_resolve_pr_number_url_simple(mock_run_cmd, gh):
     mock_run_cmd.assert_not_called()
 
 
-@patch("tools.private.release.gh.run_cmd")
-def test_resolve_pr_number_url_with_subpath(mock_run_cmd, gh):
+def test_resolve_pr_number_url_with_subpath(mocker, gh):
+    mock_run_cmd = mocker.patch("tools.private.release.gh.run_cmd")
     url = "https://github.com/my-owner/my-repo/pull/126/files"
     # Should resolve via regex without calling gh
     result = gh.resolve_pr_number(url)
@@ -36,8 +36,8 @@ def test_resolve_pr_number_url_with_subpath(mock_run_cmd, gh):
     mock_run_cmd.assert_not_called()
 
 
-@patch("tools.private.release.gh.run_cmd")
-def test_resolve_pr_number_url_with_query(mock_run_cmd, gh):
+def test_resolve_pr_number_url_with_query(mocker, gh):
+    mock_run_cmd = mocker.patch("tools.private.release.gh.run_cmd")
     url = "https://github.com/my-owner/my-repo/pull/126/files?w=1"
     # Should resolve via regex without calling gh
     result = gh.resolve_pr_number(url)
@@ -45,8 +45,8 @@ def test_resolve_pr_number_url_with_query(mock_run_cmd, gh):
     mock_run_cmd.assert_not_called()
 
 
-@patch("tools.private.release.gh.run_cmd")
-def test_resolve_pr_number_url_other_repo(mock_run_cmd, gh):
+def test_resolve_pr_number_url_other_repo(mocker, gh):
+    mock_run_cmd = mocker.patch("tools.private.release.gh.run_cmd")
     # URL for a different repo should fail immediately without calling gh
     url = "https://github.com/other-owner/other-repo/pull/126"
     with pytest.raises(ValueError, match="URL is not for the configured repository"):
@@ -54,9 +54,8 @@ def test_resolve_pr_number_url_other_repo(mock_run_cmd, gh):
     mock_run_cmd.assert_not_called()
 
 
-@patch("tools.private.release.gh.run_cmd")
-def test_resolve_pr_number_invalid_ref(mock_run_cmd, gh):
-    # Invalid reference (not number, not URL) should fail
+def test_resolve_pr_number_invalid(mocker, gh):
+    mock_run_cmd = mocker.patch("tools.private.release.gh.run_cmd")
     with pytest.raises(ValueError, match="Could not resolve PR reference"):
         gh.resolve_pr_number("invalid-ref")
     mock_run_cmd.assert_not_called()

--- a/tests/tools/private/release/git_test.py
+++ b/tests/tools/private/release/git_test.py
@@ -1,189 +1,154 @@
-import unittest
+import subprocess
 from unittest.mock import patch
+
+import pytest
 
 from tools.private.release.git import Git
 
 
-class GitCheckoutTest(unittest.TestCase):
-    def setUp(self):
-        self.git = Git(".")
-        self.patcher = patch.object(self.git, "_run_git")
-        self.mock_run_git = self.patcher.start()
-        self.addCleanup(self.patcher.stop)
-
-    def test_checkout_simple(self):
-        self.git.checkout("my-branch")
-        self.mock_run_git.assert_called_once_with(
-            "checkout", "my-branch", capture_output=False
-        )
-
-    @patch("tools.private.release.git.Git.branch_exists")
-    def test_checkout_track_remote_new_branch(self, mock_branch_exists):
-        mock_branch_exists.return_value = False
-
-        self.git.checkout("my-branch", track_remote="origin")
-
-        mock_branch_exists.assert_called_once_with("my-branch")
-        self.mock_run_git.assert_called_once_with(
-            "checkout", "--track", "origin/my-branch", capture_output=False
-        )
-
-    @patch("tools.private.release.git.Git.reset_hard")
-    @patch("tools.private.release.git.Git.branch_exists")
-    def test_checkout_track_remote_existing_branch(
-        self, mock_branch_exists, mock_reset_hard
-    ):
-        mock_branch_exists.return_value = True
-
-        self.git.checkout("my-branch", track_remote="origin")
-
-        mock_branch_exists.assert_called_once_with("my-branch")
-        self.mock_run_git.assert_called_once_with(
-            "checkout", "my-branch", capture_output=False
-        )
-        mock_reset_hard.assert_called_once_with(reset_to="origin/my-branch")
+@pytest.fixture(name="git_obj")
+def fixture_git_obj():
+    git = Git(".")
+    with patch.object(git, "_run_git") as mock_run_git:
+        git.mock_run_git = mock_run_git
+        yield git
 
 
-class GitFetchTest(unittest.TestCase):
-    def setUp(self):
-        self.git = Git(".")
-        self.patcher = patch.object(self.git, "_run_git")
-        self.mock_run_git = self.patcher.start()
-        self.addCleanup(self.patcher.stop)
-
-    def test_fetch_default(self):
-        self.git.fetch()
-        self.mock_run_git.assert_called_once_with(
-            "fetch", "origin", capture_output=False
-        )
-
-    def test_fetch_custom_remote(self):
-        self.git.fetch("upstream")
-        self.mock_run_git.assert_called_once_with(
-            "fetch", "upstream", capture_output=False
-        )
-
-    def test_fetch_with_refspec(self):
-        self.git.fetch("origin", refspec="my-branch")
-        self.mock_run_git.assert_called_once_with(
-            "fetch", "origin", "my-branch", capture_output=False
-        )
-
-    def test_fetch_with_tags_and_force(self):
-        self.git.fetch("origin", tags=True, force=True)
-        self.mock_run_git.assert_called_once_with(
-            "fetch", "origin", "--tags", "--force", capture_output=False
-        )
-
-    def test_fetch_all_options(self):
-        self.git.fetch("origin", refspec="my-branch", tags=True, force=True)
-        self.mock_run_git.assert_called_once_with(
-            "fetch", "origin", "my-branch", "--tags", "--force", capture_output=False
-        )
+def test_checkout_simple(git_obj):
+    git_obj.checkout("my-branch")
+    git_obj.mock_run_git.assert_called_once_with(
+        "checkout", "my-branch", capture_output=False
+    )
 
 
-class GitGetModifiedFilesTest(unittest.TestCase):
-    def setUp(self):
-        self.git = Git(".")
-        self.patcher = patch.object(self.git, "_run_git")
-        self.mock_run_git = self.patcher.start()
-        self.addCleanup(self.patcher.stop)
+@patch("tools.private.release.git.Git.branch_exists")
+def test_checkout_track_remote_new_branch(mock_branch_exists, git_obj):
+    mock_branch_exists.return_value = False
 
-    def test_get_modified_files(self):
-        self.mock_run_git.return_value = "file1.txt\nfile2.py\n\n"
-        files = self.git.get_modified_files("HEAD")
-        self.mock_run_git.assert_called_once_with(
-            "show", "--name-only", "--format=", "HEAD"
-        )
-        self.assertEqual(files, ["file1.txt", "file2.py"])
+    git_obj.checkout("my-branch", track_remote="origin")
 
-    def test_get_modified_files_empty(self):
-        self.mock_run_git.return_value = ""
-        files = self.git.get_modified_files("HEAD")
-        self.assertEqual(files, [])
+    mock_branch_exists.assert_called_once_with("my-branch")
+    git_obj.mock_run_git.assert_called_once_with(
+        "checkout", "--track", "origin/my-branch", capture_output=False
+    )
 
 
-class GitDiffTest(unittest.TestCase):
-    def setUp(self):
-        self.git = Git(".")
-        self.patcher = patch.object(self.git, "_run_git")
-        self.mock_run_git = self.patcher.start()
-        self.addCleanup(self.patcher.stop)
+@patch("tools.private.release.git.Git.reset_hard")
+@patch("tools.private.release.git.Git.branch_exists")
+def test_checkout_track_remote_existing_branch(
+    mock_branch_exists, mock_reset_hard, git_obj
+):
+    mock_branch_exists.return_value = True
 
-    def test_diff_has_changes(self):
-        self.mock_run_git.return_value = "some diff output"
-        output = self.git.diff()
-        self.mock_run_git.assert_called_once_with("diff")
-        self.assertEqual(output, "some diff output")
+    git_obj.checkout("my-branch", track_remote="origin")
 
-    def test_diff_empty(self):
-        self.mock_run_git.return_value = ""
-        output = self.git.diff()
-        self.mock_run_git.assert_called_once_with("diff")
-        self.assertEqual(output, "")
+    mock_branch_exists.assert_called_once_with("my-branch")
+    git_obj.mock_run_git.assert_called_once_with(
+        "checkout", "my-branch", capture_output=False
+    )
+    mock_reset_hard.assert_called_once_with(reset_to="origin/my-branch")
 
 
-class GitApplyTest(unittest.TestCase):
-    def setUp(self):
-        self.git = Git(".")
-        self.patcher = patch.object(self.git, "_run_git")
-        self.mock_run_git = self.patcher.start()
-        self.addCleanup(self.patcher.stop)
-
-    def test_apply(self):
-        self.git.apply("patch.patch")
-        self.mock_run_git.assert_called_once_with(
-            "apply", "patch.patch", capture_output=False
-        )
+def test_fetch_default(git_obj):
+    git_obj.fetch()
+    git_obj.mock_run_git.assert_called_once_with(
+        "fetch", "origin", capture_output=False
+    )
 
 
-class GitApplyCheckTest(unittest.TestCase):
-    def setUp(self):
-        self.git = Git(".")
-        self.patcher = patch.object(self.git, "_run_git")
-        self.mock_run_git = self.patcher.start()
-        self.addCleanup(self.patcher.stop)
-
-    def test_apply_check_clean(self):
-        self.mock_run_git.return_value = ""
-        result = self.git.apply_check("patch.patch")
-        self.mock_run_git.assert_called_once_with(
-            "apply", "--check", "patch.patch", capture_output=False
-        )
-        self.assertTrue(result)
-
-    def test_apply_check_conflict(self):
-        import subprocess
-
-        self.mock_run_git.side_effect = subprocess.CalledProcessError(
-            1, ["git", "apply", "--check", "patch.patch"]
-        )
-        result = self.git.apply_check("patch.patch")
-        self.mock_run_git.assert_called_once_with(
-            "apply", "--check", "patch.patch", capture_output=False
-        )
-        self.assertFalse(result)
+def test_fetch_custom_remote(git_obj):
+    git_obj.fetch("upstream")
+    git_obj.mock_run_git.assert_called_once_with(
+        "fetch", "upstream", capture_output=False
+    )
 
 
-class GitResetHardTest(unittest.TestCase):
-    def setUp(self):
-        self.git = Git(".")
-        self.patcher = patch.object(self.git, "_run_git")
-        self.mock_run_git = self.patcher.start()
-        self.addCleanup(self.patcher.stop)
-
-    def test_reset_hard_default(self):
-        self.git.reset_hard()
-        self.mock_run_git.assert_called_once_with(
-            "reset", "--hard", "HEAD", capture_output=False
-        )
-
-    def test_reset_hard_custom(self):
-        self.git.reset_hard(reset_to="my-commit")
-        self.mock_run_git.assert_called_once_with(
-            "reset", "--hard", "my-commit", capture_output=False
-        )
+def test_fetch_with_refspec(git_obj):
+    git_obj.fetch("origin", refspec="my-branch")
+    git_obj.mock_run_git.assert_called_once_with(
+        "fetch", "origin", "my-branch", capture_output=False
+    )
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_fetch_with_tags_and_force(git_obj):
+    git_obj.fetch("origin", tags=True, force=True)
+    git_obj.mock_run_git.assert_called_once_with(
+        "fetch", "origin", "--tags", "--force", capture_output=False
+    )
+
+
+def test_fetch_all_options(git_obj):
+    git_obj.fetch("origin", refspec="my-branch", tags=True, force=True)
+    git_obj.mock_run_git.assert_called_once_with(
+        "fetch", "origin", "my-branch", "--tags", "--force", capture_output=False
+    )
+
+
+def test_get_modified_files(git_obj):
+    git_obj.mock_run_git.return_value = "file1.txt\nfile2.py\n\n"
+    files = git_obj.get_modified_files("HEAD")
+    git_obj.mock_run_git.assert_called_once_with(
+        "show", "--name-only", "--format=", "HEAD"
+    )
+    assert files == ["file1.txt", "file2.py"]
+
+
+def test_get_modified_files_empty(git_obj):
+    git_obj.mock_run_git.return_value = ""
+    files = git_obj.get_modified_files("HEAD")
+    assert files == []
+
+
+def test_diff_has_changes(git_obj):
+    git_obj.mock_run_git.return_value = "some diff output"
+    output = git_obj.diff()
+    git_obj.mock_run_git.assert_called_once_with("diff")
+    assert output == "some diff output"
+
+
+def test_diff_empty(git_obj):
+    git_obj.mock_run_git.return_value = ""
+    output = git_obj.diff()
+    git_obj.mock_run_git.assert_called_once_with("diff")
+    assert output == ""
+
+
+def test_apply(git_obj):
+    git_obj.apply("patch.patch")
+    git_obj.mock_run_git.assert_called_once_with(
+        "apply", "patch.patch", capture_output=False
+    )
+
+
+def test_apply_check_clean(git_obj):
+    git_obj.mock_run_git.return_value = ""
+    result = git_obj.apply_check("patch.patch")
+    git_obj.mock_run_git.assert_called_once_with(
+        "apply", "--check", "patch.patch", capture_output=False
+    )
+    assert result is True
+
+
+def test_apply_check_conflict(git_obj):
+    git_obj.mock_run_git.side_effect = subprocess.CalledProcessError(
+        1, ["git", "apply", "--check", "patch.patch"]
+    )
+    result = git_obj.apply_check("patch.patch")
+    git_obj.mock_run_git.assert_called_once_with(
+        "apply", "--check", "patch.patch", capture_output=False
+    )
+    assert result is False
+
+
+def test_reset_hard_default(git_obj):
+    git_obj.reset_hard()
+    git_obj.mock_run_git.assert_called_once_with(
+        "reset", "--hard", "HEAD", capture_output=False
+    )
+
+
+def test_reset_hard_custom(git_obj):
+    git_obj.reset_hard(reset_to="my-commit")
+    git_obj.mock_run_git.assert_called_once_with(
+        "reset", "--hard", "my-commit", capture_output=False
+    )

--- a/tests/tools/private/release/git_test.py
+++ b/tests/tools/private/release/git_test.py
@@ -1,17 +1,17 @@
 import subprocess
-from unittest.mock import patch
 
 import pytest
 
 from tools.private.release.git import Git
 
+pytest_plugins = ["tests.tools.private.release.release_test_helper"]
+
 
 @pytest.fixture(name="git_obj")
-def fixture_git_obj():
+def fixture_git_obj(mocker):
     git = Git(".")
-    with patch.object(git, "_run_git") as mock_run_git:
-        git.mock_run_git = mock_run_git
-        yield git
+    git.mock_run_git = mocker.patch.object(git, "_run_git")
+    return git
 
 
 def test_checkout_simple(git_obj):
@@ -21,9 +21,10 @@ def test_checkout_simple(git_obj):
     )
 
 
-@patch("tools.private.release.git.Git.branch_exists")
-def test_checkout_track_remote_new_branch(mock_branch_exists, git_obj):
-    mock_branch_exists.return_value = False
+def test_checkout_track_remote_new_branch(mocker, git_obj):
+    mock_branch_exists = mocker.patch(
+        "tools.private.release.git.Git.branch_exists", return_value=False
+    )
 
     git_obj.checkout("my-branch", track_remote="origin")
 
@@ -33,12 +34,11 @@ def test_checkout_track_remote_new_branch(mock_branch_exists, git_obj):
     )
 
 
-@patch("tools.private.release.git.Git.reset_hard")
-@patch("tools.private.release.git.Git.branch_exists")
-def test_checkout_track_remote_existing_branch(
-    mock_branch_exists, mock_reset_hard, git_obj
-):
-    mock_branch_exists.return_value = True
+def test_checkout_track_remote_existing_branch(mocker, git_obj):
+    mock_branch_exists = mocker.patch(
+        "tools.private.release.git.Git.branch_exists", return_value=True
+    )
+    mock_reset_hard = mocker.patch("tools.private.release.git.Git.reset_hard")
 
     git_obj.checkout("my-branch", track_remote="origin")
 

--- a/tests/tools/private/release/on_pr_merged_test.py
+++ b/tests/tools/private/release/on_pr_merged_test.py
@@ -1,12 +1,12 @@
 import argparse
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from tools.private.release.on_pr_merged import OnPrMerged
 
 pytest_plugins = ["tests.tools.private.release.release_test_helper"]
 
 
-def test_on_pr_merged_no_comment(mock_git, mock_gh):
+def test_on_pr_merged_no_comment(mocker, mock_git, mock_gh):
     args = argparse.Namespace(pr=124, remote="origin", dry_run=True)
     mock_gh.pr_comments = {
         124: [
@@ -15,25 +15,25 @@ def test_on_pr_merged_no_comment(mock_git, mock_gh):
         ]
     }
 
-    with patch("tools.private.release.on_pr_merged.ProcessBackports") as mock_pb:
-        result = OnPrMerged(args, mock_git, mock_gh).run()
+    mock_pb = mocker.patch("tools.private.release.on_pr_merged.ProcessBackports")
+    result = OnPrMerged(args, mock_git, mock_gh).run()
 
-        assert result == 1
-        mock_pb.assert_not_called()
+    assert result == 1
+    mock_pb.assert_not_called()
 
 
-def test_on_pr_merged_has_comment_no_active_release(mock_git, mock_gh):
+def test_on_pr_merged_has_comment_no_active_release(mocker, mock_git, mock_gh):
     args = argparse.Namespace(pr=124, remote="origin", dry_run=True)
     mock_gh.pr_comments = {124: [{"body": "/backport"}]}
 
-    with patch("tools.private.release.on_pr_merged.ProcessBackports") as mock_pb:
-        result = OnPrMerged(args, mock_git, mock_gh).run()
+    mock_pb = mocker.patch("tools.private.release.on_pr_merged.ProcessBackports")
+    result = OnPrMerged(args, mock_git, mock_gh).run()
 
-        assert result == 1
-        mock_pb.assert_not_called()
+    assert result == 1
+    mock_pb.assert_not_called()
 
 
-def test_on_pr_merged_has_comment_not_in_backports(mock_git, mock_gh):
+def test_on_pr_merged_has_comment_not_in_backports(mocker, mock_git, mock_gh):
     args = argparse.Namespace(pr=124, remote="origin", dry_run=True)
     mock_gh.pr_comments = {124: [{"body": "  /backport  "}]}
     mock_gh.create_issue(
@@ -48,14 +48,14 @@ def test_on_pr_merged_has_comment_not_in_backports(mock_git, mock_gh):
         labels=["type: release"],
     )
 
-    with patch("tools.private.release.on_pr_merged.ProcessBackports") as mock_pb:
-        result = OnPrMerged(args, mock_git, mock_gh).run()
+    mock_pb = mocker.patch("tools.private.release.on_pr_merged.ProcessBackports")
+    result = OnPrMerged(args, mock_git, mock_gh).run()
 
-        assert result == 1
-        mock_pb.assert_not_called()
+    assert result == 1
+    mock_pb.assert_not_called()
 
 
-def test_on_pr_merged_success(mock_git, mock_gh):
+def test_on_pr_merged_success(mocker, mock_git, mock_gh):
     args = argparse.Namespace(pr=124, remote="origin", dry_run=True)
     mock_gh.pr_comments = {124: [{"body": "/backport"}]}
     issue_num = mock_gh.create_issue(
@@ -70,23 +70,23 @@ def test_on_pr_merged_success(mock_git, mock_gh):
         labels=["type: release"],
     )
 
-    with patch("tools.private.release.on_pr_merged.ProcessBackports") as mock_pb_class:
-        mock_pb_instance = MagicMock()
-        mock_pb_instance.run.return_value = 0
-        mock_pb_class.return_value = mock_pb_instance
+    mock_pb_class = mocker.patch("tools.private.release.on_pr_merged.ProcessBackports")
+    mock_pb_instance = MagicMock()
+    mock_pb_instance.run.return_value = 0
+    mock_pb_class.return_value = mock_pb_instance
 
-        result = OnPrMerged(args, mock_git, mock_gh).run()
+    result = OnPrMerged(args, mock_git, mock_gh).run()
 
-        assert result == 0
+    assert result == 0
 
-        # Verify ProcessBackports was instantiated with correct args
-        mock_pb_class.assert_called_once()
-        called_args = mock_pb_class.call_args[0][0]
-        assert called_args.issue == issue_num
-        assert called_args.remote == "origin"
-        assert called_args.dry_run is True
-        assert called_args.add is None
-        assert called_args.triggering_comment is None
+    # Verify ProcessBackports was instantiated with correct args
+    mock_pb_class.assert_called_once()
+    called_args = mock_pb_class.call_args[0][0]
+    assert called_args.issue == issue_num
+    assert called_args.remote == "origin"
+    assert called_args.dry_run is True
+    assert called_args.add is None
+    assert called_args.triggering_comment is None
 
-        # Verify ProcessBackports.run() was called
-        mock_pb_instance.run.assert_called_once()
+    # Verify ProcessBackports.run() was called
+    mock_pb_instance.run.assert_called_once()

--- a/tests/tools/private/release/on_pr_merged_test.py
+++ b/tests/tools/private/release/on_pr_merged_test.py
@@ -1,112 +1,92 @@
 import argparse
-import unittest
 from unittest.mock import MagicMock, patch
 
-from tests.tools.private.release.release_test_helper import _mock_git_and_gh
 from tools.private.release.on_pr_merged import OnPrMerged
 
+pytest_plugins = ["tests.tools.private.release.release_test_helper"]
 
-class CmdOnPrMergedTest(unittest.TestCase):
-    def setUp(self):
-        _mock_git_and_gh(self)
-        self.addCleanup(patch.stopall)
 
-        # Mock ProcessBackports
-        self.mock_process_patcher = patch(
-            "tools.private.release.on_pr_merged.ProcessBackports"
-        )
-        self.mock_process_class = self.mock_process_patcher.start()
-        self.mock_process_instance = MagicMock()
-        self.mock_process_class.return_value = self.mock_process_instance
-
-    def test_on_pr_merged_no_comment(self):
-        args = argparse.Namespace(pr=124, remote="origin", dry_run=True)
-        self.mock_gh.get_pr_comments.return_value = [
+def test_on_pr_merged_no_comment(mock_git, mock_gh):
+    args = argparse.Namespace(pr=124, remote="origin", dry_run=True)
+    mock_gh.pr_comments = {
+        124: [
             {"body": "Some comment"},
             {"body": "Another comment /backport_wrong"},
         ]
+    }
 
-        result = OnPrMerged(args, self.mock_git, self.mock_gh).run()
+    with patch("tools.private.release.on_pr_merged.ProcessBackports") as mock_pb:
+        result = OnPrMerged(args, mock_git, mock_gh).run()
 
-        self.assertEqual(result, 1)
-        self.mock_gh.get_pr_comments.assert_called_once_with(124)
-        self.mock_gh.get_open_tracking_issues.assert_not_called()
-        self.mock_process_class.assert_not_called()
+        assert result == 1
+        mock_pb.assert_not_called()
 
-    def test_on_pr_merged_has_comment_no_active_release(self):
-        args = argparse.Namespace(pr=124, remote="origin", dry_run=True)
-        self.mock_gh.get_pr_comments.return_value = [
-            {"body": "/backport"},
-        ]
-        self.mock_gh.get_open_tracking_issues.return_value = []
 
-        result = OnPrMerged(args, self.mock_git, self.mock_gh).run()
+def test_on_pr_merged_has_comment_no_active_release(mock_git, mock_gh):
+    args = argparse.Namespace(pr=124, remote="origin", dry_run=True)
+    mock_gh.pr_comments = {124: [{"body": "/backport"}]}
 
-        self.assertEqual(result, 1)
-        self.mock_gh.get_pr_comments.assert_called_once_with(124)
-        self.mock_gh.get_open_tracking_issues.assert_called_once()
-        self.mock_gh.get_issue_body.assert_not_called()
-        self.mock_process_class.assert_not_called()
+    with patch("tools.private.release.on_pr_merged.ProcessBackports") as mock_pb:
+        result = OnPrMerged(args, mock_git, mock_gh).run()
 
-    def test_on_pr_merged_has_comment_not_in_backports(self):
-        args = argparse.Namespace(pr=124, remote="origin", dry_run=True)
-        self.mock_gh.get_pr_comments.return_value = [
-            {"body": "  /backport  "},
-        ]
-        self.mock_gh.get_open_tracking_issues.return_value = [
-            {"number": 456, "title": "Release 2.1.0", "url": "http://..."}
-        ]
-        self.mock_gh.get_issue_body.return_value = """
+        assert result == 1
+        mock_pb.assert_not_called()
+
+
+def test_on_pr_merged_has_comment_not_in_backports(mock_git, mock_gh):
+    args = argparse.Namespace(pr=124, remote="origin", dry_run=True)
+    mock_gh.pr_comments = {124: [{"body": "  /backport  "}]}
+    mock_gh.create_issue(
+        title="Release 2.1.0",
+        body="""
 ## Checklist
 - [ ] Prepare Release
 
 ## Backports
 - [ ] #125 | status=pending
-"""
-        result = OnPrMerged(args, self.mock_git, self.mock_gh).run()
+""",
+        labels=["type: release"],
+    )
 
-        self.assertEqual(result, 1)
-        self.mock_gh.get_pr_comments.assert_called_once_with(124)
-        self.mock_gh.get_open_tracking_issues.assert_called_once()
-        self.mock_gh.get_issue_body.assert_called_once_with(456)
-        self.mock_process_class.assert_not_called()
+    with patch("tools.private.release.on_pr_merged.ProcessBackports") as mock_pb:
+        result = OnPrMerged(args, mock_git, mock_gh).run()
 
-    def test_on_pr_merged_success(self):
-        args = argparse.Namespace(pr=124, remote="origin", dry_run=True)
-        self.mock_gh.get_pr_comments.return_value = [
-            {"body": "/backport"},
-        ]
-        self.mock_gh.get_open_tracking_issues.return_value = [
-            {"number": 456, "title": "Release 2.1.0", "url": "http://..."}
-        ]
-        self.mock_gh.get_issue_body.return_value = """
+        assert result == 1
+        mock_pb.assert_not_called()
+
+
+def test_on_pr_merged_success(mock_git, mock_gh):
+    args = argparse.Namespace(pr=124, remote="origin", dry_run=True)
+    mock_gh.pr_comments = {124: [{"body": "/backport"}]}
+    issue_num = mock_gh.create_issue(
+        title="Release 2.1.0",
+        body="""
 ## Checklist
 - [ ] Prepare Release
 
 ## Backports
 - [ ] #124 | status=pending
-"""
-        self.mock_process_instance.run.return_value = 0
+""",
+        labels=["type: release"],
+    )
 
-        result = OnPrMerged(args, self.mock_git, self.mock_gh).run()
+    with patch("tools.private.release.on_pr_merged.ProcessBackports") as mock_pb_class:
+        mock_pb_instance = MagicMock()
+        mock_pb_instance.run.return_value = 0
+        mock_pb_class.return_value = mock_pb_instance
 
-        self.assertEqual(result, 0)
-        self.mock_gh.get_pr_comments.assert_called_once_with(124)
-        self.mock_gh.get_open_tracking_issues.assert_called_once()
-        self.mock_gh.get_issue_body.assert_called_once_with(456)
+        result = OnPrMerged(args, mock_git, mock_gh).run()
+
+        assert result == 0
 
         # Verify ProcessBackports was instantiated with correct args
-        self.mock_process_class.assert_called_once()
-        called_args = self.mock_process_class.call_args[0][0]
-        self.assertEqual(called_args.issue, 456)
-        self.assertEqual(called_args.remote, "origin")
-        self.assertEqual(called_args.dry_run, True)
-        self.assertIsNone(called_args.add)
-        self.assertIsNone(called_args.triggering_comment)
+        mock_pb_class.assert_called_once()
+        called_args = mock_pb_class.call_args[0][0]
+        assert called_args.issue == issue_num
+        assert called_args.remote == "origin"
+        assert called_args.dry_run is True
+        assert called_args.add is None
+        assert called_args.triggering_comment is None
 
         # Verify ProcessBackports.run() was called
-        self.mock_process_instance.run.assert_called_once()
-
-
-if __name__ == "__main__":
-    unittest.main()
+        mock_pb_instance.run.assert_called_once()

--- a/tests/tools/private/release/prepare_test.py
+++ b/tests/tools/private/release/prepare_test.py
@@ -1,250 +1,212 @@
-import unittest
-from unittest.mock import MagicMock, patch
+import argparse
+from unittest.mock import patch
 
-from tests.tools.private.release.release_test_helper import (
-    TempDirTestCase,
-    _mock_git_and_gh,
-)
-from tools.private.release.gh import (
-    MultipleTrackingIssuesError,
-    NoTrackingIssueError,
-)
 from tools.private.release.prepare import Prepare
 
-
-class CmdPrepareTest(TempDirTestCase):
-    def setUp(self):
-        super().setUp()
-        _mock_git_and_gh(self)
-
-    @patch("tools.private.release.prepare.changelog_news")
-    @patch("tools.private.release.prepare.replace_version_next")
-    def test_prepare_success_existing_issue(self, mock_replace, mock_changelog):
-        # Arrange
-        args = MagicMock(version="2.0.0", issue=None, dry_run=False)
-        self.mock_git.status.side_effect = ["", "M  foo"]
-        self.mock_git.branch_exists.return_value = False
-        self.mock_gh.get_release_tracking_issue.side_effect = None
-        self.mock_gh.get_release_tracking_issue.return_value = 123
-        self.mock_gh.create_pr.return_value = "https://github.com/foo/bar/pull/456"
-        self.mock_gh.get_issue_body.return_value = "- [ ] Prepare Release"
-
-        # Act
-        result = Prepare(args, self.mock_git, self.mock_gh).run()
-
-        # Assert
-        self.assertEqual(result, 0)
-        self.mock_gh.get_release_tracking_issue.assert_called_once_with("2.0.0")
-        self.mock_gh.create_tracking_issue.assert_not_called()
-        self.mock_gh.create_pr.assert_called_once_with(
-            title="Prepare release v2.0.0",
-            body="Work towards #123",
-            base="main",
-        )
-        self.mock_git.add_modified_and_deleted.assert_called_once()
-
-    @patch("tools.private.release.prepare.changelog_news")
-    @patch("tools.private.release.prepare.replace_version_next")
-    def test_prepare_success_create_issue(self, mock_replace, mock_changelog):
-        # Arrange
-        template_dir = self.tmpdir / ".github" / "ISSUE_TEMPLATE"
-        template_dir.mkdir(parents=True, exist_ok=True)
-        template_file = template_dir / "release_tracking_template.md"
-        template_file.write_text("dummy template content")
-
-        args = MagicMock(version="2.0.0", issue=None, dry_run=False)
-        self.mock_git.status.side_effect = ["", "M  foo"]
-        self.mock_git.branch_exists.return_value = False
-        self.mock_gh.get_release_tracking_issue.side_effect = NoTrackingIssueError(
-            "Not found"
-        )
-        self.mock_gh.create_tracking_issue.return_value = 123
-        self.mock_gh.create_pr.return_value = "https://github.com/foo/bar/pull/456"
-        self.mock_gh.get_issue_body.return_value = "- [ ] Prepare Release"
-
-        # Act
-        result = Prepare(args, self.mock_git, self.mock_gh).run()
-
-        # Assert
-        self.assertEqual(result, 0)
-        self.mock_gh.get_release_tracking_issue.assert_called_once_with("2.0.0")
-        self.mock_gh.create_tracking_issue.assert_called_once_with(
-            "2.0.0", "dummy template content"
-        )
-        self.mock_gh.create_pr.assert_called_once_with(
-            title="Prepare release v2.0.0",
-            body="Work towards #123",
-            base="main",
-        )
-        self.mock_git.add_modified_and_deleted.assert_called_once()
-
-    @patch("tools.private.release.prepare.changelog_news")
-    @patch("tools.private.release.prepare.replace_version_next")
-    def test_prepare_ambiguous_issue(self, mock_replace, mock_changelog):
-        # Arrange
-        args = MagicMock(version="2.0.0", issue=None, dry_run=False)
-        self.mock_git.status.side_effect = ["", "M  foo"]
-        self.mock_git.branch_exists.return_value = False
-        self.mock_gh.get_release_tracking_issue.side_effect = (
-            MultipleTrackingIssuesError("Multiple open tracking issues")
-        )
-
-        # Act
-        result = Prepare(args, self.mock_git, self.mock_gh).run()
-
-        # Assert
-        self.assertEqual(result, 1)
-        self.mock_gh.get_release_tracking_issue.assert_called_once_with("2.0.0")
-        self.mock_gh.create_tracking_issue.assert_not_called()
-        self.mock_gh.create_pr.assert_not_called()
-        self.mock_git.add_modified_and_deleted.assert_not_called()
-
-    @patch("tools.private.release.prepare.changelog_news")
-    @patch("tools.private.release.prepare.replace_version_next")
-    def test_prepare_dry_run(self, mock_replace, mock_changelog):
-        # Arrange
-        args = MagicMock(version="2.0.0", issue=None, dry_run=True)
-        self.mock_git.status.side_effect = [""]
-        self.mock_gh.get_release_tracking_issue.side_effect = None
-        self.mock_gh.get_release_tracking_issue.return_value = 123
-
-        # Act
-        result = Prepare(args, self.mock_git, self.mock_gh).run()
-
-        # Assert
-        self.assertEqual(result, 0)
-        self.mock_git.checkout.assert_not_called()
-        self.mock_git.commit.assert_not_called()
-        self.mock_git.push.assert_not_called()
-        self.mock_gh.create_pr.assert_not_called()
-        self.mock_gh.update_issue_body.assert_not_called()
-        self.mock_git.fetch.assert_called_once()
-        self.mock_gh.get_release_tracking_issue.assert_called_once_with("2.0.0")
-        self.mock_git.add_modified_and_deleted.assert_not_called()
-
-    @patch("tools.private.release.prepare.changelog_news")
-    @patch("tools.private.release.prepare.replace_version_next")
-    def test_prepare_use_associated_pr_from_tracking_issue(
-        self, mock_replace, mock_changelog
-    ):
-        # Arrange
-        args = MagicMock(version="2.0.0", issue=None, dry_run=False)
-        self.mock_git.status.side_effect = ["", ""]
-        self.mock_git.branch_exists.return_value = True
-        self.mock_gh.get_release_tracking_issue.side_effect = None
-        self.mock_gh.get_release_tracking_issue.return_value = 123
-        self.mock_gh.get_open_pr.return_value = None
-        # PR #456 is already associated in the tracking issue
-        self.mock_gh.get_issue_body.return_value = (
-            "- [ ] Prepare Release | status=pending pr=#456"
-        )
-
-        # Act
-        result = Prepare(args, self.mock_git, self.mock_gh).run()
-
-        # Assert
-        self.assertEqual(result, 0)
-        self.mock_git.checkout.assert_called_once_with("prepare-2.0.0")
-        self.mock_git.commit.assert_not_called()
-        self.mock_git.push.assert_called_once_with(
-            "origin", "prepare-2.0.0", set_upstream=True, force=True
-        )
-        self.mock_gh.get_open_pr.assert_called_once_with("prepare-2.0.0")
-        self.mock_gh.create_pr.assert_not_called()  # Should NOT create a new PR
-        self.mock_gh.update_issue_body.assert_called_once()
-        call_args = self.mock_gh.update_issue_body.call_args[0]
-        self.assertIn("pr=#456", call_args[1])
-
-    @patch("tools.private.release.prepare.changelog_news")
-    @patch("tools.private.release.prepare.replace_version_next")
-    def test_prepare_create_pr_when_none_associated(self, mock_replace, mock_changelog):
-        # Arrange
-        args = MagicMock(version="2.0.0", issue=None, dry_run=False)
-        self.mock_git.status.side_effect = ["", ""]
-        self.mock_git.branch_exists.return_value = True
-        self.mock_gh.get_release_tracking_issue.side_effect = None
-        self.mock_gh.get_release_tracking_issue.return_value = 123
-        self.mock_gh.get_open_pr.return_value = None
-        # No PR associated in the tracking issue
-        self.mock_gh.get_issue_body.return_value = "- [ ] Prepare Release"
-        self.mock_gh.create_pr.return_value = "https://github.com/foo/bar/pull/789"
-
-        # Act
-        result = Prepare(args, self.mock_git, self.mock_gh).run()
-
-        # Assert
-        self.assertEqual(result, 0)
-        self.mock_git.checkout.assert_called_once_with("prepare-2.0.0")
-        self.mock_git.commit.assert_not_called()
-        self.mock_git.push.assert_called_once_with(
-            "origin", "prepare-2.0.0", set_upstream=True, force=True
-        )
-        self.mock_gh.get_open_pr.assert_called_once_with("prepare-2.0.0")
-        self.mock_gh.create_pr.assert_called_once_with(
-            title="Prepare release v2.0.0",
-            body="Work towards #123",
-            base="main",
-        )
-        self.mock_gh.update_issue_body.assert_called_once()
-        call_args = self.mock_gh.update_issue_body.call_args[0]
-        self.assertIn("pr=#789", call_args[1])
-
-    @patch("tools.private.release.prepare.changelog_news")
-    @patch("tools.private.release.prepare.replace_version_next")
-    def test_prepare_reuse_existing_pr(self, mock_replace, mock_changelog):
-        # Arrange
-        args = MagicMock(version="2.0.0", issue=None, dry_run=False)
-        self.mock_git.status.side_effect = ["", ""]
-        self.mock_git.branch_exists.return_value = True
-        self.mock_gh.get_release_tracking_issue.side_effect = None
-        self.mock_gh.get_release_tracking_issue.return_value = 123
-        self.mock_gh.get_open_pr.return_value = {
-            "number": 456,
-            "url": "https://github.com/foo/bar/pull/456",
-        }
-        self.mock_gh.get_issue_body.return_value = "- [ ] Prepare Release"
-
-        # Act
-        result = Prepare(args, self.mock_git, self.mock_gh).run()
-
-        # Assert
-        self.assertEqual(result, 0)
-        self.mock_git.checkout.assert_called_once_with("prepare-2.0.0")
-        self.mock_git.commit.assert_not_called()
-        self.mock_git.push.assert_called_once_with(
-            "origin", "prepare-2.0.0", set_upstream=True, force=True
-        )
-        self.mock_gh.get_open_pr.assert_called_once_with("prepare-2.0.0")
-        self.mock_gh.create_pr.assert_not_called()
-        self.mock_gh.update_issue_body.assert_called_once()
-        call_args = self.mock_gh.update_issue_body.call_args[0]
-        self.assertIn("pr=#456", call_args[1])
-
-    @patch("tools.private.release.prepare.changelog_news")
-    @patch("tools.private.release.prepare.replace_version_next")
-    def test_prepare_dry_run_no_issue(self, mock_replace, mock_changelog):
-        # Arrange
-        template_dir = self.tmpdir / ".github" / "ISSUE_TEMPLATE"
-        template_dir.mkdir(parents=True, exist_ok=True)
-        template_file = template_dir / "release_tracking_template.md"
-        template_file.write_text("dummy template content")
-
-        args = MagicMock(version="2.0.0", issue=None, dry_run=True)
-        self.mock_git.status.side_effect = [""]
-        self.mock_gh.get_release_tracking_issue.side_effect = NoTrackingIssueError(
-            "Not found"
-        )
-
-        # Act
-        result = Prepare(args, self.mock_git, self.mock_gh).run()
-
-        # Assert
-        self.assertEqual(result, 0)
-        self.mock_git.checkout.assert_not_called()
-        self.mock_gh.create_tracking_issue.assert_not_called()
-        self.mock_gh.create_pr.assert_not_called()
-        self.mock_git.add_modified_and_deleted.assert_not_called()
+pytest_plugins = ["tests.tools.private.release.release_test_helper"]
 
 
-if __name__ == "__main__":
-    unittest.main()
+@patch("tools.private.release.prepare.changelog_news")
+@patch("tools.private.release.prepare.replace_version_next")
+def test_prepare_success_existing_issue(
+    mock_replace, mock_changelog, release_tool_env, mock_git, mock_gh
+):
+    # Arrange
+    args = argparse.Namespace(version="2.0.0", issue=None, dry_run=False)
+    mock_gh.create_issue(
+        title="Release 2.0.0",
+        body="- [ ] Prepare Release",
+        labels=["type: release"],
+    )  # Assigns issue 1001
+    mock_git.status.side_effect = ["", "M  foo"]
+    mock_git.branch_exists.return_value = False
+
+    # Act
+    result = Prepare(args, mock_git, mock_gh).run()
+
+    # Assert
+    assert result == 0
+    assert 1002 in mock_gh.prs
+    assert mock_gh.prs[1002]["title"] == "Prepare release v2.0.0"
+    assert mock_gh.prs[1002]["body"] == "Work towards #1001"
+    mock_git.add_modified_and_deleted.assert_called_once()
+
+
+@patch("tools.private.release.prepare.changelog_news")
+@patch("tools.private.release.prepare.replace_version_next")
+def test_prepare_success_create_issue(
+    mock_replace, mock_changelog, release_tool_env, mock_git, mock_gh
+):
+    # Arrange: release_tool_env sets up template_file automatically
+    args = argparse.Namespace(version="2.0.0", issue=None, dry_run=False)
+    mock_git.status.side_effect = ["", "M  foo"]
+    mock_git.branch_exists.return_value = False
+
+    # Act
+    result = Prepare(args, mock_git, mock_gh).run()
+
+    # Assert
+    assert result == 0
+    assert 1001 in mock_gh.issues
+    assert mock_gh.issues[1001]["title"] == "Release 2.0.0"
+    assert 1002 in mock_gh.prs
+    assert mock_gh.prs[1002]["title"] == "Prepare release v2.0.0"
+    assert mock_gh.prs[1002]["body"] == "Work towards #1001"
+    mock_git.add_modified_and_deleted.assert_called_once()
+
+
+@patch("tools.private.release.prepare.changelog_news")
+@patch("tools.private.release.prepare.replace_version_next")
+def test_prepare_ambiguous_issue(
+    mock_replace, mock_changelog, release_tool_env, mock_git, mock_gh
+):
+    # Arrange
+    args = argparse.Namespace(version="2.0.0", issue=None, dry_run=False)
+    mock_gh.create_issue(
+        title="Release 2.0.0", body="issue 1", labels=["type: release"]
+    )
+    mock_gh.create_issue(
+        title="Release 2.0.0", body="issue 2", labels=["type: release"]
+    )
+    mock_git.status.side_effect = ["", "M  foo"]
+    mock_git.branch_exists.return_value = False
+
+    # Act
+    result = Prepare(args, mock_git, mock_gh).run()
+
+    # Assert
+    assert result == 1
+    mock_git.add_modified_and_deleted.assert_not_called()
+
+
+@patch("tools.private.release.prepare.changelog_news")
+@patch("tools.private.release.prepare.replace_version_next")
+def test_prepare_dry_run(
+    mock_replace, mock_changelog, release_tool_env, mock_git, mock_gh
+):
+    # Arrange
+    args = argparse.Namespace(version="2.0.0", issue=None, dry_run=True)
+    mock_gh.create_issue(title="Release 2.0.0", body="body", labels=["type: release"])
+    mock_git.status.side_effect = [""]
+
+    # Act
+    result = Prepare(args, mock_git, mock_gh).run()
+
+    # Assert
+    assert result == 0
+    mock_git.checkout.assert_not_called()
+    mock_git.commit.assert_not_called()
+    mock_git.push.assert_not_called()
+    mock_git.fetch.assert_called_once()
+    mock_git.add_modified_and_deleted.assert_not_called()
+
+
+@patch("tools.private.release.prepare.changelog_news")
+@patch("tools.private.release.prepare.replace_version_next")
+def test_prepare_use_associated_pr_from_tracking_issue(
+    mock_replace, mock_changelog, release_tool_env, mock_git, mock_gh
+):
+    # Arrange
+    args = argparse.Namespace(version="2.0.0", issue=None, dry_run=False)
+    mock_gh.create_issue(
+        title="Release 2.0.0",
+        body="- [ ] Prepare Release | status=pending pr=#456",
+        labels=["type: release"],
+    )
+    mock_git.status.side_effect = ["", ""]
+    mock_git.branch_exists.return_value = True
+
+    # Act
+    result = Prepare(args, mock_git, mock_gh).run()
+
+    # Assert
+    assert result == 0
+    mock_git.checkout.assert_called_once_with("prepare-2.0.0")
+    mock_git.commit.assert_not_called()
+    mock_git.push.assert_called_once_with(
+        "origin", "prepare-2.0.0", set_upstream=True, force=True
+    )
+    updated_body = mock_gh.get_issue_body(1001)
+    assert "pr=#456" in updated_body
+
+
+@patch("tools.private.release.prepare.changelog_news")
+@patch("tools.private.release.prepare.replace_version_next")
+def test_prepare_create_pr_when_none_associated(
+    mock_replace, mock_changelog, release_tool_env, mock_git, mock_gh
+):
+    # Arrange
+    args = argparse.Namespace(version="2.0.0", issue=None, dry_run=False)
+    mock_gh.create_issue(
+        title="Release 2.0.0",
+        body="- [ ] Prepare Release",
+        labels=["type: release"],
+    )
+    mock_git.status.side_effect = ["", ""]
+    mock_git.branch_exists.return_value = True
+
+    # Act
+    result = Prepare(args, mock_git, mock_gh).run()
+
+    # Assert
+    assert result == 0
+    mock_git.checkout.assert_called_once_with("prepare-2.0.0")
+    mock_git.commit.assert_not_called()
+    mock_git.push.assert_called_once_with(
+        "origin", "prepare-2.0.0", set_upstream=True, force=True
+    )
+    updated_body = mock_gh.get_issue_body(1001)
+    assert "pr=#1002" in updated_body
+
+
+@patch("tools.private.release.prepare.changelog_news")
+@patch("tools.private.release.prepare.replace_version_next")
+def test_prepare_reuse_existing_pr(
+    mock_replace, mock_changelog, release_tool_env, mock_git, mock_gh
+):
+    # Arrange
+    args = argparse.Namespace(version="2.0.0", issue=None, dry_run=False)
+    mock_gh.create_issue(
+        title="Release 2.0.0",
+        body="- [ ] Prepare Release",
+        labels=["type: release"],
+    )
+    mock_gh.prs[456] = {
+        "number": 456,
+        "head": "prepare-2.0.0",
+        "state": "OPEN",
+        "url": "https://github.com/foo/bar/pull/456",
+    }
+    mock_git.status.side_effect = ["", ""]
+    mock_git.branch_exists.return_value = True
+
+    # Act
+    result = Prepare(args, mock_git, mock_gh).run()
+
+    # Assert
+    assert result == 0
+    mock_git.checkout.assert_called_once_with("prepare-2.0.0")
+    mock_git.commit.assert_not_called()
+    mock_git.push.assert_called_once_with(
+        "origin", "prepare-2.0.0", set_upstream=True, force=True
+    )
+    updated_body = mock_gh.get_issue_body(1001)
+    assert "pr=#456" in updated_body
+
+
+@patch("tools.private.release.prepare.changelog_news")
+@patch("tools.private.release.prepare.replace_version_next")
+def test_prepare_dry_run_no_issue(
+    mock_replace, mock_changelog, release_tool_env, mock_git, mock_gh
+):
+    # Arrange
+    args = argparse.Namespace(version="2.0.0", issue=None, dry_run=True)
+    mock_git.status.side_effect = [""]
+
+    # Act
+    result = Prepare(args, mock_git, mock_gh).run()
+
+    # Assert
+    assert result == 0
+    mock_git.checkout.assert_not_called()
+    mock_git.add_modified_and_deleted.assert_not_called()

--- a/tests/tools/private/release/prepare_test.py
+++ b/tests/tools/private/release/prepare_test.py
@@ -1,16 +1,14 @@
 import argparse
-from unittest.mock import patch
 
 from tools.private.release.prepare import Prepare
 
 pytest_plugins = ["tests.tools.private.release.release_test_helper"]
 
 
-@patch("tools.private.release.prepare.changelog_news")
-@patch("tools.private.release.prepare.replace_version_next")
-def test_prepare_success_existing_issue(
-    mock_replace, mock_changelog, release_tool_env, mock_git, mock_gh
-):
+def test_prepare_success_existing_issue(mocker, release_tool_env, mock_git, mock_gh):
+    mocker.patch("tools.private.release.prepare.replace_version_next")
+    mocker.patch("tools.private.release.prepare.changelog_news")
+
     # Arrange
     args = argparse.Namespace(version="2.0.0", issue=None, dry_run=False)
     mock_gh.create_issue(
@@ -32,11 +30,10 @@ def test_prepare_success_existing_issue(
     mock_git.add_modified_and_deleted.assert_called_once()
 
 
-@patch("tools.private.release.prepare.changelog_news")
-@patch("tools.private.release.prepare.replace_version_next")
-def test_prepare_success_create_issue(
-    mock_replace, mock_changelog, release_tool_env, mock_git, mock_gh
-):
+def test_prepare_success_create_issue(mocker, release_tool_env, mock_git, mock_gh):
+    mocker.patch("tools.private.release.prepare.replace_version_next")
+    mocker.patch("tools.private.release.prepare.changelog_news")
+
     # Arrange: release_tool_env sets up template_file automatically
     args = argparse.Namespace(version="2.0.0", issue=None, dry_run=False)
     mock_git.status.side_effect = ["", "M  foo"]
@@ -55,11 +52,10 @@ def test_prepare_success_create_issue(
     mock_git.add_modified_and_deleted.assert_called_once()
 
 
-@patch("tools.private.release.prepare.changelog_news")
-@patch("tools.private.release.prepare.replace_version_next")
-def test_prepare_ambiguous_issue(
-    mock_replace, mock_changelog, release_tool_env, mock_git, mock_gh
-):
+def test_prepare_ambiguous_issue(mocker, release_tool_env, mock_git, mock_gh):
+    mocker.patch("tools.private.release.prepare.replace_version_next")
+    mocker.patch("tools.private.release.prepare.changelog_news")
+
     # Arrange
     args = argparse.Namespace(version="2.0.0", issue=None, dry_run=False)
     mock_gh.create_issue(
@@ -79,11 +75,10 @@ def test_prepare_ambiguous_issue(
     mock_git.add_modified_and_deleted.assert_not_called()
 
 
-@patch("tools.private.release.prepare.changelog_news")
-@patch("tools.private.release.prepare.replace_version_next")
-def test_prepare_dry_run(
-    mock_replace, mock_changelog, release_tool_env, mock_git, mock_gh
-):
+def test_prepare_dry_run(mocker, release_tool_env, mock_git, mock_gh):
+    mocker.patch("tools.private.release.prepare.replace_version_next")
+    mocker.patch("tools.private.release.prepare.changelog_news")
+
     # Arrange
     args = argparse.Namespace(version="2.0.0", issue=None, dry_run=True)
     mock_gh.create_issue(title="Release 2.0.0", body="body", labels=["type: release"])
@@ -101,11 +96,12 @@ def test_prepare_dry_run(
     mock_git.add_modified_and_deleted.assert_not_called()
 
 
-@patch("tools.private.release.prepare.changelog_news")
-@patch("tools.private.release.prepare.replace_version_next")
 def test_prepare_use_associated_pr_from_tracking_issue(
-    mock_replace, mock_changelog, release_tool_env, mock_git, mock_gh
+    mocker, release_tool_env, mock_git, mock_gh
 ):
+    mocker.patch("tools.private.release.prepare.replace_version_next")
+    mocker.patch("tools.private.release.prepare.changelog_news")
+
     # Arrange
     args = argparse.Namespace(version="2.0.0", issue=None, dry_run=False)
     mock_gh.create_issue(
@@ -130,11 +126,12 @@ def test_prepare_use_associated_pr_from_tracking_issue(
     assert "pr=#456" in updated_body
 
 
-@patch("tools.private.release.prepare.changelog_news")
-@patch("tools.private.release.prepare.replace_version_next")
 def test_prepare_create_pr_when_none_associated(
-    mock_replace, mock_changelog, release_tool_env, mock_git, mock_gh
+    mocker, release_tool_env, mock_git, mock_gh
 ):
+    mocker.patch("tools.private.release.prepare.replace_version_next")
+    mocker.patch("tools.private.release.prepare.changelog_news")
+
     # Arrange
     args = argparse.Namespace(version="2.0.0", issue=None, dry_run=False)
     mock_gh.create_issue(
@@ -159,11 +156,10 @@ def test_prepare_create_pr_when_none_associated(
     assert "pr=#1002" in updated_body
 
 
-@patch("tools.private.release.prepare.changelog_news")
-@patch("tools.private.release.prepare.replace_version_next")
-def test_prepare_reuse_existing_pr(
-    mock_replace, mock_changelog, release_tool_env, mock_git, mock_gh
-):
+def test_prepare_reuse_existing_pr(mocker, release_tool_env, mock_git, mock_gh):
+    mocker.patch("tools.private.release.prepare.replace_version_next")
+    mocker.patch("tools.private.release.prepare.changelog_news")
+
     # Arrange
     args = argparse.Namespace(version="2.0.0", issue=None, dry_run=False)
     mock_gh.create_issue(
@@ -194,11 +190,10 @@ def test_prepare_reuse_existing_pr(
     assert "pr=#456" in updated_body
 
 
-@patch("tools.private.release.prepare.changelog_news")
-@patch("tools.private.release.prepare.replace_version_next")
-def test_prepare_dry_run_no_issue(
-    mock_replace, mock_changelog, release_tool_env, mock_git, mock_gh
-):
+def test_prepare_dry_run_no_issue(mocker, release_tool_env, mock_git, mock_gh):
+    mocker.patch("tools.private.release.prepare.replace_version_next")
+    mocker.patch("tools.private.release.prepare.changelog_news")
+
     # Arrange
     args = argparse.Namespace(version="2.0.0", issue=None, dry_run=True)
     mock_git.status.side_effect = [""]

--- a/tests/tools/private/release/process_backports_test.py
+++ b/tests/tools/private/release/process_backports_test.py
@@ -1,6 +1,6 @@
 import argparse
 import datetime
-from unittest.mock import ANY, call, patch
+from unittest.mock import ANY, call
 
 from tools.private.release.process_backports import ProcessBackports
 
@@ -23,13 +23,16 @@ def test_process_backports_no_pending(mock_git, mock_gh):
     mock_git.fetch.assert_not_called()
 
 
-@patch("tools.private.release.process_backports.changelog_news")
-@patch("tools.private.release.process_backports.replace_version_next")
-@patch("tools.private.release.process_backports.datetime")
-def test_process_backports_success(
-    mock_datetime, mock_replace, mock_changelog, mock_git, mock_gh
-):
+def test_process_backports_success(mocker, mock_git, mock_gh):
+    mock_changelog = mocker.patch(
+        "tools.private.release.process_backports.changelog_news"
+    )
+    mock_replace = mocker.patch(
+        "tools.private.release.process_backports.replace_version_next"
+    )
+    mock_datetime = mocker.patch("tools.private.release.process_backports.datetime")
     mock_datetime.date.today.return_value = datetime.date(2026, 7, 1)
+
     args = argparse.Namespace(
         issue=123, remote="origin", dry_run=False, add=None, triggering_comment=None
     )
@@ -106,13 +109,12 @@ def test_process_backports_success(
     assert "- [ ] Sync Changelog #124 | status=pending pr=#1001" in updated_body
 
 
-@patch("tools.private.release.process_backports.changelog_news")
-@patch("tools.private.release.process_backports.replace_version_next")
-@patch("tools.private.release.process_backports.datetime")
-def test_process_backports_sync_branch_exists(
-    mock_datetime, mock_replace, mock_changelog, mock_git, mock_gh
-):
+def test_process_backports_sync_branch_exists(mocker, mock_git, mock_gh):
+    mocker.patch("tools.private.release.process_backports.changelog_news")
+    mocker.patch("tools.private.release.process_backports.replace_version_next")
+    mock_datetime = mocker.patch("tools.private.release.process_backports.datetime")
     mock_datetime.date.today.return_value = datetime.date(2026, 7, 1)
+
     args = argparse.Namespace(
         issue=123, remote="origin", dry_run=False, add=None, triggering_comment=None
     )
@@ -157,13 +159,12 @@ def test_process_backports_sync_branch_exists(
     mock_git.reset_hard.assert_has_calls([call(reset_to="main")])
 
 
-@patch("tools.private.release.process_backports.changelog_news")
-@patch("tools.private.release.process_backports.replace_version_next")
-@patch("tools.private.release.process_backports.datetime")
-def test_process_backports_dry_run(
-    mock_datetime, mock_replace, mock_changelog, mock_git, mock_gh
-):
+def test_process_backports_dry_run(mocker, mock_git, mock_gh):
+    mocker.patch("tools.private.release.process_backports.changelog_news")
+    mocker.patch("tools.private.release.process_backports.replace_version_next")
+    mock_datetime = mocker.patch("tools.private.release.process_backports.datetime")
     mock_datetime.date.today.return_value = datetime.date(2026, 7, 1)
+
     args = argparse.Namespace(
         issue=123, remote="origin", dry_run=True, add=None, triggering_comment=None
     )
@@ -258,8 +259,8 @@ def test_process_backports_ignored_error_status(mock_git, mock_gh):
     mock_git.checkout.assert_not_called()
 
 
-@patch("tools.private.release.process_backports.datetime")
-def test_process_backports_cherry_pick_failed(mock_datetime, mock_git, mock_gh):
+def test_process_backports_cherry_pick_failed(mocker, mock_git, mock_gh):
+    mock_datetime = mocker.patch("tools.private.release.process_backports.datetime")
     mock_datetime.date.today.return_value = datetime.date(2026, 7, 1)
     args = argparse.Namespace(
         issue=123, remote="origin", dry_run=False, add=None, triggering_comment=None
@@ -297,12 +298,12 @@ def test_process_backports_cherry_pick_failed(mock_datetime, mock_git, mock_gh):
     mock_git.push.assert_not_called()
 
 
-@patch("tools.private.release.process_backports.changelog_news")
-@patch("tools.private.release.process_backports.replace_version_next")
-@patch("tools.private.release.process_backports.datetime")
 def test_process_backports_add_backports_and_auto_add_rc_task(
-    mock_datetime, mock_replace, mock_changelog, mock_git, mock_gh
+    mocker, mock_git, mock_gh
 ):
+    mocker.patch("tools.private.release.process_backports.changelog_news")
+    mocker.patch("tools.private.release.process_backports.replace_version_next")
+    mock_datetime = mocker.patch("tools.private.release.process_backports.datetime")
     mock_datetime.date.today.return_value = datetime.date(2026, 7, 1)
     args = argparse.Namespace(
         issue=123,
@@ -343,12 +344,10 @@ def test_process_backports_add_backports_and_auto_add_rc_task(
     assert "- [ ] Sync Changelog #124 | status=pending pr=#1001" in updated_body
 
 
-@patch("tools.private.release.process_backports.changelog_news")
-@patch("tools.private.release.process_backports.replace_version_next")
-@patch("tools.private.release.process_backports.datetime")
-def test_process_backports_add_backports_marks_invalid(
-    mock_datetime, mock_replace, mock_changelog, mock_git, mock_gh
-):
+def test_process_backports_add_backports_marks_invalid(mocker, mock_git, mock_gh):
+    mocker.patch("tools.private.release.process_backports.changelog_news")
+    mocker.patch("tools.private.release.process_backports.replace_version_next")
+    mock_datetime = mocker.patch("tools.private.release.process_backports.datetime")
     mock_datetime.date.today.return_value = datetime.date(2026, 7, 1)
     args = argparse.Namespace(
         issue=123,
@@ -394,12 +393,14 @@ def test_process_backports_add_backports_marks_invalid(
     assert "- [ ] Sync Changelog #125 | status=pending pr=#1001" in updated_body
 
 
-@patch("tools.private.release.process_backports.changelog_news")
-@patch("tools.private.release.process_backports.replace_version_next")
-@patch("tools.private.release.process_backports.datetime")
-def test_process_backports_version_sync_failure(
-    mock_datetime, mock_replace, mock_changelog, mock_git, mock_gh
-):
+def test_process_backports_version_sync_failure(mocker, mock_git, mock_gh):
+    mock_changelog = mocker.patch(
+        "tools.private.release.process_backports.changelog_news"
+    )
+    mock_replace = mocker.patch(
+        "tools.private.release.process_backports.replace_version_next"
+    )
+    mock_datetime = mocker.patch("tools.private.release.process_backports.datetime")
     mock_datetime.date.today.return_value = datetime.date(2026, 7, 1)
     args = argparse.Namespace(
         issue=123, remote="origin", dry_run=False, add=None, triggering_comment=None

--- a/tests/tools/private/release/process_backports_test.py
+++ b/tests/tools/private/release/process_backports_test.py
@@ -1,60 +1,41 @@
 import argparse
 import datetime
-import unittest
-from unittest.mock import call, patch
+from unittest.mock import ANY, call, patch
 
-from tests.tools.private.release.release_test_helper import _mock_git_and_gh
 from tools.private.release.process_backports import ProcessBackports
 
+pytest_plugins = ["tests.tools.private.release.release_test_helper"]
 
-class CmdProcessBackportsTest(unittest.TestCase):
-    def setUp(self):
-        _mock_git_and_gh(self)
-        self.mock_changelog_news = patch(
-            "tools.private.release.process_backports.changelog_news"
-        ).start()
-        self.mock_replace_version_next = patch(
-            "tools.private.release.process_backports.replace_version_next"
-        ).start()
-        self.addCleanup(patch.stopall)
-        self.mock_gh.resolve_pr_number.side_effect = lambda x: int(
-            x.lstrip("#").split("/")[-1]
-        )
-        self.mock_git.diff.return_value = ""
-        self.mock_git.apply_check.return_value = True
 
-        # Dynamic mock for issue body
-        self.issue_body = ""
+def test_process_backports_no_pending(mock_git, mock_gh):
+    args = argparse.Namespace(
+        issue=123, remote="origin", dry_run=False, add=None, triggering_comment=None
+    )
+    mock_gh.issues[123] = {
+        "title": "Release 2.0.0",
+        "body": "No backports here",
+        "labels": ["type: release"],
+    }
 
-        def mock_get_body(issue_num):
-            return self.issue_body
+    result = ProcessBackports(args, mock_git, mock_gh).run()
 
-        def mock_update_body(issue_num, body):
-            self.issue_body = body
+    assert result == 0
+    mock_git.fetch.assert_not_called()
 
-        self.mock_gh.get_issue_body.side_effect = mock_get_body
-        self.mock_gh.update_issue_body.side_effect = mock_update_body
 
-    def test_process_backports_no_pending(self):
-        args = argparse.Namespace(
-            issue=123, remote="origin", dry_run=False, add=None, triggering_comment=None
-        )
-        self.issue_body = "No backports here"
-
-        result = ProcessBackports(args, self.mock_git, self.mock_gh).run()
-
-        self.assertEqual(result, 0)
-        self.mock_gh.get_issue_body.assert_called_once_with(123)
-        self.mock_git.fetch.assert_not_called()
-
-    @patch("tools.private.release.process_backports.datetime")
-    def test_process_backports_success(self, mock_datetime):
-        mock_datetime.date.today.return_value = datetime.date(2026, 7, 1)
-        args = argparse.Namespace(
-            issue=123, remote="origin", dry_run=False, add=None, triggering_comment=None
-        )
-        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
-        self.issue_body = """
+@patch("tools.private.release.process_backports.changelog_news")
+@patch("tools.private.release.process_backports.replace_version_next")
+@patch("tools.private.release.process_backports.datetime")
+def test_process_backports_success(
+    mock_datetime, mock_replace, mock_changelog, mock_git, mock_gh
+):
+    mock_datetime.date.today.return_value = datetime.date(2026, 7, 1)
+    args = argparse.Namespace(
+        issue=123, remote="origin", dry_run=False, add=None, triggering_comment=None
+    )
+    mock_gh.issues[123] = {
+        "title": "Release 2.0.0",
+        "body": """
 ## Checklist
 - [ ] Prepare Release
 - [ ] Create Release branch
@@ -63,107 +44,81 @@ class CmdProcessBackportsTest(unittest.TestCase):
 
 ## Backports
 - [ ] #124 | status=pending
-"""
-        self.mock_git.get_remote_tags.return_value = []
+""",
+        "labels": ["type: release"],
+    }
+    mock_gh.prs[124] = {
+        "state": "MERGED",
+        "mergeCommit": {"oid": "abcdef12"},
+    }
+    mock_git.get_remote_tags.return_value = []
+    mock_git.sort_commits_chronologically.return_value = ["abcdef12"]
+    mock_git.get_commit_sha.side_effect = ["12345678", "12345678", "main_sha"]
+    mock_git.get_commit_message.return_value = 'Cherry-pick "fix bug"'
+    mock_git.get_modified_files.return_value = ["news/124.fixed.md"]
+    mock_git.diff.return_value = "version diff for 124"
+    mock_git.apply_check.return_value = True
 
-        def mock_resolve(items):
-            for item in items:
-                if item.pr_ref == "#124":
-                    item.commit = "abcdef12"
-                    item.status = "done"
-            return items
+    result = ProcessBackports(args, mock_git, mock_gh).run()
 
-        self.mock_gh.get_merge_commits_for_prs.side_effect = mock_resolve
+    assert result == 0
+    mock_git.fetch.assert_has_calls(
+        [
+            call("origin", tags=True, force=True),
+            call("origin"),
+            call("origin", refspec="main"),
+        ]
+    )
+    mock_git.checkout.assert_has_calls(
+        [
+            call("release/2.0", track_remote="origin"),
+            call("main", track_remote="origin"),
+            call("prepare-2.0.0-backports-6affdae", create_branch=True),
+            call("release/2.0"),
+        ]
+    )
+    mock_git.cherry_pick.assert_called_once_with("abcdef12")
+    mock_git.diff.assert_called_once()
+    mock_git.apply_check.assert_called_once_with(ANY)
+    mock_git.apply.assert_called_once_with(ANY)
+    mock_changelog.update_changelog.assert_has_calls(
+        [
+            call("2.0.0", "2026-07-01"),
+            call(
+                "2.0.0",
+                "2026-07-01",
+                news_files=["news/124.fixed.md"],
+                delete_news=True,
+            ),
+        ]
+    )
+    assert mock_git.add_modified_and_deleted.call_count == 2
+    mock_replace.assert_called_once_with("2.0.0")
+    mock_git.commit.assert_has_calls(
+        [
+            call('Cherry-pick "fix bug"\n\nWork towards #123', amend=True),
+            call("chore(release): sync changelog for v2.0.0 backports"),
+        ]
+    )
 
-        self.mock_git.sort_commits_chronologically.return_value = ["abcdef12"]
-        self.mock_git.get_commit_sha.side_effect = ["12345678", "12345678", "main_sha"]
-        self.mock_git.get_commit_message.return_value = 'Cherry-pick "fix bug"'
-        self.mock_git.get_modified_files.return_value = ["news/124.fixed.md"]
-        self.mock_git.diff.return_value = "version diff for 124"
-        self.mock_git.apply_check.return_value = True
-        self.mock_gh.create_pr.return_value = "https://github.com/foo/bar/pull/999"
+    updated_body = mock_gh.get_issue_body(123)
+    assert "- [x] #124 | status=done rc=rc0 commit= 12345678" in updated_body
+    assert "- [ ] Sync Changelog #124 | status=pending pr=#1001" in updated_body
 
-        result = ProcessBackports(args, self.mock_git, self.mock_gh).run()
 
-        self.assertEqual(result, 0)
-        self.mock_git.fetch.assert_has_calls(
-            [
-                call("origin", tags=True, force=True),
-                call("origin"),
-                call("origin", refspec="main"),
-            ]
-        )
-        self.mock_git.checkout.assert_has_calls(
-            [
-                call("release/2.0", track_remote="origin"),
-                call("main", track_remote="origin"),
-                call("prepare-2.0.0-backports-6affdae", create_branch=True),
-                call("release/2.0"),
-            ]
-        )
-        self.mock_git.cherry_pick.assert_called_once_with("abcdef12")
-        self.mock_git.diff.assert_called_once()
-        self.mock_git.apply_check.assert_called_once_with(unittest.mock.ANY)
-        self.mock_git.apply.assert_called_once_with(unittest.mock.ANY)
-        self.mock_changelog_news.update_changelog.assert_has_calls(
-            [
-                call("2.0.0", "2026-07-01"),
-                call(
-                    "2.0.0",
-                    "2026-07-01",
-                    news_files=["news/124.fixed.md"],
-                    delete_news=True,
-                ),
-            ]
-        )
-        self.assertEqual(self.mock_git.add_modified_and_deleted.call_count, 2)
-        self.mock_replace_version_next.assert_called_once_with("2.0.0")
-        self.mock_git.commit.assert_has_calls(
-            [
-                call('Cherry-pick "fix bug"\n\nWork towards #123', amend=True),
-                call("chore(release): sync changelog for v2.0.0 backports"),
-            ]
-        )
-        self.mock_git.push.assert_has_calls(
-            [
-                call("origin", "release/2.0"),
-                call(
-                    "origin",
-                    "prepare-2.0.0-backports-6affdae",
-                    set_upstream=True,
-                    force=True,
-                ),
-            ]
-        )
-
-        self.mock_gh.create_pr.assert_called_once_with(
-            title="chore(release): sync changelog for v2.0.0 backports",
-            body="Updates CHANGELOG.md and removes news files for backports:\n- #124\n\nWork towards #123\nRelease-Tracking-Issue: #123",
-            base="main",
-            labels=["type: sync-changelog"],
-        )
-        self.mock_gh.enable_auto_merge.assert_called_once_with(999)
-
-        self.assertEqual(self.mock_gh.update_issue_body.call_count, 2)
-        call_args_list = self.mock_gh.update_issue_body.call_args_list
-        self.assertEqual(call_args_list[0][0][0], 123)
-        self.assertIn(
-            "- [x] #124 | status=done rc=rc0 commit= 12345678", call_args_list[0][0][1]
-        )
-        self.assertEqual(call_args_list[1][0][0], 123)
-        self.assertIn(
-            "- [ ] Sync Changelog #124 | status=pending pr=#999",
-            call_args_list[1][0][1],
-        )
-
-    @patch("tools.private.release.process_backports.datetime")
-    def test_process_backports_sync_branch_exists(self, mock_datetime):
-        mock_datetime.date.today.return_value = datetime.date(2026, 7, 1)
-        args = argparse.Namespace(
-            issue=123, remote="origin", dry_run=False, add=None, triggering_comment=None
-        )
-        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
-        self.issue_body = """
+@patch("tools.private.release.process_backports.changelog_news")
+@patch("tools.private.release.process_backports.replace_version_next")
+@patch("tools.private.release.process_backports.datetime")
+def test_process_backports_sync_branch_exists(
+    mock_datetime, mock_replace, mock_changelog, mock_git, mock_gh
+):
+    mock_datetime.date.today.return_value = datetime.date(2026, 7, 1)
+    args = argparse.Namespace(
+        issue=123, remote="origin", dry_run=False, add=None, triggering_comment=None
+    )
+    mock_gh.issues[123] = {
+        "title": "Release 2.0.0",
+        "body": """
 ## Checklist
 - [ ] Prepare Release
 - [ ] Create Release branch
@@ -172,117 +127,49 @@ class CmdProcessBackportsTest(unittest.TestCase):
 
 ## Backports
 - [ ] #124 | status=pending
-"""
-        self.mock_git.get_remote_tags.return_value = []
+""",
+        "labels": ["type: release"],
+    }
+    mock_gh.prs[124] = {
+        "state": "MERGED",
+        "mergeCommit": {"oid": "abcdef12"},
+    }
+    mock_git.get_remote_tags.return_value = []
+    mock_git.sort_commits_chronologically.return_value = ["abcdef12"]
+    mock_git.get_commit_sha.side_effect = ["12345678", "12345678", "main_sha"]
+    mock_git.get_commit_message.return_value = 'Cherry-pick "fix bug"'
+    mock_git.get_modified_files.return_value = ["news/124.fixed.md"]
+    mock_git.diff.return_value = "version diff for 124"
+    mock_git.apply_check.return_value = True
+    mock_git.branch_exists.return_value = True
 
-        def mock_resolve(items):
-            for item in items:
-                if item.pr_ref == "#124":
-                    item.commit = "abcdef12"
-                    item.status = "done"
-            return items
+    result = ProcessBackports(args, mock_git, mock_gh).run()
 
-        self.mock_gh.get_merge_commits_for_prs.side_effect = mock_resolve
+    assert result == 0
+    mock_git.checkout.assert_has_calls(
+        [
+            call("release/2.0", track_remote="origin"),
+            call("main", track_remote="origin"),
+            call("prepare-2.0.0-backports-6affdae"),
+            call("release/2.0"),
+        ]
+    )
+    mock_git.reset_hard.assert_has_calls([call(reset_to="main")])
 
-        self.mock_git.sort_commits_chronologically.return_value = ["abcdef12"]
-        self.mock_git.get_commit_sha.side_effect = ["12345678", "12345678", "main_sha"]
-        self.mock_git.get_commit_message.return_value = 'Cherry-pick "fix bug"'
-        self.mock_git.get_modified_files.return_value = ["news/124.fixed.md"]
-        self.mock_git.diff.return_value = "version diff for 124"
-        self.mock_git.apply_check.return_value = True
-        self.mock_gh.create_pr.return_value = "https://github.com/foo/bar/pull/999"
 
-        # Configure branch to exist
-        self.mock_git.branch_exists.return_value = True
-
-        result = ProcessBackports(args, self.mock_git, self.mock_gh).run()
-
-        self.assertEqual(result, 0)
-        self.mock_git.fetch.assert_has_calls(
-            [
-                call("origin", tags=True, force=True),
-                call("origin"),
-                call("origin", refspec="main"),
-            ]
-        )
-        self.mock_git.checkout.assert_has_calls(
-            [
-                call("release/2.0", track_remote="origin"),
-                call("main", track_remote="origin"),
-                # Called without create_branch=True
-                call("prepare-2.0.0-backports-6affdae"),
-                call("release/2.0"),
-            ]
-        )
-        # Verify reset_hard was called to reset the existing branch to main
-        self.mock_git.reset_hard.assert_has_calls(
-            [
-                call(reset_to="main"),
-            ]
-        )
-        self.mock_git.cherry_pick.assert_called_once_with("abcdef12")
-        self.mock_git.diff.assert_called_once()
-        self.mock_git.apply_check.assert_called_once_with(unittest.mock.ANY)
-        self.mock_git.apply.assert_called_once_with(unittest.mock.ANY)
-        self.mock_changelog_news.update_changelog.assert_has_calls(
-            [
-                call("2.0.0", "2026-07-01"),
-                call(
-                    "2.0.0",
-                    "2026-07-01",
-                    news_files=["news/124.fixed.md"],
-                    delete_news=True,
-                ),
-            ]
-        )
-        self.assertEqual(self.mock_git.add_modified_and_deleted.call_count, 2)
-        self.mock_replace_version_next.assert_called_once_with("2.0.0")
-        self.mock_git.commit.assert_has_calls(
-            [
-                call('Cherry-pick "fix bug"\n\nWork towards #123', amend=True),
-                call("chore(release): sync changelog for v2.0.0 backports"),
-            ]
-        )
-        self.mock_git.push.assert_has_calls(
-            [
-                call("origin", "release/2.0"),
-                call(
-                    "origin",
-                    "prepare-2.0.0-backports-6affdae",
-                    set_upstream=True,
-                    force=True,
-                ),
-            ]
-        )
-
-        self.mock_gh.create_pr.assert_called_once_with(
-            title="chore(release): sync changelog for v2.0.0 backports",
-            body="Updates CHANGELOG.md and removes news files for backports:\n- #124\n\nWork towards #123\nRelease-Tracking-Issue: #123",
-            base="main",
-            labels=["type: sync-changelog"],
-        )
-        self.mock_gh.enable_auto_merge.assert_called_once_with(999)
-
-        self.assertEqual(self.mock_gh.update_issue_body.call_count, 2)
-        call_args_list = self.mock_gh.update_issue_body.call_args_list
-        self.assertEqual(call_args_list[0][0][0], 123)
-        self.assertIn(
-            "- [x] #124 | status=done rc=rc0 commit= 12345678", call_args_list[0][0][1]
-        )
-        self.assertEqual(call_args_list[1][0][0], 123)
-        self.assertIn(
-            "- [ ] Sync Changelog #124 | status=pending pr=#999",
-            call_args_list[1][0][1],
-        )
-
-    @patch("tools.private.release.process_backports.datetime")
-    def test_process_backports_dry_run(self, mock_datetime):
-        mock_datetime.date.today.return_value = datetime.date(2026, 7, 1)
-        args = argparse.Namespace(
-            issue=123, remote="origin", dry_run=True, add=None, triggering_comment=None
-        )
-        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
-        self.issue_body = """
+@patch("tools.private.release.process_backports.changelog_news")
+@patch("tools.private.release.process_backports.replace_version_next")
+@patch("tools.private.release.process_backports.datetime")
+def test_process_backports_dry_run(
+    mock_datetime, mock_replace, mock_changelog, mock_git, mock_gh
+):
+    mock_datetime.date.today.return_value = datetime.date(2026, 7, 1)
+    args = argparse.Namespace(
+        issue=123, remote="origin", dry_run=True, add=None, triggering_comment=None
+    )
+    mock_gh.issues[123] = {
+        "title": "Release 2.0.0",
+        "body": """
 ## Checklist
 - [ ] Prepare Release
 - [ ] Create Release branch
@@ -291,77 +178,35 @@ class CmdProcessBackportsTest(unittest.TestCase):
 
 ## Backports
 - [ ] #124 | status=pending
-"""
-        self.mock_git.get_remote_tags.return_value = []
+""",
+        "labels": ["type: release"],
+    }
+    mock_gh.prs[124] = {
+        "state": "MERGED",
+        "mergeCommit": {"oid": "abcdef12"},
+    }
+    mock_git.get_remote_tags.return_value = []
+    mock_git.sort_commits_chronologically.return_value = ["abcdef12"]
+    mock_git.get_commit_sha.side_effect = ["12345678", "main_sha"]
+    mock_git.get_commit_message.return_value = 'Cherry-pick "fix bug"'
+    mock_git.get_modified_files.return_value = ["news/124.fixed.md"]
+    mock_git.diff.return_value = "version diff for 124"
+    mock_git.apply_check.return_value = True
 
-        def mock_resolve(items):
-            for item in items:
-                if item.pr_ref == "#124":
-                    item.commit = "abcdef12"
-                    item.status = "done"
-            return items
+    result = ProcessBackports(args, mock_git, mock_gh).run()
 
-        self.mock_gh.get_merge_commits_for_prs.side_effect = mock_resolve
+    assert result == 0
+    mock_git.apply.assert_not_called()
+    mock_git.push.assert_not_called()
 
-        self.mock_git.sort_commits_chronologically.return_value = ["abcdef12"]
-        self.mock_git.get_commit_sha.side_effect = ["12345678", "main_sha"]
-        self.mock_git.get_commit_message.return_value = 'Cherry-pick "fix bug"'
-        self.mock_git.get_modified_files.return_value = ["news/124.fixed.md"]
-        self.mock_git.diff.return_value = "version diff for 124"
-        self.mock_git.apply_check.return_value = True
 
-        result = ProcessBackports(args, self.mock_git, self.mock_gh).run()
-
-        self.assertEqual(result, 0)
-        self.mock_git.fetch.assert_has_calls(
-            [
-                call("origin", tags=True, force=True),
-                call("origin"),
-                call("origin", refspec="main"),
-            ]
-        )
-        self.mock_git.checkout.assert_has_calls(
-            [
-                call("release/2.0", track_remote="origin"),
-                call("main", track_remote="origin"),
-                call("release/2.0"),
-            ]
-        )
-        self.mock_git.cherry_pick.assert_called_once_with("abcdef12")
-        self.mock_git.diff.assert_called_once()
-        self.mock_git.apply_check.assert_called_once_with(unittest.mock.ANY)
-        self.mock_git.apply.assert_not_called()
-        self.mock_changelog_news.update_changelog.assert_has_calls(
-            [
-                call("2.0.0", "2026-07-01"),
-                call(
-                    "2.0.0",
-                    "2026-07-01",
-                    news_files=["news/124.fixed.md"],
-                    delete_news=True,
-                ),
-            ]
-        )
-        self.assertEqual(self.mock_git.add_modified_and_deleted.call_count, 1)
-        self.mock_replace_version_next.assert_called_once_with("2.0.0")
-        self.mock_git.commit.assert_called_once_with(
-            'Cherry-pick "fix bug"\n\nWork towards #123', amend=True
-        )
-        self.mock_git.reset_hard.assert_has_calls(
-            [
-                call(reset_to="12345678"),
-                call(reset_to="main_sha"),
-            ]
-        )
-        self.mock_git.push.assert_not_called()
-        self.mock_gh.update_issue_body.assert_not_called()
-
-    def test_process_backports_ignored_and_failed_states(self):
-        args = argparse.Namespace(
-            issue=123, remote="origin", dry_run=False, add=None, triggering_comment=None
-        )
-        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
-        self.issue_body = """
+def test_process_backports_ignored_and_failed_states(mock_git, mock_gh):
+    args = argparse.Namespace(
+        issue=123, remote="origin", dry_run=False, add=None, triggering_comment=None
+    )
+    mock_gh.issues[123] = {
+        "title": "Release 2.0.0",
+        "body": """
 ## Checklist
 - [ ] Prepare Release
 - [ ] Create Release branch
@@ -370,39 +215,31 @@ class CmdProcessBackportsTest(unittest.TestCase):
 - [ ] #124 | status=pending
 - [ ] #125 | status=pending
 - [ ] #126 | status=pending
-"""
-        self.mock_git.get_remote_tags.return_value = []
+""",
+        "labels": ["type: release"],
+    }
+    mock_git.get_remote_tags.return_value = []
 
-        def mock_resolve(items):
-            for item in items:
-                if item.pr_ref == "#124":
-                    item.status = "open-pr"
-                elif item.pr_ref == "#125":
-                    item.status = "draft-pr"
-                elif item.pr_ref == "#126":
-                    item.status = "error-closed-pr"
-            return items
+    mock_gh.prs[124] = {"state": "OPEN"}
+    mock_gh.prs[125] = {"state": "OPEN", "isDraft": True}
+    mock_gh.prs[126] = {"state": "CLOSED"}
 
-        self.mock_gh.get_merge_commits_for_prs.side_effect = mock_resolve
+    result = ProcessBackports(args, mock_git, mock_gh).run()
 
-        result = ProcessBackports(args, self.mock_git, self.mock_gh).run()
+    assert result == 1
+    updated_body = mock_gh.get_issue_body(123)
+    assert "- [ ] #126 | status=error-closed-pr" in updated_body
+    mock_git.checkout.assert_not_called()
+    mock_git.cherry_pick.assert_not_called()
 
-        self.assertEqual(result, 1)
-        self.mock_gh.update_issue_body.assert_called_once()
-        call_args = self.mock_gh.update_issue_body.call_args[0]
-        self.assertEqual(call_args[0], 123)
-        self.assertIn("- [ ] #126 | status=error-closed-pr", call_args[1])
-        self.assertNotIn("status=open-pr", call_args[1])
-        self.assertNotIn("status=draft-pr", call_args[1])
-        self.mock_git.checkout.assert_not_called()
-        self.mock_git.cherry_pick.assert_not_called()
 
-    def test_process_backports_ignored_error_status(self):
-        args = argparse.Namespace(
-            issue=123, remote="origin", dry_run=False, add=None, triggering_comment=None
-        )
-        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
-        self.issue_body = """
+def test_process_backports_ignored_error_status(mock_git, mock_gh):
+    args = argparse.Namespace(
+        issue=123, remote="origin", dry_run=False, add=None, triggering_comment=None
+    )
+    mock_gh.issues[123] = {
+        "title": "Release 2.0.0",
+        "body": """
 ## Checklist
 - [ ] Prepare Release
 - [ ] Create Release branch
@@ -410,74 +247,73 @@ class CmdProcessBackportsTest(unittest.TestCase):
 ## Backports
 - [ ] #124 | status=error-merge-conflict
 - [ ] #125 | status=error-some-other-error
-"""
-        self.mock_git.get_remote_tags.return_value = []
-        self.mock_gh.get_merge_commits_for_prs.return_value = []
+""",
+        "labels": ["type: release"],
+    }
+    mock_git.get_remote_tags.return_value = []
 
-        result = ProcessBackports(args, self.mock_git, self.mock_gh).run()
+    result = ProcessBackports(args, mock_git, mock_gh).run()
 
-        self.assertEqual(result, 0)
-        self.mock_gh.get_merge_commits_for_prs.assert_not_called()
-        self.mock_git.checkout.assert_not_called()
+    assert result == 0
+    mock_git.checkout.assert_not_called()
 
-    @patch("tools.private.release.process_backports.datetime")
-    def test_process_backports_cherry_pick_failed(self, mock_datetime):
-        mock_datetime.date.today.return_value = datetime.date(2026, 7, 1)
-        args = argparse.Namespace(
-            issue=123, remote="origin", dry_run=False, add=None, triggering_comment=None
-        )
-        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
-        self.issue_body = """
+
+@patch("tools.private.release.process_backports.datetime")
+def test_process_backports_cherry_pick_failed(mock_datetime, mock_git, mock_gh):
+    mock_datetime.date.today.return_value = datetime.date(2026, 7, 1)
+    args = argparse.Namespace(
+        issue=123, remote="origin", dry_run=False, add=None, triggering_comment=None
+    )
+    mock_gh.issues[123] = {
+        "title": "Release 2.0.0",
+        "body": """
 ## Checklist
 - [ ] Prepare Release
 - [ ] Create Release branch
 
 ## Backports
 - [ ] #124 | status=pending
-"""
-        self.mock_git.get_remote_tags.return_value = []
+""",
+        "labels": ["type: release"],
+    }
+    mock_gh.prs[124] = {
+        "state": "MERGED",
+        "mergeCommit": {"oid": "abcdef12"},
+    }
+    mock_git.get_remote_tags.return_value = []
+    mock_git.sort_commits_chronologically.return_value = ["abcdef12"]
+    mock_git.cherry_pick.side_effect = Exception("Cherry-pick conflict")
 
-        def mock_resolve(items):
-            for item in items:
-                if item.pr_ref == "#124":
-                    item.commit = "abcdef12"
-                    item.status = "done"
-            return items
+    result = ProcessBackports(args, mock_git, mock_gh).run()
 
-        self.mock_gh.get_merge_commits_for_prs.side_effect = mock_resolve
+    assert result == 1
+    mock_git.checkout.assert_called_once_with("release/2.0", track_remote="origin")
+    mock_git.cherry_pick.assert_called_once_with("abcdef12")
+    mock_git.cherry_pick_abort.assert_called_once()
 
-        self.mock_git.sort_commits_chronologically.return_value = ["abcdef12"]
-        self.mock_git.cherry_pick.side_effect = Exception("Cherry-pick conflict")
+    updated_body = mock_gh.get_issue_body(123)
+    assert "- [ ] #124 | status=error-merge-conflict" in updated_body
+    mock_git.commit.assert_not_called()
+    mock_git.push.assert_not_called()
 
-        result = ProcessBackports(args, self.mock_git, self.mock_gh).run()
 
-        self.assertEqual(result, 1)
-        self.mock_git.checkout.assert_called_once_with(
-            "release/2.0", track_remote="origin"
-        )
-        self.mock_git.cherry_pick.assert_called_once_with("abcdef12")
-        self.mock_git.cherry_pick_abort.assert_called_once()
-
-        self.mock_gh.update_issue_body.assert_called_once()
-        call_args = self.mock_gh.update_issue_body.call_args[0]
-        self.assertEqual(call_args[0], 123)
-        self.assertIn("- [ ] #124 | status=error-merge-conflict", call_args[1])
-
-        self.mock_git.commit.assert_not_called()
-        self.mock_git.push.assert_not_called()
-
-    @patch("tools.private.release.process_backports.datetime")
-    def test_process_backports_add_backports_and_auto_add_rc_task(self, mock_datetime):
-        mock_datetime.date.today.return_value = datetime.date(2026, 7, 1)
-        args = argparse.Namespace(
-            issue=123,
-            remote="origin",
-            dry_run=False,
-            add=["https://github.com/bazel-contrib/rules_python/pull/124"],
-            triggering_comment=None,
-        )
-        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
-        self.issue_body = """
+@patch("tools.private.release.process_backports.changelog_news")
+@patch("tools.private.release.process_backports.replace_version_next")
+@patch("tools.private.release.process_backports.datetime")
+def test_process_backports_add_backports_and_auto_add_rc_task(
+    mock_datetime, mock_replace, mock_changelog, mock_git, mock_gh
+):
+    mock_datetime.date.today.return_value = datetime.date(2026, 7, 1)
+    args = argparse.Namespace(
+        issue=123,
+        remote="origin",
+        dry_run=False,
+        add=["https://github.com/bazel-contrib/rules_python/pull/124"],
+        triggering_comment=None,
+    )
+    mock_gh.issues[123] = {
+        "title": "Release 2.0.0",
+        "body": """
 ## Checklist
 - [x] Prepare Release | status=done pr=#122 commit=abcdef12
 - [x] Create Release branch | status=done branch=release/2.0 commit=abcdef12
@@ -485,68 +321,45 @@ class CmdProcessBackportsTest(unittest.TestCase):
 - [ ] Tag Final
 
 ## Backports
-"""
-        self.mock_git.get_remote_tags.return_value = ["2.0.0-rc0"]
-        self.mock_git.get_commit_sha.return_value = "12345678"
-        self.mock_git.get_commit_message.return_value = 'Cherry-pick "fix bug"'
+""",
+        "labels": ["type: release"],
+    }
+    mock_gh.prs[124] = {
+        "state": "MERGED",
+        "mergeCommit": {"oid": "abcdef12"},
+    }
+    mock_git.get_remote_tags.return_value = ["2.0.0-rc0"]
+    mock_git.get_commit_sha.return_value = "12345678"
+    mock_git.get_commit_message.return_value = 'Cherry-pick "fix bug"'
+    mock_git.sort_commits_chronologically.return_value = ["abcdef12"]
+    mock_git.diff.return_value = "version diff"
+    mock_git.apply_check.return_value = True
 
-        def mock_resolve(items):
-            for item in items:
-                if item.pr_ref == "#124":
-                    item.commit = "abcdef12"
-                    item.status = "done"
-            return items
+    result = ProcessBackports(args, mock_git, mock_gh).run()
 
-        self.mock_gh.get_merge_commits_for_prs.side_effect = mock_resolve
-        self.mock_git.sort_commits_chronologically.return_value = ["abcdef12"]
+    assert result == 0
+    updated_body = mock_gh.get_issue_body(123)
+    assert "- [x] #124 | status=done rc=rc1 commit= 12345678" in updated_body
+    assert "- [ ] Sync Changelog #124 | status=pending pr=#1001" in updated_body
 
-        # Mock create_pr to return a string to avoid int(MagicMock) returning 1
-        self.mock_gh.create_pr.return_value = "https://github.com/foo/bar/pull/999"
 
-        result = ProcessBackports(args, self.mock_git, self.mock_gh).run()
-
-        self.assertEqual(result, 0)
-
-        # update_issue_body should be called 3 times:
-        # 1. When adding backports and auto-adding Tag RC1 task.
-        # 2. When updating the backport status to done.
-        # 3. When updating the sync task status to pending.
-        self.assertEqual(self.mock_gh.update_issue_body.call_count, 3)
-
-        call1_args = self.mock_gh.update_issue_body.call_args_list[0][0]
-        call2_args = self.mock_gh.update_issue_body.call_args_list[1][0]
-
-        self.assertEqual(call1_args[0], 123)
-        self.assertIn("- [ ] #124", call1_args[1])
-        self.assertIn("- [ ] Tag RC1", call1_args[1])
-        self.assertIn("- [ ] Sync Changelog #124", call1_args[1])
-        self.assertIn(
-            "- [x] Tag RC0 | status=done tag=2.0.0-rc0 commit=abcdef12\n- [ ]"
-            " Tag RC1\n- [ ] Sync Changelog #124\n- [ ] Tag Final",
-            call1_args[1].strip(),
-        )
-
-        self.assertEqual(call2_args[0], 123)
-        self.assertIn("- [x] #124 | status=done rc=rc1 commit= 12345678", call2_args[1])
-
-        call3_args = self.mock_gh.update_issue_body.call_args_list[2][0]
-        self.assertEqual(call3_args[0], 123)
-        self.assertIn(
-            "- [ ] Sync Changelog #124 | status=pending pr=#999", call3_args[1]
-        )
-
-    @patch("tools.private.release.process_backports.datetime")
-    def test_process_backports_add_backports_marks_invalid(self, mock_datetime):
-        mock_datetime.date.today.return_value = datetime.date(2026, 7, 1)
-        args = argparse.Namespace(
-            issue=123,
-            remote="origin",
-            dry_run=False,
-            add=["124", "invalid", "125"],
-            triggering_comment=None,
-        )
-        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
-        self.issue_body = """
+@patch("tools.private.release.process_backports.changelog_news")
+@patch("tools.private.release.process_backports.replace_version_next")
+@patch("tools.private.release.process_backports.datetime")
+def test_process_backports_add_backports_marks_invalid(
+    mock_datetime, mock_replace, mock_changelog, mock_git, mock_gh
+):
+    mock_datetime.date.today.return_value = datetime.date(2026, 7, 1)
+    args = argparse.Namespace(
+        issue=123,
+        remote="origin",
+        dry_run=False,
+        add=["124", "invalid", "125"],
+        triggering_comment=None,
+    )
+    mock_gh.issues[123] = {
+        "title": "Release 2.0.0",
+        "body": """
 ## Checklist
 - [x] Prepare Release | status=done pr=#122 commit=abcdef12
 - [x] Create Release branch | status=done branch=release/2.0 commit=abcdef12
@@ -554,59 +367,46 @@ class CmdProcessBackportsTest(unittest.TestCase):
 - [ ] Tag Final
 
 ## Backports
-"""
-        self.mock_git.get_remote_tags.return_value = ["2.0.0-rc0"]
-        self.mock_git.get_commit_sha.return_value = "1234567890"
-        self.mock_git.get_commit_message.return_value = 'Cherry-pick "fix bug"'
+""",
+        "labels": ["type: release"],
+    }
+    mock_gh.prs[124] = {
+        "state": "MERGED",
+        "mergeCommit": {"oid": "sha_124"},
+    }
+    mock_gh.prs[125] = {
+        "state": "MERGED",
+        "mergeCommit": {"oid": "sha_125"},
+    }
+    mock_git.get_remote_tags.return_value = ["2.0.0-rc0"]
+    mock_git.get_commit_sha.return_value = "1234567890"
+    mock_git.get_commit_message.return_value = 'Cherry-pick "fix bug"'
+    mock_git.sort_commits_chronologically.return_value = ["sha_124", "sha_125"]
+    mock_git.diff.return_value = "version diff"
+    mock_git.apply_check.return_value = True
 
-        def mock_resolve(items):
-            # Both 124 and 125 should be processed, 'invalid' should be ignored (it has error status)
-            for item in items:
-                if item.pr_ref == "#124":
-                    item.commit = "sha_124"
-                    item.status = "done"
-                elif item.pr_ref == "#125":
-                    item.commit = "sha_125"
-                    item.status = "done"
-            return items
+    result = ProcessBackports(args, mock_git, mock_gh).run()
 
-        self.mock_gh.get_merge_commits_for_prs.side_effect = mock_resolve
-        self.mock_git.sort_commits_chronologically.return_value = ["sha_124", "sha_125"]
-        self.mock_gh.create_pr.return_value = "https://github.com/foo/bar/pull/999"
+    assert result == 0
+    updated_body = mock_gh.get_issue_body(123)
+    assert "- [ ] invalid | status=error-invalid-pr" in updated_body
+    assert "- [ ] Sync Changelog #124 | status=pending pr=#1001" in updated_body
+    assert "- [ ] Sync Changelog #125 | status=pending pr=#1001" in updated_body
 
-        result = ProcessBackports(args, self.mock_git, self.mock_gh).run()
 
-        self.assertEqual(result, 0)
-        # Should have updated body to add 124, 125, and invalid
-        # update_issue_body should be called 4 times:
-        # 1. When adding backports.
-        # 2. When updating 124 status to done.
-        # 3. When updating 125 status to done.
-        # 4. When updating sync tasks status to pending.
-        self.assertEqual(self.mock_gh.update_issue_body.call_count, 4)
-        call1_args = self.mock_gh.update_issue_body.call_args_list[0][0]
-        self.assertIn("- [ ] #124", call1_args[1])
-        self.assertIn("- [ ] #125", call1_args[1])
-        self.assertIn("- [ ] invalid | status=error-invalid-pr", call1_args[1])
-        self.assertIn("- [ ] Sync Changelog #124", call1_args[1])
-        self.assertIn("- [ ] Sync Changelog #125", call1_args[1])
-
-        call4_args = self.mock_gh.update_issue_body.call_args_list[3][0]
-        self.assertIn(
-            "- [ ] Sync Changelog #124 | status=pending pr=#999", call4_args[1]
-        )
-        self.assertIn(
-            "- [ ] Sync Changelog #125 | status=pending pr=#999", call4_args[1]
-        )
-
-    @patch("tools.private.release.process_backports.datetime")
-    def test_process_backports_version_sync_failure(self, mock_datetime):
-        mock_datetime.date.today.return_value = datetime.date(2026, 7, 1)
-        args = argparse.Namespace(
-            issue=123, remote="origin", dry_run=False, add=None, triggering_comment=None
-        )
-        self.mock_gh.get_issue_title.return_value = "Release 2.0.0"
-        self.issue_body = """
+@patch("tools.private.release.process_backports.changelog_news")
+@patch("tools.private.release.process_backports.replace_version_next")
+@patch("tools.private.release.process_backports.datetime")
+def test_process_backports_version_sync_failure(
+    mock_datetime, mock_replace, mock_changelog, mock_git, mock_gh
+):
+    mock_datetime.date.today.return_value = datetime.date(2026, 7, 1)
+    args = argparse.Namespace(
+        issue=123, remote="origin", dry_run=False, add=None, triggering_comment=None
+    )
+    mock_gh.issues[123] = {
+        "title": "Release 2.0.0",
+        "body": """
 ## Checklist
 - [ ] Prepare Release
 - [ ] Create Release branch
@@ -617,135 +417,76 @@ class CmdProcessBackportsTest(unittest.TestCase):
 ## Backports
 - [ ] #124 | status=pending
 - [ ] #125 | status=pending
-"""
-        self.mock_git.get_remote_tags.return_value = []
+""",
+        "labels": ["type: release"],
+    }
+    mock_gh.prs[124] = {
+        "state": "MERGED",
+        "mergeCommit": {"oid": "sha_124"},
+    }
+    mock_gh.prs[125] = {
+        "state": "MERGED",
+        "mergeCommit": {"oid": "sha_125"},
+    }
+    mock_git.get_remote_tags.return_value = []
+    mock_git.sort_commits_chronologically.return_value = ["sha_124", "sha_125"]
+    mock_git.get_commit_sha.side_effect = [
+        "12345678",
+        "sha_124_amended",
+        "sha_125_amended",
+        "main_sha",
+    ]
+    mock_git.get_commit_message.return_value = 'Cherry-pick "fix bug"'
+    mock_git.get_modified_files.side_effect = [
+        ["news/124.fixed.md"],
+        ["news/125.fixed.md"],
+    ]
+    mock_git.diff.return_value = "diff content"
+    mock_git.apply_check.side_effect = [False, True]
 
-        def mock_resolve(items):
-            for item in items:
-                if item.pr_ref in ("#124", "#125"):
-                    item.commit = "sha_" + item.pr_ref.lstrip("#")
-                    item.status = "done"
-            return items
+    result = ProcessBackports(args, mock_git, mock_gh).run()
 
-        self.mock_gh.get_merge_commits_for_prs.side_effect = mock_resolve
-
-        self.mock_git.sort_commits_chronologically.return_value = ["sha_124", "sha_125"]
-        self.mock_git.get_commit_sha.side_effect = [
-            "12345678",
-            "sha_124_amended",
-            "sha_125_amended",
-            "main_sha",
+    assert result == 0
+    mock_git.checkout.assert_has_calls(
+        [
+            call("release/2.0", track_remote="origin"),
+            call("main", track_remote="origin"),
+            call("prepare-2.0.0-backports-b552a96", create_branch=True),
+            call("release/2.0"),
         ]
-        self.mock_git.get_commit_message.return_value = 'Cherry-pick "fix bug"'
-        self.mock_git.get_modified_files.side_effect = [
-            ["news/124.fixed.md"],
-            ["news/125.fixed.md"],
+    )
+    mock_git.cherry_pick.assert_has_calls(
+        [
+            call("sha_124"),
+            call("sha_125"),
         ]
-        self.mock_git.diff.side_effect = ["diff 124", "diff 125"]
-        self.mock_git.apply_check.side_effect = [False, True]
-        self.mock_gh.create_pr.return_value = "https://github.com/foo/bar/pull/999"
+    )
+    assert mock_git.diff.call_count == 2
+    assert mock_git.apply_check.call_count == 2
+    mock_git.apply.assert_called_once_with(ANY)
 
-        result = ProcessBackports(args, self.mock_git, self.mock_gh).run()
+    mock_changelog.update_changelog.assert_has_calls(
+        [
+            call("2.0.0", "2026-07-01"),
+            call("2.0.0", "2026-07-01"),
+            call(
+                "2.0.0",
+                "2026-07-01",
+                news_files=["news/124.fixed.md", "news/125.fixed.md"],
+                delete_news=True,
+            ),
+        ]
+    )
+    assert mock_git.add_modified_and_deleted.call_count == 3
+    assert mock_replace.call_count == 2
 
-        self.assertEqual(result, 0)
-        self.mock_git.fetch.assert_has_calls(
-            [
-                call("origin", tags=True, force=True),
-                call("origin"),
-                call("origin", refspec="main"),
-            ]
-        )
-        self.mock_git.checkout.assert_has_calls(
-            [
-                call("release/2.0", track_remote="origin"),
-                call("main", track_remote="origin"),
-                call("prepare-2.0.0-backports-b552a96", create_branch=True),
-                call("release/2.0"),
-            ]
-        )
-        self.mock_git.cherry_pick.assert_has_calls(
-            [
-                call("sha_124"),
-                call("sha_125"),
-            ]
-        )
-        # diff should be called for each successful cherry-pick
-        self.assertEqual(self.mock_git.diff.call_count, 2)
-        # apply_check should be called for both patches
-        self.assertEqual(self.mock_git.apply_check.call_count, 2)
-        # apply should only be called for 125 (since 124 failed check)
-        self.mock_git.apply.assert_called_once_with(unittest.mock.ANY)
+    assert 1001 in mock_gh.prs
+    pr = mock_gh.prs[1001]
+    assert (
+        "Warning: These PRs failed to update their version markers:\n- #124"
+        in pr["body"]
+    )
 
-        self.mock_changelog_news.update_changelog.assert_has_calls(
-            [
-                call("2.0.0", "2026-07-01"),
-                call("2.0.0", "2026-07-01"),
-                call(
-                    "2.0.0",
-                    "2026-07-01",
-                    news_files=["news/124.fixed.md", "news/125.fixed.md"],
-                    delete_news=True,
-                ),
-            ]
-        )
-        # add_modified_and_deleted called:
-        # - once per cherry-pick (2)
-        # - once on main backport branch (1)
-        # Total = 3
-        self.assertEqual(self.mock_git.add_modified_and_deleted.call_count, 3)
-        # replace_version_next called once per cherry-pick
-        self.assertEqual(self.mock_replace_version_next.call_count, 2)
-
-        self.mock_git.commit.assert_has_calls(
-            [
-                call('Cherry-pick "fix bug"\n\nWork towards #123', amend=True),
-                call('Cherry-pick "fix bug"\n\nWork towards #123', amend=True),
-                call("chore(release): sync changelog for v2.0.0 backports"),
-            ]
-        )
-        self.mock_git.push.assert_has_calls(
-            [
-                call("origin", "release/2.0"),
-                call("origin", "release/2.0"),
-                call(
-                    "origin",
-                    "prepare-2.0.0-backports-b552a96",
-                    set_upstream=True,
-                    force=True,
-                ),
-            ]
-        )
-
-        # PR body should contain warning about 124
-        expected_body = (
-            "Updates CHANGELOG.md and removes news files for backports:\n"
-            "- #124\n"
-            "- #125\n"
-            "\n"
-            "Warning: These PRs failed to update their version markers:\n"
-            "- #124\n"
-            "\n"
-            "Work towards #123\n"
-            "Release-Tracking-Issue: #123"
-        )
-        self.mock_gh.create_pr.assert_called_once_with(
-            title="chore(release): sync changelog for v2.0.0 backports",
-            body=expected_body,
-            base="main",
-            labels=["type: sync-changelog"],
-        )
-        self.mock_gh.enable_auto_merge.assert_called_once_with(999)
-
-        # update_issue_body called 3 times (twice for backports, once for sync tasks)
-        self.assertEqual(self.mock_gh.update_issue_body.call_count, 3)
-        call3_args = self.mock_gh.update_issue_body.call_args_list[2][0]
-        self.assertIn(
-            "- [ ] Sync Changelog #124 | status=pending pr=#999", call3_args[1]
-        )
-        self.assertIn(
-            "- [ ] Sync Changelog #125 | status=pending pr=#999", call3_args[1]
-        )
-
-
-if __name__ == "__main__":
-    unittest.main()
+    updated_body = mock_gh.get_issue_body(123)
+    assert "- [ ] Sync Changelog #124 | status=pending pr=#1001" in updated_body
+    assert "- [ ] Sync Changelog #125 | status=pending pr=#1001" in updated_body

--- a/tests/tools/private/release/promote_test.py
+++ b/tests/tools/private/release/promote_test.py
@@ -1,313 +1,281 @@
 import argparse
-import os
-import tempfile
-import unittest
 from pathlib import Path
 from unittest.mock import call, patch
 
-from tests.tools.private.release.release_test_helper import _mock_git_and_gh
-from tools.private.release.gh import NoTrackingIssueError
 from tools.private.release.promote import Promote
 
-
-class CmdPromoteTest(unittest.TestCase):
-    def setUp(self):
-        _mock_git_and_gh(self)
-        self.test_dir = tempfile.TemporaryDirectory()
-        self.addCleanup(self.test_dir.cleanup)
-
-    def test_promote_rc_success(self):
-        # Arrange
-        args = argparse.Namespace(
-            version="2.0.0", issue=123, dry_run=False, remote="my-remote"
-        )
-        self.mock_git.get_remote_tags.return_value = ["2.0.0-rc0", "2.0.0-rc1"]
-        self.mock_git.get_commit_sha.return_value = "abcdef123456"
-        self.mock_git.tag_exists.return_value = False
-        initial_body = "- [ ] Tag Final"
-        self.mock_gh.get_issue_body.return_value = initial_body
-
-        # Act
-        result = Promote(args, self.mock_git, self.mock_gh).run()
-
-        # Assert
-        self.assertEqual(result, 0)
-        self.mock_git.fetch.assert_has_calls(
-            [
-                call("my-remote", tags=True, force=True),
-                call("my-remote", refspec="release/2.0"),
-            ]
-        )
-        self.mock_git.get_commit_sha.assert_has_calls(
-            [call("2.0.0-rc1"), call("my-remote/release/2.0")]
-        )
-        self.mock_git.checkout.assert_not_called()
-        self.mock_git.tag_exists.assert_called_once_with("2.0.0")
-        self.mock_git.tag.assert_called_once_with("2.0.0", "abcdef123456")
-        self.mock_git.push.assert_called_once_with("my-remote", "2.0.0")
-
-        # Verify issue update
-        self.mock_gh.get_issue_body.assert_called_once_with(123)
-        expected_updated_body = (
-            "- [x] Tag Final | status=done tag=2.0.0 commit= abcdef12"
-        )
-        self.mock_gh.update_issue_body.assert_called_once_with(
-            123, expected_updated_body
-        )
-        expected_comment = (
-            "**New Release Tagged!** 🐍🌿\n\n"
-            "Version **2.0.0** has been successfully generated and tagged on branch [`release/2.0`](https://github.com/bazel-contrib/rules_python/tree/release/2.0).\n\n"
-            "- [Github Release 2.0.0](https://github.com/bazel-contrib/rules_python/releases/tag/2.0.0)\n"
-            "- [BCR Entry 2.0.0](https://registry.bazel.build/modules/rules_python/2.0.0)\n"
-            "- [BCR PRs](https://github.com/bazelbuild/bazel-central-registry/pulls?q=is%3Apr%20%28%22bazel-contrib/rules_python%22%20in%3Atitle%29%20%28%22%402.0.0%22%20in%3Atitle%29)\n"
-            "- [Release workflow status](https://github.com/bazel-contrib/rules_python/actions/workflows/release_promote.yaml)"
-        )
-        self.mock_gh.post_issue_comment.assert_called_once_with(123, expected_comment)
-
-    def test_promote_rc_writes_github_output(self):
-        # Arrange
-        github_output_path = os.path.join(self.test_dir.name, "github_output")
-        args = argparse.Namespace(
-            version="2.0.0", issue=123, dry_run=False, remote="my-remote"
-        )
-        self.mock_git.get_remote_tags.return_value = ["2.0.0-rc0", "2.0.0-rc1"]
-        self.mock_git.get_commit_sha.return_value = "abcdef123456"
-        self.mock_git.tag_exists.return_value = False
-        initial_body = "- [ ] Tag Final"
-        self.mock_gh.get_issue_body.return_value = initial_body
-
-        # Act
-        with patch.dict("os.environ", {"GITHUB_OUTPUT": github_output_path}):
-            result = Promote(args, self.mock_git, self.mock_gh).run()
-
-        # Assert
-        self.assertEqual(result, 0)
-        self.assertTrue(os.path.exists(github_output_path))
-        content = Path(github_output_path).read_text(encoding="utf-8")
-        self.assertEqual(content, "version=2.0.0\n")
-
-    def test_promote_rc_resolve_issue_success(self):
-        # Arrange
-        args = argparse.Namespace(
-            version="2.0.0", issue=None, dry_run=False, remote="my-remote"
-        )
-        self.mock_git.get_remote_tags.return_value = ["2.0.0-rc1"]
-        self.mock_git.tag_exists.return_value = False
-        self.mock_gh.get_release_tracking_issue.side_effect = None
-        self.mock_gh.get_release_tracking_issue.return_value = 123
-        self.mock_git.get_commit_sha.return_value = "abcdef123456"
-        initial_body = "- [ ] Tag Final"
-        self.mock_gh.get_issue_body.return_value = initial_body
-
-        # Act
-        result = Promote(args, self.mock_git, self.mock_gh).run()
-
-        # Assert
-        self.assertEqual(result, 0)
-        self.mock_git.fetch.assert_has_calls(
-            [
-                call("my-remote", tags=True, force=True),
-                call("my-remote", refspec="release/2.0"),
-            ]
-        )
-        self.mock_gh.get_release_tracking_issue.assert_called_once_with("2.0.0")
-        self.mock_git.get_commit_sha.assert_has_calls(
-            [call("2.0.0-rc1"), call("my-remote/release/2.0")]
-        )
-        self.mock_git.checkout.assert_not_called()
-        self.mock_git.tag.assert_called_once_with("2.0.0", "abcdef123456")
-        self.mock_git.push.assert_called_once_with("my-remote", "2.0.0")
-        self.mock_gh.get_issue_body.assert_called_once_with(123)
-        expected_updated_body = (
-            "- [x] Tag Final | status=done tag=2.0.0 commit= abcdef12"
-        )
-        self.mock_gh.update_issue_body.assert_called_once_with(
-            123, expected_updated_body
-        )
-        expected_comment = (
-            "**New Release Tagged!** 🐍🌿\n\n"
-            "Version **2.0.0** has been successfully generated and tagged on branch [`release/2.0`](https://github.com/bazel-contrib/rules_python/tree/release/2.0).\n\n"
-            "- [Github Release 2.0.0](https://github.com/bazel-contrib/rules_python/releases/tag/2.0.0)\n"
-            "- [BCR Entry 2.0.0](https://registry.bazel.build/modules/rules_python/2.0.0)\n"
-            "- [BCR PRs](https://github.com/bazelbuild/bazel-central-registry/pulls?q=is%3Apr%20%28%22bazel-contrib/rules_python%22%20in%3Atitle%29%20%28%22%402.0.0%22%20in%3Atitle%29)\n"
-            "- [Release workflow status](https://github.com/bazel-contrib/rules_python/actions/workflows/release_promote.yaml)"
-        )
-        self.mock_gh.post_issue_comment.assert_called_once_with(123, expected_comment)
-
-    def test_promote_patch_success(self):
-        # Arrange
-        args = argparse.Namespace(
-            version="2.0.1", issue=123, dry_run=False, remote="my-remote"
-        )
-        self.mock_git.tag_exists.return_value = False
-        self.mock_git.get_commit_sha.return_value = "12345678"
-        initial_body = "- [ ] Tag Final"
-        self.mock_gh.get_issue_body.return_value = initial_body
-
-        # Act
-        result = Promote(args, self.mock_git, self.mock_gh).run()
-
-        # Assert
-        self.assertEqual(result, 0)
-        self.mock_git.fetch.assert_has_calls(
-            [
-                call("my-remote", tags=True, force=True),
-                call("my-remote", refspec="release/2.0"),
-            ]
-        )
-        self.mock_git.get_current_branch.assert_not_called()
-        self.mock_git.get_tags.assert_not_called()
-        self.mock_git.get_remote_tags.assert_not_called()
-
-        self.mock_git.checkout.assert_not_called()
-        self.mock_git.get_commit_sha.assert_called_once_with("my-remote/release/2.0")
-        self.mock_git.tag.assert_called_once_with("2.0.1", "12345678")
-        self.mock_git.push.assert_called_once_with("my-remote", "2.0.1")
-
-        expected_updated_body = (
-            "- [x] Tag Final | status=done tag=2.0.1 commit= 12345678"
-        )
-        self.mock_gh.update_issue_body.assert_called_once_with(
-            123, expected_updated_body
-        )
-        expected_comment = (
-            "**New Release Tagged!** 🐍🌿\n\n"
-            "Version **2.0.1** has been successfully generated and tagged on branch [`release/2.0`](https://github.com/bazel-contrib/rules_python/tree/release/2.0).\n\n"
-            "- [Github Release 2.0.1](https://github.com/bazel-contrib/rules_python/releases/tag/2.0.1)\n"
-            "- [BCR Entry 2.0.1](https://registry.bazel.build/modules/rules_python/2.0.1)\n"
-            "- [BCR PRs](https://github.com/bazelbuild/bazel-central-registry/pulls?q=is%3Apr%20%28%22bazel-contrib/rules_python%22%20in%3Atitle%29%20%28%22%402.0.1%22%20in%3Atitle%29)\n"
-            "- [Release workflow status](https://github.com/bazel-contrib/rules_python/actions/workflows/release_promote.yaml)"
-        )
-        self.mock_gh.post_issue_comment.assert_called_once_with(123, expected_comment)
-
-    @patch("builtins.print")
-    def test_promote_rc_dry_run_success(self, mock_print):
-        # Arrange
-        args = argparse.Namespace(
-            version="2.0.0", issue=123, dry_run=True, remote="my-remote"
-        )
-        self.mock_git.get_remote_tags.return_value = ["2.0.0-rc0", "2.0.0-rc1"]
-        self.mock_git.get_commit_sha.return_value = "abcdef123456"
-        self.mock_git.tag_exists.return_value = False
-        initial_body = "- [ ] Tag Final"
-        self.mock_gh.get_issue_body.return_value = initial_body
-
-        # Act
-        result = Promote(args, self.mock_git, self.mock_gh).run()
-
-        # Assert
-        self.assertEqual(result, 0)
-        self.mock_git.fetch.assert_has_calls(
-            [
-                call("my-remote", tags=True, force=True),
-                call("my-remote", refspec="release/2.0"),
-            ]
-        )
-        self.mock_git.get_commit_sha.assert_has_calls(
-            [call("2.0.0-rc1"), call("my-remote/release/2.0")]
-        )
-        self.mock_git.tag_exists.assert_called_once_with("2.0.0")
-
-        # Core dry-run assertions: NO modifications
-        self.mock_git.tag.assert_not_called()
-        self.mock_git.push.assert_not_called()
-        self.mock_gh.update_issue_body.assert_not_called()
-        self.mock_gh.post_issue_comment.assert_not_called()
-
-        mock_print.assert_has_calls(
-            [
-                call("Verifying tracking issue #123 format..."),
-                call("Fetching remote branch my-remote/release/2.0..."),
-                call(
-                    "[DRY RUN] Pre-conditions passed successfully for promoting"
-                    " 2.0.0-rc1 to 2.0.0."
-                ),
-                call("[DRY RUN] Would tag commit abcdef12 as 2.0.0"),
-                call("[DRY RUN] Would push tag 2.0.0 to my-remote"),
-                call("[DRY RUN] Would update tracking issue #123 checklist"),
-                call("[DRY RUN] Would post comment to tracking issue #123"),
-            ]
-        )
-
-    def test_promote_rc_tag_already_exists(self):
-        # Arrange
-        args = argparse.Namespace(
-            version="2.0.0", issue=123, dry_run=False, remote="my-remote"
-        )
-        self.mock_git.get_remote_tags.return_value = ["2.0.0-rc1"]
-        self.mock_git.tag_exists.return_value = True
-
-        # Act
-        result = Promote(args, self.mock_git, self.mock_gh).run()
-
-        # Assert
-        self.assertEqual(result, 1)
-        self.mock_git.checkout.assert_not_called()
-        self.mock_git.tag.assert_not_called()
-        self.mock_git.push.assert_not_called()
-        self.mock_gh.get_issue_body.assert_not_called()
-        self.mock_gh.update_issue_body.assert_not_called()
-
-    def test_promote_rc_issue_not_found(self):
-        # Arrange
-        args = argparse.Namespace(
-            version="2.0.0", issue=None, dry_run=False, remote="my-remote"
-        )
-        self.mock_git.get_remote_tags.return_value = ["2.0.0-rc1"]
-        self.mock_git.tag_exists.return_value = False
-        self.mock_gh.get_release_tracking_issue.side_effect = NoTrackingIssueError(
-            "Not found"
-        )
-
-        # Act
-        result = Promote(args, self.mock_git, self.mock_gh).run()
-
-        # Assert
-        self.assertEqual(result, 1)
-        self.mock_gh.get_release_tracking_issue.assert_called_once_with("2.0.0")
-        self.mock_git.checkout.assert_not_called()
-        self.mock_git.tag.assert_not_called()
-        self.mock_git.push.assert_not_called()
-        self.mock_gh.get_issue_body.assert_not_called()
-
-    def test_promote_rc_issue_malformed(self):
-        # Arrange
-        args = argparse.Namespace(
-            version="2.0.0", issue=123, dry_run=False, remote="my-remote"
-        )
-        self.mock_git.get_remote_tags.return_value = ["2.0.0-rc1"]
-        self.mock_git.tag_exists.return_value = False
-        self.mock_git.get_commit_sha.return_value = "abcdef123456"
-        initial_body = "malformed body"
-        self.mock_gh.get_issue_body.return_value = initial_body
-
-        # Act
-        result = Promote(args, self.mock_git, self.mock_gh).run()
-
-        # Assert
-        self.assertEqual(result, 1)
-        self.mock_gh.get_issue_body.assert_called_once_with(123)
-        self.mock_git.checkout.assert_not_called()
-        self.mock_git.tag.assert_not_called()
-        self.mock_git.push.assert_not_called()
-        self.mock_gh.update_issue_body.assert_not_called()
-
-    def test_promote_rc_no_rc_found(self):
-        # Arrange
-        args = argparse.Namespace(
-            version="2.0.0", issue=123, dry_run=False, remote="my-remote"
-        )
-        self.mock_git.get_remote_tags.return_value = []
-
-        # Act
-        result = Promote(args, self.mock_git, self.mock_gh).run()
-
-        # Assert
-        self.assertEqual(result, 1)
-        self.mock_git.checkout.assert_not_called()
-        self.mock_git.tag.assert_not_called()
-        self.mock_gh.get_issue_body.assert_not_called()
+pytest_plugins = ["tests.tools.private.release.release_test_helper"]
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_promote_rc_success(mock_git, mock_gh):
+    # Arrange
+    issue_num = mock_gh.create_issue(
+        title="Release 2.0.0",
+        body="- [ ] Tag Final",
+        labels=["type: release"],
+    )
+    args = argparse.Namespace(
+        version="2.0.0", issue=issue_num, dry_run=False, remote="my-remote"
+    )
+    mock_git.get_remote_tags.return_value = ["2.0.0-rc0", "2.0.0-rc1"]
+    mock_git.get_commit_sha.return_value = "abcdef123456"
+    mock_git.tag_exists.return_value = False
+
+    # Act
+    result = Promote(args, mock_git, mock_gh).run()
+
+    # Assert
+    assert result == 0
+    mock_git.fetch.assert_has_calls(
+        [
+            call("my-remote", tags=True, force=True),
+            call("my-remote", refspec="release/2.0"),
+        ]
+    )
+    mock_git.get_commit_sha.assert_has_calls(
+        [call("2.0.0-rc1"), call("my-remote/release/2.0")]
+    )
+    mock_git.checkout.assert_not_called()
+    mock_git.tag_exists.assert_called_once_with("2.0.0")
+    mock_git.tag.assert_called_once_with("2.0.0", "abcdef123456")
+    mock_git.push.assert_called_once_with("my-remote", "2.0.0")
+
+    # Verify issue update
+    expected_updated_body = "- [x] Tag Final | status=done tag=2.0.0 commit= abcdef12"
+    assert mock_gh.get_issue_body(issue_num) == expected_updated_body
+
+    expected_comment = (
+        "**New Release Tagged!** 🐍🌿\n\n"
+        "Version **2.0.0** has been successfully generated and tagged on branch [`release/2.0`](https://github.com/bazel-contrib/rules_python/tree/release/2.0).\n\n"
+        "- [Github Release 2.0.0](https://github.com/bazel-contrib/rules_python/releases/tag/2.0.0)\n"
+        "- [BCR Entry 2.0.0](https://registry.bazel.build/modules/rules_python/2.0.0)\n"
+        "- [BCR PRs](https://github.com/bazelbuild/bazel-central-registry/pulls?q=is%3Apr%20%28%22bazel-contrib/rules_python%22%20in%3Atitle%29%20%28%22%402.0.0%22%20in%3Atitle%29)\n"
+        "- [Release workflow status](https://github.com/bazel-contrib/rules_python/actions/workflows/release_promote.yaml)"
+    )
+    assert mock_gh.issue_comments[issue_num] == [expected_comment]
+
+
+def test_promote_rc_writes_github_output(tmp_path, monkeypatch, mock_git, mock_gh):
+    # Arrange
+    github_output_path = str(tmp_path / "github_output")
+    monkeypatch.setenv("GITHUB_OUTPUT", github_output_path)
+    issue_num = mock_gh.create_issue(
+        title="Release 2.0.0",
+        body="- [ ] Tag Final",
+        labels=["type: release"],
+    )
+    args = argparse.Namespace(
+        version="2.0.0", issue=issue_num, dry_run=False, remote="my-remote"
+    )
+    mock_git.get_remote_tags.return_value = ["2.0.0-rc0", "2.0.0-rc1"]
+    mock_git.get_commit_sha.return_value = "abcdef123456"
+    mock_git.tag_exists.return_value = False
+
+    # Act
+    result = Promote(args, mock_git, mock_gh).run()
+
+    # Assert
+    assert result == 0
+    assert Path(github_output_path).exists()
+    content = Path(github_output_path).read_text(encoding="utf-8")
+    assert content == "version=2.0.0\n"
+
+
+def test_promote_rc_resolve_issue_success(mock_git, mock_gh):
+    # Arrange
+    args = argparse.Namespace(
+        version="2.0.0", issue=None, dry_run=False, remote="my-remote"
+    )
+    issue_num = mock_gh.create_issue(
+        title="Release 2.0.0",
+        body="- [ ] Tag Final",
+        labels=["type: release"],
+    )
+    mock_git.get_remote_tags.return_value = ["2.0.0-rc1"]
+    mock_git.tag_exists.return_value = False
+    mock_git.get_commit_sha.return_value = "abcdef123456"
+
+    # Act
+    result = Promote(args, mock_git, mock_gh).run()
+
+    # Assert
+    assert result == 0
+    mock_git.fetch.assert_has_calls(
+        [
+            call("my-remote", tags=True, force=True),
+            call("my-remote", refspec="release/2.0"),
+        ]
+    )
+    mock_git.get_commit_sha.assert_has_calls(
+        [call("2.0.0-rc1"), call("my-remote/release/2.0")]
+    )
+    mock_git.checkout.assert_not_called()
+    mock_git.tag.assert_called_once_with("2.0.0", "abcdef123456")
+    mock_git.push.assert_called_once_with("my-remote", "2.0.0")
+
+    expected_updated_body = "- [x] Tag Final | status=done tag=2.0.0 commit= abcdef12"
+    assert mock_gh.get_issue_body(issue_num) == expected_updated_body
+
+
+def test_promote_patch_success(mock_git, mock_gh):
+    # Arrange
+    issue_num = mock_gh.create_issue(
+        title="Release 2.0.1",
+        body="- [ ] Tag Final",
+        labels=["type: release"],
+    )
+    args = argparse.Namespace(
+        version="2.0.1", issue=issue_num, dry_run=False, remote="my-remote"
+    )
+    mock_git.tag_exists.return_value = False
+    mock_git.get_commit_sha.return_value = "12345678"
+
+    # Act
+    result = Promote(args, mock_git, mock_gh).run()
+
+    # Assert
+    assert result == 0
+    mock_git.fetch.assert_has_calls(
+        [
+            call("my-remote", tags=True, force=True),
+            call("my-remote", refspec="release/2.0"),
+        ]
+    )
+    mock_git.get_current_branch.assert_not_called()
+    mock_git.get_tags.assert_not_called()
+    mock_git.get_remote_tags.assert_not_called()
+
+    mock_git.checkout.assert_not_called()
+    mock_git.get_commit_sha.assert_called_once_with("my-remote/release/2.0")
+    mock_git.tag.assert_called_once_with("2.0.1", "12345678")
+    mock_git.push.assert_called_once_with("my-remote", "2.0.1")
+
+    expected_updated_body = "- [x] Tag Final | status=done tag=2.0.1 commit= 12345678"
+    assert mock_gh.get_issue_body(issue_num) == expected_updated_body
+
+
+@patch("builtins.print")
+def test_promote_rc_dry_run_success(mock_print, mock_git, mock_gh):
+    # Arrange
+    issue_num = mock_gh.create_issue(
+        title="Release 2.0.0",
+        body="- [ ] Tag Final",
+        labels=["type: release"],
+    )
+    args = argparse.Namespace(
+        version="2.0.0", issue=issue_num, dry_run=True, remote="my-remote"
+    )
+    mock_git.get_remote_tags.return_value = ["2.0.0-rc0", "2.0.0-rc1"]
+    mock_git.get_commit_sha.return_value = "abcdef123456"
+    mock_git.tag_exists.return_value = False
+
+    # Act
+    result = Promote(args, mock_git, mock_gh).run()
+
+    # Assert
+    assert result == 0
+    mock_git.fetch.assert_has_calls(
+        [
+            call("my-remote", tags=True, force=True),
+            call("my-remote", refspec="release/2.0"),
+        ]
+    )
+    mock_git.get_commit_sha.assert_has_calls(
+        [call("2.0.0-rc1"), call("my-remote/release/2.0")]
+    )
+    mock_git.tag_exists.assert_called_once_with("2.0.0")
+
+    # Core dry-run assertions: NO modifications
+    mock_git.tag.assert_not_called()
+    mock_git.push.assert_not_called()
+
+    mock_print.assert_has_calls(
+        [
+            call(f"Verifying tracking issue #{issue_num} format..."),
+            call("Fetching remote branch my-remote/release/2.0..."),
+            call(
+                "[DRY RUN] Pre-conditions passed successfully for promoting"
+                " 2.0.0-rc1 to 2.0.0."
+            ),
+            call("[DRY RUN] Would tag commit abcdef12 as 2.0.0"),
+            call("[DRY RUN] Would push tag 2.0.0 to my-remote"),
+            call(f"[DRY RUN] Would update tracking issue #{issue_num} checklist"),
+            call(f"[DRY RUN] Would post comment to tracking issue #{issue_num}"),
+        ]
+    )
+
+
+def test_promote_rc_tag_already_exists(mock_git, mock_gh):
+    # Arrange
+    args = argparse.Namespace(
+        version="2.0.0", issue=123, dry_run=False, remote="my-remote"
+    )
+    mock_git.get_remote_tags.return_value = ["2.0.0-rc1"]
+    mock_git.tag_exists.return_value = True
+
+    # Act
+    result = Promote(args, mock_git, mock_gh).run()
+
+    # Assert
+    assert result == 1
+    mock_git.checkout.assert_not_called()
+    mock_git.tag.assert_not_called()
+    mock_git.push.assert_not_called()
+
+
+def test_promote_rc_issue_not_found(mock_git, mock_gh):
+    # Arrange
+    args = argparse.Namespace(
+        version="2.0.0", issue=None, dry_run=False, remote="my-remote"
+    )
+    mock_git.get_remote_tags.return_value = ["2.0.0-rc1"]
+    mock_git.tag_exists.return_value = False
+
+    # Act
+    result = Promote(args, mock_git, mock_gh).run()
+
+    # Assert
+    assert result == 1
+    mock_git.checkout.assert_not_called()
+    mock_git.tag.assert_not_called()
+    mock_git.push.assert_not_called()
+
+
+def test_promote_rc_issue_malformed(mock_git, mock_gh):
+    # Arrange
+    issue_num = mock_gh.create_issue(
+        title="Release 2.0.0",
+        body="malformed body",
+        labels=["type: release"],
+    )
+    args = argparse.Namespace(
+        version="2.0.0", issue=issue_num, dry_run=False, remote="my-remote"
+    )
+    mock_git.get_remote_tags.return_value = ["2.0.0-rc1"]
+    mock_git.tag_exists.return_value = False
+    mock_git.get_commit_sha.return_value = "abcdef123456"
+
+    # Act
+    result = Promote(args, mock_git, mock_gh).run()
+
+    # Assert
+    assert result == 1
+    mock_git.checkout.assert_not_called()
+    mock_git.tag.assert_not_called()
+    mock_git.push.assert_not_called()
+
+
+def test_promote_rc_no_rc_found(mock_git, mock_gh):
+    # Arrange
+    args = argparse.Namespace(
+        version="2.0.0", issue=123, dry_run=False, remote="my-remote"
+    )
+    mock_git.get_remote_tags.return_value = []
+
+    # Act
+    result = Promote(args, mock_git, mock_gh).run()
+
+    # Assert
+    assert result == 1
+    mock_git.checkout.assert_not_called()
+    mock_git.tag.assert_not_called()

--- a/tests/tools/private/release/release_issue_test.py
+++ b/tests/tools/private/release/release_issue_test.py
@@ -1,5 +1,3 @@
-import unittest
-
 from tools.private.release.release_issue import (
     add_backports_to_body,
     add_sync_changelog_task_to_body,
@@ -9,67 +7,66 @@ from tools.private.release.release_issue import (
 )
 
 
-class ReleaseIssueTest(unittest.TestCase):
-    def test_parse_metadata_line_spaces(self):
-        # Test with spaces around '='
-        line = "- [ ] Tag Final | tag = 2.0.0 commit = abcdef12"
-        expected = {
-            "checked": False,
-            "name": "Tag Final",
-            "metadata": {"tag": "2.0.0", "commit": "abcdef12"},
-            "original_line": line,
-        }
-        self.assertEqual(parse_metadata_line(line), expected)
+def test_parse_metadata_line_spaces():
+    # Test with spaces around '='
+    line = "- [ ] Tag Final | tag = 2.0.0 commit = abcdef12"
+    expected = {
+        "checked": False,
+        "name": "Tag Final",
+        "metadata": {"tag": "2.0.0", "commit": "abcdef12"},
+        "original_line": line,
+    }
+    assert parse_metadata_line(line) == expected
 
-        # Test with spaces after '='
-        line = "- [ ] Tag Final | tag= 2.0.0 commit= abcdef12"
-        expected = {
-            "checked": False,
-            "name": "Tag Final",
-            "metadata": {"tag": "2.0.0", "commit": "abcdef12"},
-            "original_line": line,
-        }
-        self.assertEqual(parse_metadata_line(line), expected)
+    # Test with spaces after '='
+    line = "- [ ] Tag Final | tag= 2.0.0 commit= abcdef12"
+    expected = {
+        "checked": False,
+        "name": "Tag Final",
+        "metadata": {"tag": "2.0.0", "commit": "abcdef12"},
+        "original_line": line,
+    }
+    assert parse_metadata_line(line) == expected
 
-        # Test with standard format (no spaces)
-        line = "- [ ] Tag Final | tag=2.0.0 commit=abcdef12"
-        expected = {
-            "checked": False,
-            "name": "Tag Final",
-            "metadata": {"tag": "2.0.0", "commit": "abcdef12"},
-            "original_line": line,
-        }
-        self.assertEqual(parse_metadata_line(line), expected)
+    # Test with standard format (no spaces)
+    line = "- [ ] Tag Final | tag=2.0.0 commit=abcdef12"
+    expected = {
+        "checked": False,
+        "name": "Tag Final",
+        "metadata": {"tag": "2.0.0", "commit": "abcdef12"},
+        "original_line": line,
+    }
+    assert parse_metadata_line(line) == expected
 
-        # Test with no metadata
-        line = "- [ ] Tag Final"
-        expected = {
-            "checked": False,
-            "name": "Tag Final",
-            "metadata": {},
-            "original_line": line,
-        }
-        self.assertEqual(parse_metadata_line(line), expected)
+    # Test with no metadata
+    line = "- [ ] Tag Final"
+    expected = {
+        "checked": False,
+        "name": "Tag Final",
+        "metadata": {},
+        "original_line": line,
+    }
+    assert parse_metadata_line(line) == expected
 
-    def test_format_metadata_line(self):
-        # Test with commit metadata (should have space)
-        metadata = {"status": "done", "tag": "2.0.0", "commit": "abcdef12"}
-        expected = "- [x] Tag Final | status=done tag=2.0.0 commit= abcdef12"
-        self.assertEqual(format_metadata_line(True, "Tag Final", metadata), expected)
 
-        # Test with other metadata (should not have space)
-        metadata = {"status": "done", "pr": "#122"}
-        expected = "- [x] Prepare Release | status=done pr=#122"
-        self.assertEqual(
-            format_metadata_line(True, "Prepare Release", metadata), expected
-        )
+def test_format_metadata_line():
+    # Test with commit metadata (should have space)
+    metadata = {"status": "done", "tag": "2.0.0", "commit": "abcdef12"}
+    expected = "- [x] Tag Final | status=done tag=2.0.0 commit= abcdef12"
+    assert format_metadata_line(True, "Tag Final", metadata) == expected
 
-        # Test with no metadata
-        expected = "- [ ] Tag Final"
-        self.assertEqual(format_metadata_line(False, "Tag Final", {}), expected)
+    # Test with other metadata (should not have space)
+    metadata = {"status": "done", "pr": "#122"}
+    expected = "- [x] Prepare Release | status=done pr=#122"
+    assert format_metadata_line(True, "Prepare Release", metadata) == expected
 
-    def test_add_backports_to_body(self):
-        body = """
+    # Test with no metadata
+    expected = "- [ ] Tag Final"
+    assert format_metadata_line(False, "Tag Final", {}) == expected
+
+
+def test_add_backports_to_body():
+    body = """
 ## Checklist
 - [ ] Prepare Release
 - [ ] Create Release branch
@@ -78,14 +75,14 @@ class ReleaseIssueTest(unittest.TestCase):
 ## Backports
 - [ ] #123 | status=done
 """
-        items = [
-            {"ref": "124"},
-            {"ref": "#124"},
-            {"ref": "125"},
-            {"ref": "#123"},
-        ]
-        updated_body = add_backports_to_body(body, items)
-        expected_body = """
+    items = [
+        {"ref": "124"},
+        {"ref": "#124"},
+        {"ref": "125"},
+        {"ref": "#123"},
+    ]
+    updated_body = add_backports_to_body(body, items)
+    expected_body = """
 ## Checklist
 - [ ] Prepare Release
 - [ ] Create Release branch
@@ -96,29 +93,30 @@ class ReleaseIssueTest(unittest.TestCase):
 - [ ] #124
 - [ ] #125
 """
-        self.assertEqual(updated_body.strip(), expected_body.strip())
+    assert updated_body.strip() == expected_body.strip()
 
-    def test_add_sync_changelog_task_to_body(self):
-        body = """
+
+def test_add_sync_changelog_task_to_body():
+    body = """
 ## Checklist
 - [ ] Prepare Release
 - [ ] Create Release branch
 - [ ] Tag Final
 """
-        # Insert first task (should go before Tag Final)
-        body = add_sync_changelog_task_to_body(body, 124)
-        expected = """
+    # Insert first task (should go before Tag Final)
+    body = add_sync_changelog_task_to_body(body, 124)
+    expected = """
 ## Checklist
 - [ ] Prepare Release
 - [ ] Create Release branch
 - [ ] Sync Changelog #124
 - [ ] Tag Final
 """
-        self.assertEqual(body.strip(), expected.strip())
+    assert body.strip() == expected.strip()
 
-        # Insert second task (should go after the last Sync Changelog task)
-        body = add_sync_changelog_task_to_body(body, 125)
-        expected = """
+    # Insert second task (should go after the last Sync Changelog task)
+    body = add_sync_changelog_task_to_body(body, 125)
+    expected = """
 ## Checklist
 - [ ] Prepare Release
 - [ ] Create Release branch
@@ -126,14 +124,15 @@ class ReleaseIssueTest(unittest.TestCase):
 - [ ] Sync Changelog #125
 - [ ] Tag Final
 """
-        self.assertEqual(body.strip(), expected.strip())
+    assert body.strip() == expected.strip()
 
-        # Insert duplicate (should be ignored)
-        body = add_sync_changelog_task_to_body(body, 124)
-        self.assertEqual(body.strip(), expected.strip())
+    # Insert duplicate (should be ignored)
+    body = add_sync_changelog_task_to_body(body, 124)
+    assert body.strip() == expected.strip()
 
-    def test_parse_checklist_state_with_sync_changelogs(self):
-        body = """
+
+def test_parse_checklist_state_with_sync_changelogs():
+    body = """
 ## Checklist
 - [x] Prepare Release | status=done pr=#122 commit=abcdef12
 - [x] Create Release branch | status=done branch=release/2.0
@@ -141,22 +140,18 @@ class ReleaseIssueTest(unittest.TestCase):
 - [ ] Sync Changelog #126
 - [ ] Tag Final
 """
-        state = parse_checklist_state(body)
-        self.assertIn(124, state["sync_changelogs"])
-        self.assertIn(126, state["sync_changelogs"])
+    state = parse_checklist_state(body)
+    assert 124 in state["sync_changelogs"]
+    assert 126 in state["sync_changelogs"]
 
-        task_124 = state["sync_changelogs"][124]
-        self.assertEqual(task_124.name, "Sync Changelog #124")
-        self.assertFalse(task_124.checked)
-        self.assertEqual(task_124.status, "pending")
-        self.assertEqual(task_124.pr, "#125")
+    task_124 = state["sync_changelogs"][124]
+    assert task_124.name == "Sync Changelog #124"
+    assert not task_124.checked
+    assert task_124.status == "pending"
+    assert task_124.pr == "#125"
 
-        task_126 = state["sync_changelogs"][126]
-        self.assertEqual(task_126.name, "Sync Changelog #126")
-        self.assertFalse(task_126.checked)
-        self.assertIsNone(task_126.status)
-        self.assertIsNone(task_126.pr)
-
-
-if __name__ == "__main__":
-    unittest.main()
+    task_126 = state["sync_changelogs"][126]
+    assert task_126.name == "Sync Changelog #126"
+    assert not task_126.checked
+    assert task_126.status is None
+    assert task_126.pr is None

--- a/tests/tools/private/release/release_test.py
+++ b/tests/tools/private/release/release_test.py
@@ -1,23 +1,19 @@
-import unittest
+import pytest
 
 from tools.private.release import release as releaser
 
 
-class ReleaseCLITest(unittest.TestCase):
-    def test_valid_version(self):
-        # These should not raise an exception
-        releaser.create_parser().parse_args(["prepare", "0.28.0"])
-        releaser.create_parser().parse_args(["promote", "1.0.0", "--remote", "origin"])
-        releaser.create_parser().parse_args(
-            ["create-release-issue", "--version", "1.2.3rc4"]
-        )
-
-    def test_invalid_version(self):
-        with self.assertRaises(SystemExit):
-            releaser.create_parser().parse_args(["prepare", "0.28"])
-        with self.assertRaises(SystemExit):
-            releaser.create_parser().parse_args(["prepare", "a.b.c"])
+def test_valid_version():
+    # These should not raise an exception
+    releaser.create_parser().parse_args(["prepare", "0.28.0"])
+    releaser.create_parser().parse_args(["promote", "1.0.0", "--remote", "origin"])
+    releaser.create_parser().parse_args(
+        ["create-release-issue", "--version", "1.2.3rc4"]
+    )
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_invalid_version():
+    with pytest.raises(SystemExit):
+        releaser.create_parser().parse_args(["prepare", "0.28"])
+    with pytest.raises(SystemExit):
+        releaser.create_parser().parse_args(["prepare", "a.b.c"])

--- a/tests/tools/private/release/release_test_helper.py
+++ b/tests/tools/private/release/release_test_helper.py
@@ -5,6 +5,8 @@ import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from tools.private.release.gh import (
     MultipleTrackingIssuesError,
     NoTrackingIssueError,
@@ -74,3 +76,32 @@ class ReleaseToolTestCase(TempDirTestCase):
         self.template_file = template_dir / "release_tracking_template.md"
         self.template_content = DEFAULT_RELEASE_TEMPLATE_CONTENT
         self.template_file.write_text(self.template_content, encoding="utf-8")
+
+
+@pytest.fixture(name="mock_git")
+def fixture_mock_git():
+    mock_git_inst = MagicMock()
+    mock_git_inst.get_current_branch.return_value = None
+    mock_git_inst.get_tags.return_value = []
+    mock_git_inst.get_remote_tags.return_value = []
+    mock_git_inst.status.return_value = ""
+    mock_git_inst.branch_exists.return_value = False
+    mock_git_inst.tag_exists.return_value = False
+
+    with patch("tools.private.release.utils.Git", return_value=mock_git_inst):
+        yield mock_git_inst
+
+
+@pytest.fixture(name="mock_gh")
+def fixture_mock_gh():
+    return MockGitHub()
+
+
+@pytest.fixture(name="release_tool_env")
+def fixture_release_tool_env(tmp_path, monkeypatch):
+    """Fixture providing a temp cwd with release template set up."""
+    monkeypatch.chdir(tmp_path)
+    template_dir = tmp_path / ".github" / "ISSUE_TEMPLATE"
+    template_dir.mkdir(parents=True, exist_ok=True)
+    template_file = template_dir / "release_tracking_template.md"
+    template_file.write_text(DEFAULT_RELEASE_TEMPLATE_CONTENT, encoding="utf-8")

--- a/tests/tools/private/release/release_test_helper.py
+++ b/tests/tools/private/release/release_test_helper.py
@@ -1,8 +1,10 @@
+import dataclasses
 import os
 import pathlib
 import shutil
 import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -12,6 +14,17 @@ from tools.private.release.gh import (
     NoTrackingIssueError,
 )
 from tools.private.release.mock_gh import MockGitHub
+
+
+@dataclasses.dataclass
+class ReleaseToolEnv:
+    """Environment setup for testing release tools.
+
+    Attributes:
+        git_root: The root path of the temporary Git repository workspace.
+    """
+
+    git_root: Path
 
 
 def _mock_git(test_case):
@@ -105,3 +118,4 @@ def fixture_release_tool_env(tmp_path, monkeypatch):
     template_dir.mkdir(parents=True, exist_ok=True)
     template_file = template_dir / "release_tracking_template.md"
     template_file.write_text(DEFAULT_RELEASE_TEMPLATE_CONTENT, encoding="utf-8")
+    yield ReleaseToolEnv(git_root=tmp_path)

--- a/tests/tools/private/release/release_test_helper.py
+++ b/tests/tools/private/release/release_test_helper.py
@@ -1,18 +1,9 @@
 import dataclasses
-import os
-import pathlib
-import shutil
-import tempfile
-import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from tools.private.release.gh import (
-    MultipleTrackingIssuesError,
-    NoTrackingIssueError,
-)
 from tools.private.release.mock_gh import MockGitHub
 
 
@@ -27,46 +18,6 @@ class ReleaseToolEnv:
     git_root: Path
 
 
-def _mock_git(test_case):
-    mock_git = MagicMock()
-    test_case.mock_git = mock_git
-
-    # Mock Git inside utils.py since it instantiates it locally
-    patch("tools.private.release.utils.Git", return_value=mock_git).start()
-
-    test_case.addCleanup(patch.stopall)
-
-    # Apply safe defaults
-    mock_git.get_current_branch.return_value = None
-    mock_git.get_tags.return_value = []
-    mock_git.get_remote_tags.return_value = []
-    mock_git.status.return_value = ""
-    mock_git.branch_exists.return_value = False
-    mock_git.tag_exists.return_value = False
-    return mock_git
-
-
-def _mock_git_and_gh(test_case):
-    _mock_git(test_case)
-    mock_gh = MagicMock()
-    test_case.mock_gh = mock_gh
-
-    mock_gh.MultipleTrackingIssuesError = MultipleTrackingIssuesError
-    mock_gh.NoTrackingIssueError = NoTrackingIssueError
-
-    mock_gh.get_release_tracking_issue.side_effect = NoTrackingIssueError("Not found")
-    mock_gh.get_open_pr.return_value = None
-
-
-class TempDirTestCase(unittest.TestCase):
-    def setUp(self):
-        self.tmpdir = pathlib.Path(tempfile.mkdtemp())
-        self.original_cwd = os.getcwd()
-        self.addCleanup(shutil.rmtree, self.tmpdir)
-        os.chdir(self.tmpdir)
-        self.addCleanup(os.chdir, self.original_cwd)
-
-
 DEFAULT_RELEASE_TEMPLATE_CONTENT = (
     "template content\n"
     "- [ ] Prepare Release\n"
@@ -75,20 +26,6 @@ DEFAULT_RELEASE_TEMPLATE_CONTENT = (
     "\n"
     "## Backports\n"
 )
-
-
-class ReleaseToolTestCase(TempDirTestCase):
-    def setUp(self):
-        super().setUp()
-        self.gh = MockGitHub()
-        self.setUpReleaseTemplate()
-
-    def setUpReleaseTemplate(self):
-        template_dir = self.tmpdir / ".github/ISSUE_TEMPLATE"
-        template_dir.mkdir(parents=True, exist_ok=True)
-        self.template_file = template_dir / "release_tracking_template.md"
-        self.template_content = DEFAULT_RELEASE_TEMPLATE_CONTENT
-        self.template_file.write_text(self.template_content, encoding="utf-8")
 
 
 @pytest.fixture(name="mock_git")

--- a/tests/tools/private/release/utils_test.py
+++ b/tests/tools/private/release/utils_test.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import pytest
 
 from tools.private.release import utils
@@ -7,99 +5,111 @@ from tools.private.release import utils
 pytest_plugins = ["tests.tools.private.release.release_test_helper"]
 
 
-@patch("tools.private.release.git.Git.get_tags")
-def test_get_latest_version_success(mock_get_tags):
-    mock_get_tags.return_value = ["0.1.0", "1.0.0", "0.2.0"]
+def test_get_latest_version_success(mocker):
+    mocker.patch(
+        "tools.private.release.git.Git.get_tags",
+        return_value=["0.1.0", "1.0.0", "0.2.0"],
+    )
     assert utils.get_latest_version() == "1.0.0"
 
 
-@patch("tools.private.release.git.Git.get_tags")
-def test_get_latest_version_rc_is_latest(mock_get_tags):
-    mock_get_tags.return_value = ["0.1.0", "1.0.0", "1.1.0rc0"]
+def test_get_latest_version_rc_is_latest(mocker):
+    mocker.patch(
+        "tools.private.release.git.Git.get_tags",
+        return_value=["0.1.0", "1.0.0", "1.1.0rc0"],
+    )
     with pytest.raises(
         ValueError, match="The latest version is a pre-release version: 1.1.0rc0"
     ):
         utils.get_latest_version()
 
 
-@patch("tools.private.release.git.Git.get_tags")
-def test_get_latest_version_no_tags(mock_get_tags):
-    mock_get_tags.return_value = []
+def test_get_latest_version_no_tags(mocker):
+    mocker.patch("tools.private.release.git.Git.get_tags", return_value=[])
     with pytest.raises(
         RuntimeError, match="No git tags found matching X.Y.Z or X.Y.ZrcN format."
     ):
         utils.get_latest_version()
 
 
-@patch("tools.private.release.git.Git.get_tags")
-def test_get_latest_version_no_matching_tags(mock_get_tags):
-    mock_get_tags.return_value = ["v1.0", "latest"]
+def test_get_latest_version_no_matching_tags(mocker):
+    mocker.patch(
+        "tools.private.release.git.Git.get_tags", return_value=["v1.0", "latest"]
+    )
     with pytest.raises(
         RuntimeError, match="No git tags found matching X.Y.Z or X.Y.ZrcN format."
     ):
         utils.get_latest_version()
 
 
-@patch("tools.private.release.git.Git.get_tags")
-def test_get_latest_version_only_rc_tags(mock_get_tags):
-    mock_get_tags.return_value = ["1.0.0rc0", "1.1.0rc0"]
+def test_get_latest_version_only_rc_tags(mocker):
+    mocker.patch(
+        "tools.private.release.git.Git.get_tags", return_value=["1.0.0rc0", "1.1.0rc0"]
+    )
     with pytest.raises(
         ValueError, match="The latest version is a pre-release version: 1.1.0rc0"
     ):
         utils.get_latest_version()
 
 
-@patch("tools.private.release.git.Git.get_tags")
-def test_get_latest_rc_tag_no_tags(mock_get_tags):
-    mock_get_tags.return_value = []
+def test_get_latest_rc_tag_no_tags(mocker):
+    mocker.patch("tools.private.release.git.Git.get_tags", return_value=[])
     assert utils.get_latest_rc_tag("2.0.0") is None
 
 
-@patch("tools.private.release.git.Git.get_tags")
-def test_get_latest_rc_tag_no_matching_tags(mock_get_tags):
-    mock_get_tags.return_value = [
-        "1.0.0",
-        "2.0.0",
-        "v2.0.0-rc0",
-        "2.1.0-rc0",
-    ]
+def test_get_latest_rc_tag_no_matching_tags(mocker):
+    mocker.patch(
+        "tools.private.release.git.Git.get_tags",
+        return_value=[
+            "1.0.0",
+            "2.0.0",
+            "v2.0.0-rc0",
+            "2.1.0-rc0",
+        ],
+    )
     assert utils.get_latest_rc_tag("2.0.0") is None
 
 
-@patch("tools.private.release.git.Git.get_tags")
-def test_get_latest_rc_tag_success(mock_get_tags):
-    mock_get_tags.return_value = [
-        "2.0.0-rc0",
-        "2.0.0-rc2",
-        "2.0.0-rc1",
-        "2.1.0-rc0",
-    ]
+def test_get_latest_rc_tag_success(mocker):
+    mocker.patch(
+        "tools.private.release.git.Git.get_tags",
+        return_value=[
+            "2.0.0-rc0",
+            "2.0.0-rc2",
+            "2.0.0-rc1",
+            "2.1.0-rc0",
+        ],
+    )
     assert utils.get_latest_rc_tag("2.0.0") == "2.0.0-rc2"
 
 
-@patch("tools.private.release.git.Git.get_tags")
-def test_get_latest_rc_tag_ignores_v_prefix(mock_get_tags):
-    mock_get_tags.return_value = ["v2.0.0-rc0", "2.0.0-rc1"]
+def test_get_latest_rc_tag_ignores_v_prefix(mocker):
+    mocker.patch(
+        "tools.private.release.git.Git.get_tags",
+        return_value=["v2.0.0-rc0", "2.0.0-rc1"],
+    )
     assert utils.get_latest_rc_tag("2.0.0") == "2.0.0-rc1"
 
 
-@patch("tools.private.release.git.Git.get_remote_tags")
-def test_get_latest_rc_tag_remote_success(mock_get_remote_tags):
-    mock_get_remote_tags.return_value = [
-        "2.0.0-rc0",
-        "2.0.0-rc2",
-        "2.0.0-rc1",
-        "2.1.0-rc0",
-    ]
+def test_get_latest_rc_tag_remote_success(mocker):
+    mock_get_remote_tags = mocker.patch(
+        "tools.private.release.git.Git.get_remote_tags",
+        return_value=[
+            "2.0.0-rc0",
+            "2.0.0-rc2",
+            "2.0.0-rc1",
+            "2.1.0-rc0",
+        ],
+    )
     assert utils.get_latest_rc_tag("2.0.0", remote="origin") == "2.0.0-rc2"
     mock_get_remote_tags.assert_called_once_with("origin")
 
 
-@patch("tools.private.release.git.Git.get_current_branch", return_value="main")
-@patch("tools.private.release.utils.get_latest_version", return_value="1.2.3")
-def test_determine_next_version_no_markers(
-    mock_get_latest_version, mock_get_current_branch, release_tool_env
-):
+def test_determine_next_version_no_markers(mocker, release_tool_env):
+    mocker.patch(
+        "tools.private.release.git.Git.get_current_branch", return_value="main"
+    )
+    mocker.patch("tools.private.release.utils.get_latest_version", return_value="1.2.3")
     (release_tool_env.git_root / "mock_file.bzl").write_text("no markers here")
 
     next_version = utils.determine_next_version()
@@ -107,11 +117,11 @@ def test_determine_next_version_no_markers(
     assert next_version == "1.2.4"
 
 
-@patch("tools.private.release.git.Git.get_current_branch", return_value="main")
-@patch("tools.private.release.utils.get_latest_version", return_value="1.2.3")
-def test_determine_next_version_only_patch(
-    mock_get_latest_version, mock_get_current_branch, release_tool_env
-):
+def test_determine_next_version_only_patch(mocker, release_tool_env):
+    mocker.patch(
+        "tools.private.release.git.Git.get_current_branch", return_value="main"
+    )
+    mocker.patch("tools.private.release.utils.get_latest_version", return_value="1.2.3")
     (release_tool_env.git_root / "mock_file.bzl").write_text(
         ":::{versionchanged} VERSION_NEXT_PATCH"
     )
@@ -121,11 +131,11 @@ def test_determine_next_version_only_patch(
     assert next_version == "1.2.4"
 
 
-@patch("tools.private.release.git.Git.get_current_branch", return_value="main")
-@patch("tools.private.release.utils.get_latest_version", return_value="1.2.3")
-def test_determine_next_version_only_feature(
-    mock_get_latest_version, mock_get_current_branch, release_tool_env
-):
+def test_determine_next_version_only_feature(mocker, release_tool_env):
+    mocker.patch(
+        "tools.private.release.git.Git.get_current_branch", return_value="main"
+    )
+    mocker.patch("tools.private.release.utils.get_latest_version", return_value="1.2.3")
     (release_tool_env.git_root / "mock_file.bzl").write_text(
         ":::{versionadded} VERSION_NEXT_FEATURE"
     )
@@ -135,11 +145,11 @@ def test_determine_next_version_only_feature(
     assert next_version == "1.3.0"
 
 
-@patch("tools.private.release.git.Git.get_current_branch", return_value="main")
-@patch("tools.private.release.utils.get_latest_version", return_value="1.2.3")
-def test_determine_next_version_both_markers(
-    mock_get_latest_version, mock_get_current_branch, release_tool_env
-):
+def test_determine_next_version_both_markers(mocker, release_tool_env):
+    mocker.patch(
+        "tools.private.release.git.Git.get_current_branch", return_value="main"
+    )
+    mocker.patch("tools.private.release.utils.get_latest_version", return_value="1.2.3")
     (release_tool_env.git_root / "mock_file_patch.bzl").write_text(
         ":::{versionchanged} VERSION_NEXT_PATCH"
     )
@@ -152,37 +162,42 @@ def test_determine_next_version_both_markers(
     assert next_version == "1.3.0"
 
 
-@patch("tools.private.release.git.Git.get_current_branch", return_value="release/0.37")
-@patch("tools.private.release.git.Git.get_tags")
-def test_determine_next_version_on_release_branch_with_existing_tags(
-    mock_get_tags, mock_get_branch
-):
-    mock_get_tags.return_value = ["0.37.0", "0.37.1", "0.36.0"]
+def test_determine_next_version_on_release_branch_with_existing_tags(mocker):
+    mocker.patch(
+        "tools.private.release.git.Git.get_current_branch", return_value="release/0.37"
+    )
+    mocker.patch(
+        "tools.private.release.git.Git.get_tags",
+        return_value=["0.37.0", "0.37.1", "0.36.0"],
+    )
 
     next_version = utils.determine_next_version()
 
     assert next_version == "0.37.2"
 
 
-@patch("tools.private.release.git.Git.get_current_branch", return_value="release/0.38")
-@patch("tools.private.release.git.Git.get_tags")
-def test_determine_next_version_on_release_branch_no_tags(
-    mock_get_tags, mock_get_branch
-):
-    mock_get_tags.return_value = ["0.37.0"]  # No 0.38.x tags
+def test_determine_next_version_on_release_branch_no_tags(mocker):
+    mocker.patch(
+        "tools.private.release.git.Git.get_current_branch", return_value="release/0.38"
+    )
+    mocker.patch(
+        "tools.private.release.git.Git.get_tags", return_value=["0.37.0"]
+    )  # No 0.38.x tags
 
     next_version = utils.determine_next_version()
 
     assert next_version == "0.38.0"
 
 
-@patch("tools.private.release.git.Git.get_current_branch", return_value="release/0.37")
-@patch("tools.private.release.git.Git.get_tags")
-def test_determine_next_version_on_release_branch_with_active_rc(
-    mock_get_tags, mock_get_branch
-):
+def test_determine_next_version_on_release_branch_with_active_rc(mocker):
+    mocker.patch(
+        "tools.private.release.git.Git.get_current_branch", return_value="release/0.37"
+    )
     # 0.37.0-rc0 and rc1 exist, but no stable 0.37.0 yet
-    mock_get_tags.return_value = ["0.37.0-rc0", "0.37.0-rc1", "0.36.0"]
+    mocker.patch(
+        "tools.private.release.git.Git.get_tags",
+        return_value=["0.37.0-rc0", "0.37.0-rc1", "0.36.0"],
+    )
 
     next_version = utils.determine_next_version()
 
@@ -190,13 +205,17 @@ def test_determine_next_version_on_release_branch_with_active_rc(
     assert next_version == "0.37.0"
 
 
-@patch("tools.private.release.git.Git.get_current_branch", return_value="release/0.37")
-@patch("tools.private.release.git.Git.get_tags")
 def test_determine_next_version_on_release_branch_with_stable_and_active_patch_rc(
-    mock_get_tags, mock_get_branch
+    mocker,
 ):
+    mocker.patch(
+        "tools.private.release.git.Git.get_current_branch", return_value="release/0.37"
+    )
     # 0.37.0 stable exists, and 0.37.1-rc0 exists (but no stable 0.37.1 yet)
-    mock_get_tags.return_value = ["0.37.0", "0.37.1-rc0", "0.36.0"]
+    mocker.patch(
+        "tools.private.release.git.Git.get_tags",
+        return_value=["0.37.0", "0.37.1-rc0", "0.36.0"],
+    )
 
     next_version = utils.determine_next_version()
 
@@ -204,11 +223,11 @@ def test_determine_next_version_on_release_branch_with_stable_and_active_patch_r
     assert next_version == "0.37.1"
 
 
-@patch("tools.private.release.git.Git.get_current_branch", return_value="main")
-@patch("tools.private.release.utils.get_latest_version", return_value="1.2.3")
-def test_determine_next_version_on_main_branch_fallback(
-    mock_get_latest_version, mock_get_branch, release_tool_env
-):
+def test_determine_next_version_on_main_branch_fallback(mocker, release_tool_env):
+    mocker.patch(
+        "tools.private.release.git.Git.get_current_branch", return_value="main"
+    )
+    mocker.patch("tools.private.release.utils.get_latest_version", return_value="1.2.3")
     (release_tool_env.git_root / "mock_file.bzl").write_text("no markers here")
 
     next_version = utils.determine_next_version()

--- a/tests/tools/private/release/utils_test.py
+++ b/tests/tools/private/release/utils_test.py
@@ -1,213 +1,224 @@
-import unittest
 from unittest.mock import patch
 
-from tests.tools.private.release.release_test_helper import TempDirTestCase
+import pytest
+
 from tools.private.release import utils
 
-
-class GetLatestVersionTest(unittest.TestCase):
-    @patch("tools.private.release.git.Git.get_tags")
-    def test_get_latest_version_success(self, mock_get_tags):
-        mock_get_tags.return_value = ["0.1.0", "1.0.0", "0.2.0"]
-        self.assertEqual(utils.get_latest_version(), "1.0.0")
-
-    @patch("tools.private.release.git.Git.get_tags")
-    def test_get_latest_version_rc_is_latest(self, mock_get_tags):
-        mock_get_tags.return_value = ["0.1.0", "1.0.0", "1.1.0rc0"]
-        with self.assertRaisesRegex(
-            ValueError, "The latest version is a pre-release version: 1.1.0rc0"
-        ):
-            utils.get_latest_version()
-
-    @patch("tools.private.release.git.Git.get_tags")
-    def test_get_latest_version_no_tags(self, mock_get_tags):
-        mock_get_tags.return_value = []
-        with self.assertRaisesRegex(
-            RuntimeError, "No git tags found matching X.Y.Z or X.Y.ZrcN format."
-        ):
-            utils.get_latest_version()
-
-    @patch("tools.private.release.git.Git.get_tags")
-    def test_get_latest_version_no_matching_tags(self, mock_get_tags):
-        mock_get_tags.return_value = ["v1.0", "latest"]
-        with self.assertRaisesRegex(
-            RuntimeError, "No git tags found matching X.Y.Z or X.Y.ZrcN format."
-        ):
-            utils.get_latest_version()
-
-    @patch("tools.private.release.git.Git.get_tags")
-    def test_get_latest_version_only_rc_tags(self, mock_get_tags):
-        mock_get_tags.return_value = ["1.0.0rc0", "1.1.0rc0"]
-        with self.assertRaisesRegex(
-            ValueError, "The latest version is a pre-release version: 1.1.0rc0"
-        ):
-            utils.get_latest_version()
+pytest_plugins = ["tests.tools.private.release.release_test_helper"]
 
 
-class GetLatestRcTagTest(unittest.TestCase):
-    @patch("tools.private.release.git.Git.get_tags")
-    def test_get_latest_rc_tag_no_tags(self, mock_get_tags):
-        mock_get_tags.return_value = []
-        self.assertIsNone(utils.get_latest_rc_tag("2.0.0"))
-
-    @patch("tools.private.release.git.Git.get_tags")
-    def test_get_latest_rc_tag_no_matching_tags(self, mock_get_tags):
-        mock_get_tags.return_value = [
-            "1.0.0",
-            "2.0.0",
-            "v2.0.0-rc0",
-            "2.1.0-rc0",
-        ]
-        self.assertIsNone(utils.get_latest_rc_tag("2.0.0"))
-
-    @patch("tools.private.release.git.Git.get_tags")
-    def test_get_latest_rc_tag_success(self, mock_get_tags):
-        mock_get_tags.return_value = [
-            "2.0.0-rc0",
-            "2.0.0-rc2",
-            "2.0.0-rc1",
-            "2.1.0-rc0",
-        ]
-        self.assertEqual(utils.get_latest_rc_tag("2.0.0"), "2.0.0-rc2")
-
-    @patch("tools.private.release.git.Git.get_tags")
-    def test_get_latest_rc_tag_ignores_v_prefix(self, mock_get_tags):
-        mock_get_tags.return_value = ["v2.0.0-rc0", "2.0.0-rc1"]
-        self.assertEqual(utils.get_latest_rc_tag("2.0.0"), "2.0.0-rc1")
-
-    @patch("tools.private.release.git.Git.get_remote_tags")
-    def test_get_latest_rc_tag_remote_success(self, mock_get_remote_tags):
-        mock_get_remote_tags.return_value = [
-            "2.0.0-rc0",
-            "2.0.0-rc2",
-            "2.0.0-rc1",
-            "2.1.0-rc0",
-        ]
-        self.assertEqual(utils.get_latest_rc_tag("2.0.0", remote="origin"), "2.0.0-rc2")
-        mock_get_remote_tags.assert_called_once_with("origin")
+@patch("tools.private.release.git.Git.get_tags")
+def test_get_latest_version_success(mock_get_tags):
+    mock_get_tags.return_value = ["0.1.0", "1.0.0", "0.2.0"]
+    assert utils.get_latest_version() == "1.0.0"
 
 
-class DetermineNextVersionTest(TempDirTestCase):
-    def setUp(self):
-        super().setUp()
-        self.mock_get_latest_version = patch(
-            "tools.private.release.utils.get_latest_version"
-        ).start()
-        self.mock_get_current_branch = patch(
-            "tools.private.release.git.Git.get_current_branch"
-        ).start()
-        self.mock_get_current_branch.return_value = "main"
-        self.addCleanup(patch.stopall)
-
-    def test_no_markers(self):
-        (self.tmpdir / "mock_file.bzl").write_text("no markers here")
-        self.mock_get_latest_version.return_value = "1.2.3"
-
-        next_version = utils.determine_next_version()
-
-        self.assertEqual(next_version, "1.2.4")
-
-    def test_only_patch(self):
-        (self.tmpdir / "mock_file.bzl").write_text(
-            ":::{versionchanged} VERSION_NEXT_PATCH"
-        )
-        self.mock_get_latest_version.return_value = "1.2.3"
-
-        next_version = utils.determine_next_version()
-
-        self.assertEqual(next_version, "1.2.4")
-
-    def test_only_feature(self):
-        (self.tmpdir / "mock_file.bzl").write_text(
-            ":::{versionadded} VERSION_NEXT_FEATURE"
-        )
-        self.mock_get_latest_version.return_value = "1.2.3"
-
-        next_version = utils.determine_next_version()
-
-        self.assertEqual(next_version, "1.3.0")
-
-    def test_both_markers(self):
-        (self.tmpdir / "mock_file_patch.bzl").write_text(
-            ":::{versionchanged} VERSION_NEXT_PATCH"
-        )
-        (self.tmpdir / "mock_file_feature.bzl").write_text(
-            ":::{versionadded} VERSION_NEXT_FEATURE"
-        )
-        self.mock_get_latest_version.return_value = "1.2.3"
-
-        next_version = utils.determine_next_version()
-
-        self.assertEqual(next_version, "1.3.0")
-
-    @patch("tools.private.release.git.Git.get_current_branch")
-    @patch("tools.private.release.git.Git.get_tags")
-    def test_determine_next_version_on_release_branch_with_existing_tags(
-        self, mock_get_tags, mock_get_branch
+@patch("tools.private.release.git.Git.get_tags")
+def test_get_latest_version_rc_is_latest(mock_get_tags):
+    mock_get_tags.return_value = ["0.1.0", "1.0.0", "1.1.0rc0"]
+    with pytest.raises(
+        ValueError, match="The latest version is a pre-release version: 1.1.0rc0"
     ):
-        mock_get_branch.return_value = "release/0.37"
-        mock_get_tags.return_value = ["0.37.0", "0.37.1", "0.36.0"]
+        utils.get_latest_version()
 
-        next_version = utils.determine_next_version()
 
-        self.assertEqual(next_version, "0.37.2")
-
-    @patch("tools.private.release.git.Git.get_current_branch")
-    @patch("tools.private.release.git.Git.get_tags")
-    def test_determine_next_version_on_release_branch_no_tags(
-        self, mock_get_tags, mock_get_branch
+@patch("tools.private.release.git.Git.get_tags")
+def test_get_latest_version_no_tags(mock_get_tags):
+    mock_get_tags.return_value = []
+    with pytest.raises(
+        RuntimeError, match="No git tags found matching X.Y.Z or X.Y.ZrcN format."
     ):
-        mock_get_branch.return_value = "release/0.38"
-        mock_get_tags.return_value = ["0.37.0"]  # No 0.38.x tags
+        utils.get_latest_version()
 
-        next_version = utils.determine_next_version()
 
-        self.assertEqual(next_version, "0.38.0")
-
-    @patch("tools.private.release.git.Git.get_current_branch")
-    @patch("tools.private.release.git.Git.get_tags")
-    def test_determine_next_version_on_release_branch_with_active_rc(
-        self, mock_get_tags, mock_get_branch
+@patch("tools.private.release.git.Git.get_tags")
+def test_get_latest_version_no_matching_tags(mock_get_tags):
+    mock_get_tags.return_value = ["v1.0", "latest"]
+    with pytest.raises(
+        RuntimeError, match="No git tags found matching X.Y.Z or X.Y.ZrcN format."
     ):
-        mock_get_branch.return_value = "release/0.37"
-        # 0.37.0-rc0 and rc1 exist, but no stable 0.37.0 yet
-        mock_get_tags.return_value = ["0.37.0-rc0", "0.37.0-rc1", "0.36.0"]
+        utils.get_latest_version()
 
-        next_version = utils.determine_next_version()
 
-        # Should target 0.37.0, not 0.37.1
-        self.assertEqual(next_version, "0.37.0")
-
-    @patch("tools.private.release.git.Git.get_current_branch")
-    @patch("tools.private.release.git.Git.get_tags")
-    def test_determine_next_version_on_release_branch_with_stable_and_active_patch_rc(
-        self, mock_get_tags, mock_get_branch
+@patch("tools.private.release.git.Git.get_tags")
+def test_get_latest_version_only_rc_tags(mock_get_tags):
+    mock_get_tags.return_value = ["1.0.0rc0", "1.1.0rc0"]
+    with pytest.raises(
+        ValueError, match="The latest version is a pre-release version: 1.1.0rc0"
     ):
-        mock_get_branch.return_value = "release/0.37"
-        # 0.37.0 stable exists, and 0.37.1-rc0 exists (but no stable 0.37.1 yet)
-        mock_get_tags.return_value = ["0.37.0", "0.37.1-rc0", "0.36.0"]
-
-        next_version = utils.determine_next_version()
-
-        # Should target 0.37.1, not 0.37.2
-        self.assertEqual(next_version, "0.37.1")
-
-    @patch("tools.private.release.git.Git.get_current_branch")
-    def test_determine_next_version_on_main_branch_fallback(self, mock_get_branch):
-        mock_get_branch.return_value = "main"
-        # Should fallback to default behavior (which uses mock_get_latest_version from setUp)
-        self.mock_get_latest_version.return_value = "1.2.3"
-        (self.tmpdir / "mock_file.bzl").write_text("no markers here")
-
-        next_version = utils.determine_next_version()
-
-        self.assertEqual(next_version, "1.2.4")
+        utils.get_latest_version()
 
 
-class ReplaceVersionNextTest(TempDirTestCase):
-    def test_replace_version_next(self):
-        # Arrange
-        mock_file_content = """
+@patch("tools.private.release.git.Git.get_tags")
+def test_get_latest_rc_tag_no_tags(mock_get_tags):
+    mock_get_tags.return_value = []
+    assert utils.get_latest_rc_tag("2.0.0") is None
+
+
+@patch("tools.private.release.git.Git.get_tags")
+def test_get_latest_rc_tag_no_matching_tags(mock_get_tags):
+    mock_get_tags.return_value = [
+        "1.0.0",
+        "2.0.0",
+        "v2.0.0-rc0",
+        "2.1.0-rc0",
+    ]
+    assert utils.get_latest_rc_tag("2.0.0") is None
+
+
+@patch("tools.private.release.git.Git.get_tags")
+def test_get_latest_rc_tag_success(mock_get_tags):
+    mock_get_tags.return_value = [
+        "2.0.0-rc0",
+        "2.0.0-rc2",
+        "2.0.0-rc1",
+        "2.1.0-rc0",
+    ]
+    assert utils.get_latest_rc_tag("2.0.0") == "2.0.0-rc2"
+
+
+@patch("tools.private.release.git.Git.get_tags")
+def test_get_latest_rc_tag_ignores_v_prefix(mock_get_tags):
+    mock_get_tags.return_value = ["v2.0.0-rc0", "2.0.0-rc1"]
+    assert utils.get_latest_rc_tag("2.0.0") == "2.0.0-rc1"
+
+
+@patch("tools.private.release.git.Git.get_remote_tags")
+def test_get_latest_rc_tag_remote_success(mock_get_remote_tags):
+    mock_get_remote_tags.return_value = [
+        "2.0.0-rc0",
+        "2.0.0-rc2",
+        "2.0.0-rc1",
+        "2.1.0-rc0",
+    ]
+    assert utils.get_latest_rc_tag("2.0.0", remote="origin") == "2.0.0-rc2"
+    mock_get_remote_tags.assert_called_once_with("origin")
+
+
+@patch("tools.private.release.git.Git.get_current_branch", return_value="main")
+@patch("tools.private.release.utils.get_latest_version", return_value="1.2.3")
+def test_determine_next_version_no_markers(
+    mock_get_latest_version, mock_get_current_branch, release_tool_env
+):
+    (release_tool_env.git_root / "mock_file.bzl").write_text("no markers here")
+
+    next_version = utils.determine_next_version()
+
+    assert next_version == "1.2.4"
+
+
+@patch("tools.private.release.git.Git.get_current_branch", return_value="main")
+@patch("tools.private.release.utils.get_latest_version", return_value="1.2.3")
+def test_determine_next_version_only_patch(
+    mock_get_latest_version, mock_get_current_branch, release_tool_env
+):
+    (release_tool_env.git_root / "mock_file.bzl").write_text(
+        ":::{versionchanged} VERSION_NEXT_PATCH"
+    )
+
+    next_version = utils.determine_next_version()
+
+    assert next_version == "1.2.4"
+
+
+@patch("tools.private.release.git.Git.get_current_branch", return_value="main")
+@patch("tools.private.release.utils.get_latest_version", return_value="1.2.3")
+def test_determine_next_version_only_feature(
+    mock_get_latest_version, mock_get_current_branch, release_tool_env
+):
+    (release_tool_env.git_root / "mock_file.bzl").write_text(
+        ":::{versionadded} VERSION_NEXT_FEATURE"
+    )
+
+    next_version = utils.determine_next_version()
+
+    assert next_version == "1.3.0"
+
+
+@patch("tools.private.release.git.Git.get_current_branch", return_value="main")
+@patch("tools.private.release.utils.get_latest_version", return_value="1.2.3")
+def test_determine_next_version_both_markers(
+    mock_get_latest_version, mock_get_current_branch, release_tool_env
+):
+    (release_tool_env.git_root / "mock_file_patch.bzl").write_text(
+        ":::{versionchanged} VERSION_NEXT_PATCH"
+    )
+    (release_tool_env.git_root / "mock_file_feature.bzl").write_text(
+        ":::{versionadded} VERSION_NEXT_FEATURE"
+    )
+
+    next_version = utils.determine_next_version()
+
+    assert next_version == "1.3.0"
+
+
+@patch("tools.private.release.git.Git.get_current_branch", return_value="release/0.37")
+@patch("tools.private.release.git.Git.get_tags")
+def test_determine_next_version_on_release_branch_with_existing_tags(
+    mock_get_tags, mock_get_branch
+):
+    mock_get_tags.return_value = ["0.37.0", "0.37.1", "0.36.0"]
+
+    next_version = utils.determine_next_version()
+
+    assert next_version == "0.37.2"
+
+
+@patch("tools.private.release.git.Git.get_current_branch", return_value="release/0.38")
+@patch("tools.private.release.git.Git.get_tags")
+def test_determine_next_version_on_release_branch_no_tags(
+    mock_get_tags, mock_get_branch
+):
+    mock_get_tags.return_value = ["0.37.0"]  # No 0.38.x tags
+
+    next_version = utils.determine_next_version()
+
+    assert next_version == "0.38.0"
+
+
+@patch("tools.private.release.git.Git.get_current_branch", return_value="release/0.37")
+@patch("tools.private.release.git.Git.get_tags")
+def test_determine_next_version_on_release_branch_with_active_rc(
+    mock_get_tags, mock_get_branch
+):
+    # 0.37.0-rc0 and rc1 exist, but no stable 0.37.0 yet
+    mock_get_tags.return_value = ["0.37.0-rc0", "0.37.0-rc1", "0.36.0"]
+
+    next_version = utils.determine_next_version()
+
+    # Should target 0.37.0, not 0.37.1
+    assert next_version == "0.37.0"
+
+
+@patch("tools.private.release.git.Git.get_current_branch", return_value="release/0.37")
+@patch("tools.private.release.git.Git.get_tags")
+def test_determine_next_version_on_release_branch_with_stable_and_active_patch_rc(
+    mock_get_tags, mock_get_branch
+):
+    # 0.37.0 stable exists, and 0.37.1-rc0 exists (but no stable 0.37.1 yet)
+    mock_get_tags.return_value = ["0.37.0", "0.37.1-rc0", "0.36.0"]
+
+    next_version = utils.determine_next_version()
+
+    # Should target 0.37.1, not 0.37.2
+    assert next_version == "0.37.1"
+
+
+@patch("tools.private.release.git.Git.get_current_branch", return_value="main")
+@patch("tools.private.release.utils.get_latest_version", return_value="1.2.3")
+def test_determine_next_version_on_main_branch_fallback(
+    mock_get_latest_version, mock_get_branch, release_tool_env
+):
+    (release_tool_env.git_root / "mock_file.bzl").write_text("no markers here")
+
+    next_version = utils.determine_next_version()
+
+    assert next_version == "1.2.4"
+
+
+def test_replace_version_next(release_tool_env):
+    # Arrange
+    mock_file_content = """
 :::{versionadded} VERSION_NEXT_FEATURE
 blabla
 :::
@@ -216,51 +227,47 @@ blabla
 blabla
 :::
 """
-        (self.tmpdir / "mock_file.bzl").write_text(mock_file_content)
+    (release_tool_env.git_root / "mock_file.bzl").write_text(mock_file_content)
 
-        utils.replace_version_next("0.28.0")
+    utils.replace_version_next("0.28.0")
 
-        new_content = (self.tmpdir / "mock_file.bzl").read_text()
+    new_content = (release_tool_env.git_root / "mock_file.bzl").read_text()
 
-        self.assertIn(":::{versionadded} 0.28.0", new_content)
-        self.assertIn(":::{versionadded} 0.28.0", new_content)
-        self.assertNotIn("VERSION_NEXT_FEATURE", new_content)
-        self.assertNotIn("VERSION_NEXT_PATCH", new_content)
+    assert ":::{versionadded} 0.28.0" in new_content
+    assert "VERSION_NEXT_FEATURE" not in new_content
+    assert "VERSION_NEXT_PATCH" not in new_content
 
-    def test_replace_version_next_excludes_bazel_dirs(self):
-        # Arrange
-        mock_file_content = """
+
+def test_replace_version_next_excludes_bazel_dirs(release_tool_env):
+    # Arrange
+    mock_file_content = """
 :::{versionadded} VERSION_NEXT_FEATURE
 blabla
 :::
 """
-        bazel_dir = self.tmpdir / "bazel-rules_python"
-        bazel_dir.mkdir()
-        (bazel_dir / "mock_file.bzl").write_text(mock_file_content)
+    bazel_dir = release_tool_env.git_root / "bazel-rules_python"
+    bazel_dir.mkdir()
+    (bazel_dir / "mock_file.bzl").write_text(mock_file_content)
 
-        tools_dir = self.tmpdir / "tools" / "private" / "release"
-        tools_dir.mkdir(parents=True)
-        (tools_dir / "mock_file.bzl").write_text(mock_file_content)
+    tools_dir = release_tool_env.git_root / "tools" / "private" / "release"
+    tools_dir.mkdir(parents=True)
+    (tools_dir / "mock_file.bzl").write_text(mock_file_content)
 
-        tests_dir = self.tmpdir / "tests" / "tools" / "private" / "release"
-        tests_dir.mkdir(parents=True)
-        (tests_dir / "mock_file.bzl").write_text(mock_file_content)
+    tests_dir = release_tool_env.git_root / "tests" / "tools" / "private" / "release"
+    tests_dir.mkdir(parents=True)
+    (tests_dir / "mock_file.bzl").write_text(mock_file_content)
 
-        version = "0.28.0"
+    version = "0.28.0"
 
-        # Act
-        utils.replace_version_next(version)
+    # Act
+    utils.replace_version_next(version)
 
-        # Assert
-        new_content = (bazel_dir / "mock_file.bzl").read_text()
-        self.assertIn("VERSION_NEXT_FEATURE", new_content)
+    # Assert
+    new_content = (bazel_dir / "mock_file.bzl").read_text()
+    assert "VERSION_NEXT_FEATURE" in new_content
 
-        new_content = (tools_dir / "mock_file.bzl").read_text()
-        self.assertIn("VERSION_NEXT_FEATURE", new_content)
+    new_content = (tools_dir / "mock_file.bzl").read_text()
+    assert "VERSION_NEXT_FEATURE" in new_content
 
-        new_content = (tests_dir / "mock_file.bzl").read_text()
-        self.assertIn("VERSION_NEXT_FEATURE", new_content)
-
-
-if __name__ == "__main__":
-    unittest.main()
+    new_content = (tests_dir / "mock_file.bzl").read_text()
+    assert "VERSION_NEXT_FEATURE" in new_content

--- a/tools/private/release/backport_create_releases.py
+++ b/tools/private/release/backport_create_releases.py
@@ -162,7 +162,7 @@ class BackportCreateReleases:
                         )
                         new_issue_num = "<NEW_ISSUE_NUM>"
                     else:
-                        new_issue_num = self._gh.create_tracking_issue(
+                        new_issue_num = self._gh.create_release_tracking_issue(
                             version, issue_template
                         )
                         print(

--- a/tools/private/release/create_release_issue.py
+++ b/tools/private/release/create_release_issue.py
@@ -42,7 +42,7 @@ class CreateReleaseIssue:
             lines = [line for line in lines if not re.search(r"Tag RC\d+", line)]
             template_content = "\n".join(lines)
 
-        issue_num = self.gh.create_tracking_issue(version, template_content)
+        issue_num = self.gh.create_release_tracking_issue(version, template_content)
         print(f"Created tracking issue #{issue_num} for v{version}")
         return 0
 

--- a/tools/private/release/gh.py
+++ b/tools/private/release/gh.py
@@ -1,9 +1,11 @@
 """GitHub CLI helper functions for the release tool."""
 
+import enum
 import json
 import os
 import re
 import tempfile
+from typing import TypedDict
 
 from tools.private.release.release_issue import BackportTask
 from tools.private.release.shell import run_cmd
@@ -22,6 +24,71 @@ GH_REACTION_HEART = "heart"
 GH_REACTION_HOORAY = "hooray"
 GH_REACTION_ROCKET = "rocket"
 GH_REACTION_EYES = "eyes"
+
+
+class BackportTaskStatus(str, enum.Enum):
+    """Status strings for backport tasks on a release tracking issue."""
+
+    PENDING = "pending"
+    DONE = "done"
+    RESOLVED = "resolved"
+    OPEN_PR = "open-pr"
+    DRAFT_PR = "draft-pr"
+    ERROR_NOT_FOUND = "error-not-found"
+    ERROR_CLOSED_PR = "error-closed-pr"
+    ERROR_NO_MERGE_COMMIT = "error-no-merge-commit"
+    ERROR_UNKNOWN = "error-unknown"
+    ERROR_RESOLUTION_FAILED = "error-resolution-failed"
+    ERROR_MERGE_CONFLICT = "error-merge-conflict"
+    ERROR_INVALID_PR = "error-invalid-pr"
+    IGNORE = "ignore"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class IssueDict(TypedDict, total=False):
+    """In-memory representation of a GitHub Issue object.
+
+    See GitHub API docs:
+    https://docs.github.com/en/rest/issues/issues#get-an-issue
+    """
+
+    number: int
+    title: str
+    body: str
+    labels: list[str]
+    url: str
+
+
+class AutoMergeDict(TypedDict, total=False):
+    """Representation of auto-merge status on a Pull Request.
+
+    See GitHub API docs:
+    https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request
+    """
+
+    merge_method: str
+
+
+class PrDict(TypedDict, total=False):
+    """In-memory representation of a GitHub Pull Request object.
+
+    See GitHub API docs:
+    https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request
+    """
+
+    number: int
+    title: str
+    body: str
+    base: str
+    head: str
+    labels: list[str]
+    url: str
+    state: str
+    isDraft: bool
+    mergeCommit: dict[str, str]
+    auto_merge: AutoMergeDict | None
 
 
 class MultipleTrackingIssuesError(ValueError):
@@ -93,97 +160,107 @@ class GitHub:
         label: str | None = None,
         state: str | None = None,
         search: str | None = None,
-    ) -> list[dict]:
+    ) -> list[IssueDict]:
         """Helper to list issues using gh CLI.
 
         Args:
             fields: Comma-separated list of fields to return.
             label: Filter by label.
-            state: Filter by state (open, closed, all).
+            state: Filter by state ('open', 'closed', 'all').
             search: Search query.
 
         Returns:
-            A list of dictionaries representing the issues.
+            A list of issue dictionaries.
         """
-        cmd = ["list"]
+        cmd = ["list", f"--json={fields}"]
         if label:
             cmd.append(f"--label={label}")
         if state:
             cmd.append(f"--state={state}")
         if search:
             cmd.append(f"--search={search}")
-        cmd.append(f"--json={fields}")
 
         output = self._gh_issue(*cmd)
         return json.loads(output) if output else []
 
-    def get_open_tracking_issues(self, version: str | None = None) -> list[dict]:
-        """Returns a list of open tracking issues with the 'type: release' label.
+    def get_open_tracking_issues(self, version: str | None = None) -> list[IssueDict]:
+        """Finds open tracking issues for release.
 
         Args:
-            version: Optional version to filter by.
+            version: Optional specific version to match (e.g., "1.0.0").
 
         Returns:
-            A list of open tracking issues.
+            List of matching open release tracking issue dictionaries.
         """
-        search = f'"Release {version}" in:title' if version else None
+        search = f"Release {version}" if version else None
         return self.list_issues(
+            fields="number,title,url",
             label=RELEASE_LABEL,
             state="open",
             search=search,
-            fields="number,title,url",
         )
 
     def get_release_tracking_issue(self, version: str) -> int:
-        """Resolves the tracking issue number for a given version.
-
-        Searches for an open issue with label 'type: release' and 'Release
-        <version>' in the title.
+        """Finds the single open tracking issue for a given version.
 
         Args:
-            version: The version to find the tracking issue for.
+            version: Version string (e.g. "1.0.0").
 
         Returns:
-            The tracking issue number.
+            The issue number.
 
         Raises:
             NoTrackingIssueError: If no open tracking issue is found.
-            MultipleTrackingIssuesError: If multiple open tracking issues are
-              found.
+            MultipleTrackingIssuesError: If multiple open tracking issues are found.
         """
-        matching_issues = self.get_open_tracking_issues(version)
-
-        exact_matches = []
-        for issue in matching_issues:
-            if issue["title"] == f"Release {version}":
-                exact_matches.append(issue)
-
-        if not exact_matches:
+        issues = self.get_open_tracking_issues(version)
+        matching = [i for i in issues if i["title"] == f"Release {version}"]
+        if not matching:
             raise NoTrackingIssueError(
-                f"No open tracking issue found matching 'Release {version}' "
-                f"in repo {self.repo} with label '{RELEASE_LABEL}'"
+                f"No open tracking issue found for Release {version}"
             )
-        if len(exact_matches) > 1:
-            urls = [issue["url"] for issue in exact_matches]
+        if len(matching) > 1:
             raise MultipleTrackingIssuesError(
-                f"Multiple open tracking issues found for version {version} "
-                f"in repo {self.repo} with label '{RELEASE_LABEL}':\n" + "\n".join(urls)
+                f"Multiple open tracking issues found for Release {version}: "
+                + ", ".join(str(i["number"]) for i in matching)
             )
+        return matching[0]["number"]
 
-        return exact_matches[0]["number"]
-
-    def create_tracking_issue(self, version: str, template_content: str) -> int:
-        """Creates a new release tracking issue from template content.
-
-        Strips YAML frontmatter if present.
+    def create_issue(
+        self, title: str, body: str, labels: list[str] | None = None
+    ) -> int:
+        """Creates an issue using gh CLI.
 
         Args:
-            version: The version to create the tracking issue for.
-            template_content: The markdown template content for the issue body.
+            title: Title of the issue.
+            body: Body of the issue.
+            labels: List of labels to add.
+
+        Returns:
+            The issue number.
+        """
+        cmd = ["create", f"--title={title}", f"--body={body}"]
+        if labels:
+            for label in labels:
+                cmd.append(f"--label={label}")
+
+        output = self._gh_issue(*cmd)
+        if not output:
+            raise RuntimeError("gh issue create returned no output")
+        # output is URL: https://github.com/owner/repo/issues/123
+        return int(output.rstrip("/").split("/")[-1])
+
+    def create_release_tracking_issue(self, version: str, template_content: str) -> int:
+        """Creates a release tracking issue from a template.
+
+        Args:
+            version: Release version string (e.g., "1.0.0").
+            template_content: Content of the issue template markdown file.
 
         Returns:
             The created issue number.
         """
+        title = f"Release {version}"
         # Strip YAML frontmatter if present
         issue_body = template_content
         if template_content.startswith("---"):
@@ -191,110 +268,111 @@ class GitHub:
             if len(parts) >= 3:
                 issue_body = parts[2].strip()
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".md") as f:
-            f.write(issue_body)
-            f.flush()
-            temp_path = f.name
-
-            output = self._gh_issue(
-                "create",
-                f"--title=Release {version}",
-                f"--label={RELEASE_LABEL}",
-                f"--body-file={temp_path}",
-            )
-            if not output:
-                raise RuntimeError("Failed to get issue URL from gh issue create")
-            issue_url = output.strip()
-            issue_num = int(issue_url.split("/")[-1])
-            return issue_num
-
-    def create_issue(
-        self, title: str, body: str, labels: list[str] | None = None
-    ) -> int:
-        """Creates a generic issue.
-
-        Args:
-            title: The title of the issue.
-            body: The body of the issue.
-            labels: Optional list of labels to add.
-
-        Returns:
-            The created issue number.
-        """
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".md") as f:
-            f.write(body)
-            f.flush()
-            temp_path = f.name
-
-            cmd = [
-                "create",
-                f"--title={title}",
-                f"--body-file={temp_path}",
-            ]
-            if labels:
-                for label in labels:
-                    cmd.append(f"--label={label}")
-
-            output = self._gh_issue(*cmd)
-            if not output:
-                raise RuntimeError("Failed to get issue URL from gh issue create")
-            issue_url = output.strip()
-            issue_num = int(issue_url.split("/")[-1])
-            return issue_num
+        return self.create_issue(title=title, body=issue_body, labels=[RELEASE_LABEL])
 
     def get_issue_body(self, issue_num: int) -> str:
-        """Fetches the body of a specific issue.
+        """Gets the body content of an issue.
 
         Args:
             issue_num: The issue number.
 
         Returns:
-            The issue body markdown.
+            The body string of the issue.
         """
-        output = self._gh_issue(
-            "view",
-            str(issue_num),
-            "--json=body",
-            "--jq=.body",
-        )
-        return output if output else ""
+        output = self._gh_issue("view", str(issue_num), "--json=body")
+        if not output:
+            return ""
+        data = json.loads(output)
+        return data.get("body", "")
 
     def get_issue_title(self, issue_num: int) -> str:
-        """Fetches the title of a specific issue.
+        """Gets the title of an issue.
 
         Args:
             issue_num: The issue number.
 
         Returns:
-            The issue title.
+            The title string of the issue.
         """
-        output = self._gh_issue(
-            "view",
-            str(issue_num),
-            "--json=title",
-        )
-        return json.loads(output)["title"] if output else ""
+        output = self._gh_issue("view", str(issue_num), "--json=title")
+        if not output:
+            return ""
+        data = json.loads(output)
+        return data.get("title", "")
 
     def update_issue_body(self, issue_num: int, body: str) -> None:
-        """Updates the body of a specific issue.
+        """Updates the body of an issue.
 
         Args:
             issue_num: The issue number.
-            body: The new issue body markdown.
+            body: The new body content.
         """
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+        with tempfile.NamedTemporaryFile("w", delete=False, mode="w") as f:
             f.write(body)
+            f.flush()
             temp_path = f.name
+
         try:
             self._gh_issue(
-                "edit",
-                str(issue_num),
-                f"--body-file={temp_path}",
-                capture_output=False,
+                "edit", str(issue_num), f"--body-file={temp_path}", capture_output=False
             )
         finally:
             if os.path.exists(temp_path):
-                os.unlink(temp_path)
+                os.remove(temp_path)
+
+    def resolve_pr_number(self, pr_ref: str) -> int:
+        """Resolves a PR reference (number, #number, or GitHub URL) to a PR number.
+
+        Args:
+            pr_ref: PR number string (e.g., "123", "#123") or URL.
+
+        Returns:
+            The integer PR number.
+
+        Raises:
+            ValueError: If the PR reference cannot be resolved or is for another repo.
+        """
+        clean_ref = pr_ref.lstrip("#")
+        if clean_ref.isdigit():
+            return int(clean_ref)
+
+        if pr_ref.startswith("http"):
+            pattern = rf"github\.com/{re.escape(self.repo)}/pull/(\d+)(/|\?|\Z)"
+            match = re.search(pattern, pr_ref, re.IGNORECASE)
+            if match:
+                return int(match.group(1))
+            raise ValueError(
+                f"URL is not for the configured repository ({self.repo}): {pr_ref}"
+            )
+
+        raise ValueError(f"Could not resolve PR reference: {pr_ref}")
+
+    def get_pr_info(self, pr_num: int) -> PrDict:
+        """Gets info about a PR using gh CLI.
+
+        Args:
+            pr_num: The PR number.
+
+        Returns:
+            Dictionary containing PR fields (state, isDraft, mergeCommit, etc.).
+        """
+        output = self._gh_pr("view", str(pr_num), "--json=state,isDraft,mergeCommit")
+        return json.loads(output) if output else {}
+
+    def get_pr_comments(self, pr_num: int) -> list[dict]:
+        """Gets all comments for a PR using gh CLI.
+
+        Args:
+            pr_num: The PR number.
+
+        Returns:
+            List of comment objects (with body, author, etc.).
+        """
+        output = self._gh_pr("view", str(pr_num), "--json=comments")
+        if not output:
+            return []
+        data = json.loads(output)
+        return data.get("comments", [])
 
     def create_pr(
         self,
@@ -306,10 +384,10 @@ class GitHub:
         """Creates a pull request.
 
         Args:
-            title: The title of the PR.
-            body: The body of the PR.
-            base: The base branch to merge into (default: 'main').
-            labels: Optional list of labels to add to the PR.
+            title: Title of the PR.
+            body: Body of the PR.
+            base: Base branch to merge into (default: "main").
+            labels: Optional list of labels to add.
 
         Returns:
             The URL of the created PR.
@@ -342,95 +420,31 @@ class GitHub:
             cmd.append("--merge")
         self._gh_pr(*cmd, capture_output=False)
 
-    def get_open_pr(self, branch_name: str) -> dict | None:
-        """Returns PR info if an open PR exists for the given branch.
+    def get_open_pr(self, branch_name: str) -> PrDict | None:
+        """Finds an open PR for the given branch.
 
         Args:
-            branch_name: The head branch name of the PR.
+            branch_name: The head branch name to search for.
 
         Returns:
-            A dictionary with 'number' and 'url' of the PR, or None.
+            Dictionary with 'number' and 'url' if an open PR exists, else None.
         """
-        output = self._gh_pr(
+        cmd = [
             "list",
             f"--head={branch_name}",
             "--state=open",
             "--json=number,url",
-        )
+        ]
+        output = self._gh_pr(*cmd)
         prs = json.loads(output) if output else []
         return prs[0] if prs else None
 
-    def get_pr_info(self, pr_num: int) -> dict:
-        """Gets information about a PR.
-
-        Includes state, merge commit, body, and draft status.
-
-        Args:
-            pr_num: The PR number.
-
-        Returns:
-            A dictionary containing the PR info.
-        """
-        output = self._gh_pr(
-            "view",
-            str(pr_num),
-            "--json=state,mergeCommit,body,isDraft",
-        )
-        return json.loads(output) if output else {}
-
-    def get_pr_comments(self, pr_num: int) -> list[dict]:
-        """Gets comments for a PR.
-
-        Args:
-            pr_num: The PR number.
-
-        Returns:
-            A list of comments.
-        """
-        output = self._gh_pr(
-            "view",
-            str(pr_num),
-            "--json=comments",
-        )
-        return json.loads(output).get("comments") or []
-
-    def resolve_pr_number(self, pr_ref: str) -> int:
-        """Resolves a PR reference (number, #number, URL) to a PR number.
-
-        Args:
-            pr_ref: The PR reference string.
-
-        Returns:
-            The resolved PR number.
-
-        Raises:
-            ValueError: If the reference cannot be resolved.
-        """
-        # 1. Try number (e.g. "123" or "#123")
-        clean_ref = pr_ref.lstrip("#")
-        if clean_ref.isdigit():
-            return int(clean_ref)
-
-        # 2. Try URL (starts with http)
-        if pr_ref.startswith("http"):
-            # Try to extract PR number from URL using regex
-            # Pattern matches: github.com/<self.repo>/pull/<number> followed by /, ?, or EOF
-            pattern = rf"github\.com/{re.escape(self.repo)}/pull/(\d+)(/|\?|\Z)"
-            match = re.search(pattern, pr_ref, re.IGNORECASE)
-            if match:
-                return int(match.group(1))
-            raise ValueError(
-                f"URL is not for the configured repository ({self.repo}): {pr_ref}"
-            )
-
-        raise ValueError(f"Could not resolve PR reference: {pr_ref}")
-
     def post_issue_comment(self, issue_num: int, comment_body: str) -> None:
-        """Posts a comment to a specific issue.
+        """Posts a comment on an issue or PR.
 
         Args:
-            issue_num: The issue number.
-            comment_body: The comment body markdown.
+            issue_num: The issue or PR number.
+            comment_body: The body content of the comment.
         """
         self._gh_issue(
             "comment",
@@ -440,22 +454,15 @@ class GitHub:
         )
 
     def add_comment_reaction(self, comment_id: int, reaction: str) -> None:
-        """Adds a reaction to a comment.
+        """Adds a reaction to an issue or PR comment.
 
         Args:
-            comment_id: The ID of the comment.
-            reaction: The reaction type (e.g. '+1', '-1', 'eyes', etc).
+            comment_id: The comment ID (note: gh api endpoint needed for comment reactions).
+            reaction: The reaction type (e.g., "+1", "-1", "rocket").
         """
-        path = f"/repos/{self.repo}/issues/comments/{comment_id}/reactions"
         self._run_gh(
             "api",
-            "--method",
-            "POST",
-            "-H",
-            "Accept: application/vnd.github+json",
-            "-H",
-            "X-GitHub-Api-Version: 2022-11-28",
-            path,
+            f"repos/{self.repo}/issues/comments/{comment_id}/reactions",
             "-f",
             f"content={reaction}",
             capture_output=False,
@@ -474,40 +481,61 @@ class GitHub:
         Returns:
             The list of resolved BackportTask items.
         """
-        resolved_items = []
-        for item in pending_items:
-            pr_num = int(item.pr_ref.lstrip("#"))
-            print(f"Resolving PR #{pr_num} to merge commit...")
-            try:
-                pr_info = self.get_pr_info(pr_num)
-                if not pr_info:
-                    print(f"PR #{pr_num} not found. Gating.")
-                    item.status = "error-not-found"
-                else:
-                    state = pr_info.get("state")
-                    is_draft = pr_info.get("isDraft", False)
-                    if state == "OPEN" or is_draft:
-                        print(
-                            f"PR #{pr_num} is open or draft (state: {state},"
-                            f" draft: {is_draft}). Ignoring."
-                        )
-                        item.status = "open-pr" if not is_draft else "draft-pr"
-                    elif state == "CLOSED":
-                        print(f"PR #{pr_num} is closed but not merged. Gating.")
-                        item.status = "error-closed-pr"
-                    elif state == "MERGED":
-                        merge_commit = pr_info.get("mergeCommit")
-                        if merge_commit and "oid" in merge_commit:
-                            item.commit = merge_commit["oid"]
-                            item.status = "resolved"
-                        else:
-                            print(f"PR #{pr_num} has no merge commit SHA. Gating.")
-                            item.status = "error-no-merge-commit"
+        return resolve_merge_commits_for_prs(self, pending_items)
+
+
+def resolve_merge_commits_for_prs(
+    gh_client: GitHub, pending_items: list[BackportTask]
+) -> list[BackportTask]:
+    """Resolves PR references in pending backports to their merge commit SHAs.
+
+    Updates item.status based on PR state if it cannot be resolved.
+
+    Args:
+        gh_client: The GitHub client.
+        pending_items: A list of BackportTask items to resolve.
+
+    Returns:
+        The list of resolved BackportTask items.
+    """
+    resolved_items = []
+    for item in pending_items:
+        pr_num = int(item.pr_ref.lstrip("#"))
+        print(f"Resolving PR #{pr_num} to merge commit...")
+        try:
+            pr_info = gh_client.get_pr_info(pr_num)
+            if not pr_info:
+                print(f"PR #{pr_num} not found. Gating.")
+                item.status = BackportTaskStatus.ERROR_NOT_FOUND
+            else:
+                state = pr_info.get("state")
+                is_draft = pr_info.get("isDraft", False)
+                if state == "OPEN" or is_draft:
+                    print(
+                        f"PR #{pr_num} is open or draft (state: {state},"
+                        f" draft: {is_draft}). Ignoring."
+                    )
+                    item.status = (
+                        BackportTaskStatus.OPEN_PR
+                        if not is_draft
+                        else BackportTaskStatus.DRAFT_PR
+                    )
+                elif state == "CLOSED":
+                    print(f"PR #{pr_num} is closed but not merged. Gating.")
+                    item.status = BackportTaskStatus.ERROR_CLOSED_PR
+                elif state == "MERGED":
+                    merge_commit = pr_info.get("mergeCommit")
+                    if merge_commit and "oid" in merge_commit:
+                        item.commit = merge_commit["oid"]
+                        item.status = BackportTaskStatus.RESOLVED
                     else:
-                        print(f"PR #{pr_num} has unknown state: {state}. Gating.")
-                        item.status = "error-unknown"
-            except Exception as e:
-                print(f"Error resolving PR #{pr_num}: {e}. Gating.")
-                item.status = "error-resolution-failed"
-            resolved_items.append(item)
-        return resolved_items
+                        print(f"PR #{pr_num} has no merge commit SHA. Gating.")
+                        item.status = BackportTaskStatus.ERROR_NO_MERGE_COMMIT
+                else:
+                    print(f"PR #{pr_num} has unknown state: {state}. Gating.")
+                    item.status = BackportTaskStatus.ERROR_UNKNOWN
+        except Exception as e:
+            print(f"Error resolving PR #{pr_num}: {e}. Gating.")
+            item.status = BackportTaskStatus.ERROR_RESOLUTION_FAILED
+        resolved_items.append(item)
+    return resolved_items

--- a/tools/private/release/mock_gh.py
+++ b/tools/private/release/mock_gh.py
@@ -2,15 +2,36 @@
 
 import re
 
-from tools.private.release.gh import RELEASE_LABEL
+from tools.private.release.gh import (
+    RELEASE_LABEL,
+    IssueDict,
+    MultipleTrackingIssuesError,
+    NoTrackingIssueError,
+    PrDict,
+    resolve_merge_commits_for_prs,
+)
 
 
 class MockGitHub:
     def __init__(self, repo: str = "bazel-contrib/rules_python"):
         self.repo = repo
-        self.issues = {}
+        self.issues: dict[int, IssueDict] = {}
         self.next_issue_num = 1001
-        self.prs = {}  # num -> pr_info
+        self.prs: dict[int, PrDict] = {}  # num -> pr_info
+        self.issue_comments: dict[int, list[str]] = {}
+        self.reactions: dict[int, list[str]] = {}
+        self.pr_comments: dict[int, list[dict]] = {}
+
+    def post_issue_comment(self, issue_num: int, comment_body: str) -> None:
+        self.issue_comments.setdefault(issue_num, []).append(comment_body)
+
+    def add_comment_reaction(self, comment_id: int, reaction: str) -> None:
+        self.reactions.setdefault(comment_id, []).append(reaction)
+
+    def enable_auto_merge(self, pr_num: int, method: str = "squash") -> None:
+        if pr_num not in self.prs:
+            self.create_pr(title="", body="")
+        self.prs[pr_num]["auto_merge"] = {"merge_method": method}
 
     def create_issue(
         self, title: str, body: str, labels: list[str] | None = None
@@ -26,7 +47,7 @@ class MockGitHub:
         }
         return issue_num
 
-    def create_tracking_issue(self, version: str, template_content: str) -> int:
+    def create_release_tracking_issue(self, version: str, template_content: str) -> int:
         # Strip YAML frontmatter if present (simplified copy from gh.py)
         issue_body = template_content
         if template_content.startswith("---"):
@@ -42,6 +63,11 @@ class MockGitHub:
         if issue_num not in self.issues:
             raise ValueError(f"Issue #{issue_num} not found in MockGitHub")
         return self.issues[issue_num]["body"]
+
+    def get_issue_title(self, issue_num: int) -> str:
+        if issue_num not in self.issues:
+            raise ValueError(f"Issue #{issue_num} not found in MockGitHub")
+        return self.issues[issue_num]["title"]
 
     def update_issue_body(self, issue_num: int, body: str):
         if issue_num not in self.issues:
@@ -64,7 +90,52 @@ class MockGitHub:
             )
         raise ValueError(f"Could not resolve PR ref: {pr_ref}")
 
-    def get_open_tracking_issues(self, version: str | None = None) -> list[dict]:
+    def get_release_tracking_issue(self, version: str) -> int:
+        search_title = f"Release {version}"
+        matching = [
+            num
+            for num, issue in self.issues.items()
+            if issue["title"] == search_title
+            and RELEASE_LABEL in issue.get("labels", [])
+        ]
+        if not matching:
+            raise NoTrackingIssueError(
+                f"No open tracking issue found for Release {version}"
+            )
+        if len(matching) > 1:
+            raise MultipleTrackingIssuesError(
+                f"Multiple open tracking issues found for Release {version}"
+            )
+        return matching[0]
+
+    def create_pr(
+        self,
+        title: str,
+        body: str,
+        base: str = "main",
+        labels: list[str] | None = None,
+    ) -> str:
+        pr_num = self.next_issue_num
+        self.next_issue_num += 1
+        url = f"https://github.com/{self.repo}/pull/{pr_num}"
+        self.prs[pr_num] = {
+            "title": title,
+            "body": body,
+            "base": base,
+            "labels": labels or [],
+            "number": pr_num,
+            "url": url,
+            "state": "OPEN",
+        }
+        return url
+
+    def get_open_pr(self, branch_name: str) -> PrDict | None:
+        for pr in self.prs.values():
+            if pr.get("head") == branch_name and pr.get("state") == "OPEN":
+                return pr
+        return None
+
+    def get_open_tracking_issues(self, version: str | None = None) -> list[IssueDict]:
         results = []
         for issue in self.issues.values():
             if RELEASE_LABEL in issue["labels"]:
@@ -75,10 +146,16 @@ class MockGitHub:
                     results.append(issue)
         return results
 
-    def get_pr_info(self, pr_num: int) -> dict:
+    def get_pr_info(self, pr_num: int) -> PrDict:
         if pr_num in self.prs:
             return self.prs[pr_num]
         return {
             "state": "MERGED",
             "mergeCommit": {"oid": f"mock_merge_sha_{pr_num}"},
         }
+
+    def get_pr_comments(self, pr_num: int) -> list[dict]:
+        return self.pr_comments.get(pr_num, [])
+
+    def get_merge_commits_for_prs(self, pending_items: list) -> list:
+        return resolve_merge_commits_for_prs(self, pending_items)

--- a/tools/private/release/prepare.py
+++ b/tools/private/release/prepare.py
@@ -88,7 +88,9 @@ class Prepare:
                         f"No active tracking issue found for {version}."
                         " Creating a new one..."
                     )
-                    issue_num = self.gh.create_tracking_issue(version, template_content)
+                    issue_num = self.gh.create_release_tracking_issue(
+                        version, template_content
+                    )
                     print(f"Tracking issue: #{issue_num}")
         else:
             print(f"Tracking issue: #{issue_num}")


### PR DESCRIPTION
Migrates release tool unit tests under `tests/tools/private/release/` to Pytest and Pytest-mock (`mocker` fixture).

- Added `pytest-mock` dependency to `docs/pyproject.toml`, updated `docs/uv.lock` & `docs/requirements.txt`, and added `@pypi//pytest_mock` to release test helper `deps`.
- Converted release test targets from standard unittest to pytest fixtures.
- Refactored tests to use the standard `mocker` fixture from `pytest-mock`.