### PR TITLE
tests: add workspace-compatible unified pypi hub so @pypi refs work

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -138,7 +138,7 @@ pip_parse(
     requirements_lock = "//examples/wheel:requirements_server.txt",
 )
 
-load("@pypiserver//:requirements.bzl", install_pypiserver = "install_deps")
+load("@pypiserver//:requirements.bzl", install_pypiserver = "install_deps", pypiserver_requirements = "all_requirements")
 
 install_pypiserver()
 
@@ -151,7 +151,7 @@ pip_parse(
     requirements_lock = "//docs:requirements.txt",
 )
 
-load("@dev_pip//:requirements.bzl", docs_install_deps = "install_deps")
+load("@dev_pip//:requirements.bzl", dev_pip_requirements = "all_requirements", docs_install_deps = "install_deps")
 
 docs_install_deps()
 
@@ -164,7 +164,7 @@ pip_parse(
     requirements_lock = "//tests/multi_pypi/alpha:requirements.txt",
 )
 
-load("@pypi_alpha//:requirements.bzl", pypi_alpha_install_deps = "install_deps")
+load("@pypi_alpha//:requirements.bzl", pypi_alpha_install_deps = "install_deps", pypi_alpha_requirements = "all_requirements")
 
 pypi_alpha_install_deps()
 
@@ -174,6 +174,22 @@ pip_parse(
     requirements_lock = "//tests/multi_pypi/beta:requirements.txt",
 )
 
-load("@pypi_beta//:requirements.bzl", pypi_beta_install_deps = "install_deps")
+load("@pypi_beta//:requirements.bzl", pypi_beta_install_deps = "install_deps", pypi_beta_requirements = "all_requirements")
 
 pypi_beta_install_deps()
+
+load(
+    "//python/private/pypi:unified_hub_repo.bzl",
+    "unified_workspace_hub_repo",
+)  # buildifier: disable=bzl-visibility
+
+unified_workspace_hub_repo(
+    name = "pypi",
+    default_hub = "dev_pip",
+    hubs = {
+        "dev_pip": dev_pip_requirements,
+        "pypi_alpha": pypi_alpha_requirements,
+        "pypi_beta": pypi_beta_requirements,
+        "pypiserver": pypiserver_requirements,
+    },
+)

