### PR TITLE
refactor(release): extract pypi publishing to standalone workflow

### DIFF
--- a/.github/workflows/publish_pypi.yaml
+++ b/.github/workflows/publish_pypi.yaml
@@ -1,0 +1,32 @@
+name: Publish to PyPI
+
+on:
+  workflow_call:
+    inputs:
+      tag_name:
+        description: "release tag: tag that will be released"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "release tag: tag that will be released"
+        required: true
+        type: string
+
+jobs:
+  publish_pypi:
+    name: Publish runfiles to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag_name || github.ref_name }}
+      - env:
+          # This special value tells pypi that the user identity is supplied within the token
+          TWINE_USERNAME: __token__
+          # Note, the PYPI_API_TOKEN is for the rules-python pypi user, added by @rickylev on
+          # https://github.com/bazel-contrib/rules_python/settings/secrets/actions
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: bazel run --stamp --embed_label=${{ inputs.tag_name || github.ref_name }} //python/runfiles:wheel.publish

--- a/.github/workflows/release_publish.yaml
+++ b/.github/workflows/release_publish.yaml
@@ -77,19 +77,9 @@ jobs:
 
   publish_pypi:
     # We just want publish_pypi last, since once uploaded, it can't be changed.
-    name: Publish runfiles to PyPI
     needs: publish_bcr
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ inputs.tag_name || github.ref_name }}
-      - if: github.event_name == 'push' || github.event.inputs.publish_to_pypi
-        env:
-          # This special value tells pypi that the user identity is supplied within the token
-          TWINE_USERNAME: __token__
-          # Note, the PYPI_API_TOKEN is for the rules-python pypi user, added by @rickylev on
-          # https://github.com/bazel-contrib/rules_python/settings/secrets/actions
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: bazel run --stamp --embed_label=${{ inputs.tag_name || github.ref_name }} //python/runfiles:wheel.publish
+    if: github.event_name == 'push' || inputs.publish_to_pypi
+    uses: ./.github/workflows/publish_pypi.yaml
+    with:
+      tag_name: ${{ inputs.tag_name || github.ref_name }}
+    secrets: inherit

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -67,7 +67,7 @@ gh workflow run release_publish.yaml --ref <TAG> -f publish_to_pypi=false
 
 If PyPI publishing failed or was skipped during the main release, the PyPI
 publishing workflow can be triggered manually using the GitHub CLI (`gh`) or
-via the GitHub Actions UI:
+via the [GitHub Actions UI](https://github.com/bazel-contrib/rules_python/actions/workflows/publish_pypi.yaml):
 
 ```shell
 gh workflow run publish_pypi.yaml --ref <TAG> -f tag_name=<TAG>

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -63,6 +63,16 @@ you can set the `publish_to_pypi` input to `false`:
 gh workflow run release_publish.yaml --ref <TAG> -f publish_to_pypi=false
 ```
 
+### Manually publishing to PyPI
+
+If PyPI publishing failed or was skipped during the main release, the PyPI
+publishing workflow can be triggered manually using the GitHub CLI (`gh`) or
+via the GitHub Actions UI:
+
+```shell
+gh workflow run publish_pypi.yaml --ref <TAG> -f tag_name=<TAG>
+```
+
 ### Determining Semantic Version
 
 **rules_python** uses [semantic version](https://semver.org), so releases with


### PR DESCRIPTION
Factor out PyPI publishing from release_publish.yaml into a new standalone workflow publish_pypi.yaml.

This enables PyPI publishing to be manually executed via workflow_dispatch while maintaining the ability to be invoked by release_publish.yaml during release execution.