--- a/python/private/pypi/BUILD.bazel
+++ b/python/private/pypi/BUILD.bazel
@@ -402,7 +402,10 @@ bzl_library(
 bzl_library(
     name = "unified_hub_repo",
     srcs = ["unified_hub_repo.bzl"],
-    deps = ["//python/private:text_util"],
+    deps = [
+        "//python/private:normalize_name",
+        "//python/private:text_util",
+    ],
 )
 
 bzl_library(

--- a/python/private/pypi/unified_hub_repo.bzl
+++ b/python/private/pypi/unified_hub_repo.bzl
@@ -1,5 +1,6 @@
 """Repository rule for creating the Unified PyPI Hub."""
 
+load("//python/private:normalize_name.bzl", "normalize_name")
 load("//python/private:text_util.bzl", "render")
 
 _ROOT_BUILD_TMPL = """\
@@ -79,3 +80,32 @@ unified_hub_repo = repository_rule(
     },
     doc = "Private repository rule creating the automatic Unified PyPI Hub.",
 )
+
+def unified_workspace_hub_repo(name, hubs, default_hub = None, extra_aliases = {}):
+    """Creates a Unified PyPI Hub repository for WORKSPACE mode by loading requirements from hubs.
+
+    Args:
+        name: Name of the repository rule (e.g. "pypi").
+        hubs: Dict mapping hub name to its `all_requirements` list or dict.
+              e.g. {"dev_pip": dev_pip_requirements, "pypi_alpha": pypi_alpha_requirements}
+        default_hub: Optional default hub name.
+        extra_aliases: Dictionary mapping 'package:alias' to a list of hubs that support it.
+    """
+    packages = {}
+    for hub_name, req_map in hubs.items():
+        req_list = req_map.keys() if type(req_map) == type({}) else req_map
+        for req in req_list:
+            pkg_name = req.split("//")[-1].split(":")[0]
+            norm_pkg = normalize_name(pkg_name)
+            if norm_pkg not in packages:
+                packages[norm_pkg] = []
+            if hub_name not in packages[norm_pkg]:
+                packages[norm_pkg].append(hub_name)
+
+    unified_hub_repo(
+        name = name,
+        default_hub = default_hub,
+        extra_aliases = extra_aliases,
+        hubs = sorted(hubs.keys()),
+        packages = packages,
+    )

--- a/tests/support/pytest_test/BUILD.bazel
+++ b/tests/support/pytest_test/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("//python/private:bzlmod_enabled.bzl", "BZLMOD_ENABLED")  # buildifier: disable=bzl-visibility
 
 package(default_visibility = ["//:__subpackages__"])
 
@@ -20,11 +19,11 @@ bzl_library(
 # These aliases are used to avoid duplicate targets in the deps list
 alias(
     name = "default_pytest",
-    actual = "@pypi//pytest" if BZLMOD_ENABLED else "//python/private:empty",
+    actual = "@pypi//pytest",
 )
 
 # These aliases are used to avoid duplicate targets in the deps list
 alias(
     name = "default_pytest_bazel",
-    actual = "@pypi//pytest_bazel" if BZLMOD_ENABLED else "//python/private:empty",
+    actual = "@pypi//pytest_bazel",
 )

--- a/tests/tools/private/release/BUILD.bazel
+++ b/tests/tools/private/release/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//python:py_library.bzl", "py_library")
-load("//tests/support:support.bzl", "SUPPORTS_BZLMOD")
+load("//tests/support:support.bzl", "NOT_WINDOWS")
 load("//tests/support/pytest_test:pytest_test.bzl", "pytest_test")
 
 py_library(
@@ -8,7 +8,7 @@ py_library(
         "conftest.py",
         "release_test_helper.py",
     ],
-    target_compatible_with = SUPPORTS_BZLMOD,
+    target_compatible_with = NOT_WINDOWS,
     deps = [
         "//tools/private/release:mock_gh",
         "//tools/private/release:release_lib",
@@ -19,7 +19,7 @@ py_library(
 pytest_test(
     name = "add_backports_test",
     srcs = ["add_backports_test.py"],
-    target_compatible_with = SUPPORTS_BZLMOD,
+    target_compatible_with = NOT_WINDOWS,
     deps = [
         ":release_test_helper",
         "//tools/private/release:release_lib",
@@ -29,7 +29,7 @@ pytest_test(
 pytest_test(
     name = "changelog_news_test",
     srcs = ["changelog_news_test.py"],
-    target_compatible_with = SUPPORTS_BZLMOD,
+    target_compatible_with = NOT_WINDOWS,
     deps = [
         ":release_test_helper",
         "//tools/private/release:release_lib",
@@ -39,7 +39,7 @@ pytest_test(
 pytest_test(
     name = "complete_sync_changelog_test",
     srcs = ["complete_sync_changelog_test.py"],
-    target_compatible_with = SUPPORTS_BZLMOD,
+    target_compatible_with = NOT_WINDOWS,
     deps = [
         ":release_test_helper",
         "//tools/private/release:release_lib",
@@ -49,7 +49,7 @@ pytest_test(
 pytest_test(
     name = "create_release_branch_test",
     srcs = ["create_release_branch_test.py"],
-    target_compatible_with = SUPPORTS_BZLMOD,
+    target_compatible_with = NOT_WINDOWS,
     deps = [
         ":release_test_helper",
         "//tools/private/release:release_lib",
@@ -59,7 +59,7 @@ pytest_test(
 pytest_test(
     name = "git_test",
     srcs = ["git_test.py"],
-    target_compatible_with = SUPPORTS_BZLMOD,
+    target_compatible_with = NOT_WINDOWS,
     deps = [
         ":release_test_helper",
         "//tools/private/release:release_lib",
@@ -69,7 +69,7 @@ pytest_test(
 pytest_test(
     name = "on_pr_merged_test",
     srcs = ["on_pr_merged_test.py"],
-    target_compatible_with = SUPPORTS_BZLMOD,
+    target_compatible_with = NOT_WINDOWS,
     deps = [
         ":release_test_helper",
         "//tools/private/release:release_lib",
@@ -79,7 +79,7 @@ pytest_test(
 pytest_test(
     name = "promote_test",
     srcs = ["promote_test.py"],
-    target_compatible_with = SUPPORTS_BZLMOD,
+    target_compatible_with = NOT_WINDOWS,
     deps = [
         ":release_test_helper",
         "//tools/private/release:release_lib",
@@ -89,7 +89,7 @@ pytest_test(
 pytest_test(
     name = "release_issue_test",
     srcs = ["release_issue_test.py"],
-    target_compatible_with = SUPPORTS_BZLMOD,
+    target_compatible_with = NOT_WINDOWS,
     deps = [
         ":release_test_helper",
         "//tools/private/release:release_lib",
@@ -99,7 +99,7 @@ pytest_test(
 pytest_test(
     name = "release_test",
     srcs = ["release_test.py"],
-    target_compatible_with = SUPPORTS_BZLMOD,
+    target_compatible_with = NOT_WINDOWS,
     deps = [
         ":release_test_helper",
         "//tools/private/release:release_lib",
@@ -109,7 +109,7 @@ pytest_test(
 pytest_test(
     name = "backport_create_releases_test",
     srcs = ["backport_create_releases_test.py"],
-    target_compatible_with = SUPPORTS_BZLMOD,
+    target_compatible_with = NOT_WINDOWS,
     deps = [
         ":release_test_helper",
         "//tools/private/release:release_lib",
@@ -119,7 +119,7 @@ pytest_test(
 pytest_test(
     name = "prepare_test",
     srcs = ["prepare_test.py"],
-    target_compatible_with = SUPPORTS_BZLMOD,
+    target_compatible_with = NOT_WINDOWS,
     deps = [
         ":release_test_helper",
         "//tools/private/release:release_lib",
@@ -129,7 +129,7 @@ pytest_test(
 pytest_test(
     name = "gh_test",
     srcs = ["gh_test.py"],
-    target_compatible_with = SUPPORTS_BZLMOD,
+    target_compatible_with = NOT_WINDOWS,
     deps = [
         ":release_test_helper",
         "//tools/private/release:release_lib",
@@ -139,7 +139,7 @@ pytest_test(
 pytest_test(
     name = "backport_prepare_test",
     srcs = ["backport_prepare_test.py"],
-    target_compatible_with = SUPPORTS_BZLMOD,
+    target_compatible_with = NOT_WINDOWS,
     deps = [
         ":release_test_helper",
         "//tools/private/release:release_lib",
@@ -149,7 +149,7 @@ pytest_test(
 pytest_test(
     name = "process_backports_test",
     srcs = ["process_backports_test.py"],
-    target_compatible_with = SUPPORTS_BZLMOD,
+    target_compatible_with = NOT_WINDOWS,
     deps = [
         ":release_test_helper",
         "//tools/private/release:release_lib",
@@ -159,7 +159,7 @@ pytest_test(
 pytest_test(
     name = "create_rc_test",
     srcs = ["create_rc_test.py"],
-    target_compatible_with = SUPPORTS_BZLMOD,
+    target_compatible_with = NOT_WINDOWS,
     deps = [
         ":release_test_helper",
         "//tools/private/release:release_lib",
@@ -169,7 +169,7 @@ pytest_test(
 pytest_test(
     name = "utils_test",
     srcs = ["utils_test.py"],
-    target_compatible_with = SUPPORTS_BZLMOD,
+    target_compatible_with = NOT_WINDOWS,
     deps = [
         ":release_test_helper",
         "//tools/private/release:release_lib",


### PR DESCRIPTION
Currently, the unified pypi hub is bzlmod only. While this is WAI,
it makes using the references in tests that would be good to run
under workspace unable to run.

To fix, have our workspace config create a unified hub repo with
the underlying pypi hubs that it needs to map to.

This is kept as an internal-only helper because it doesn't
generalize well to arbitrary projects.