### PR TITLE
fix(pip.parse): allow uv_lock to be set without requirements_lock

### DIFF
--- a/news/3952.fixed.md
+++ b/news/3952.fixed.md
@@ -1,0 +1,3 @@
+(pypi) Allow `uv_lock` to be specified in `pip.parse` without requiring
+`requirements_lock` (or other os-specific requirement file attributes) to be
+set.

--- a/python/private/pypi/hub_builder.bzl
+++ b/python/private/pypi/hub_builder.bzl
@@ -498,6 +498,7 @@ def _create_whl_repos(
             requirements_lock = pip_attr.requirements_lock,
             requirements_osx = pip_attr.requirements_darwin,
             requirements_windows = pip_attr.requirements_windows,
+            uv_lock = pip_attr.uv_lock,
             extra_pip_args = pip_attr.extra_pip_args,
             platforms = sorted(platforms),  # here we only need keys
             python_version = full_version(

--- a/python/private/pypi/requirements_files_by_platform.bzl
+++ b/python/private/pypi/requirements_files_by_platform.bzl
@@ -73,6 +73,7 @@ def requirements_files_by_platform(
         requirements_linux = None,
         requirements_lock = None,
         requirements_windows = None,
+        uv_lock = None,
         platforms,
         extra_pip_args = None,
         python_version = None,
@@ -88,6 +89,7 @@ def requirements_files_by_platform(
         requirements_linux (label): The requirements file for the linux OS.
         requirements_lock (label): The requirements file for all OSes, or used as a fallback.
         requirements_windows (label): The requirements file for windows OS.
+        uv_lock (label): The uv.lock file, or used as primary source.
         extra_pip_args (string list): Extra pip arguments to perform extra validations and to
             be joined with args fined in files.
         python_version: str or None. This is needed when the get_index_urls is
@@ -106,10 +108,11 @@ def requirements_files_by_platform(
         requirements_linux or
         requirements_osx or
         requirements_windows or
-        requirements_by_platform
+        requirements_by_platform or
+        uv_lock
     ):
         fail_fn(
-            "A 'requirements_lock' attribute must be specified, a platform-specific lockfiles " +
+            "A 'requirements_lock' or 'uv_lock' attribute must be specified, a platform-specific lockfiles " +
             "via 'requirements_by_platform' or an os-specific lockfiles must be specified " +
             "via 'requirements_*' attributes",
         )
@@ -143,9 +146,12 @@ def requirements_files_by_platform(
             fail_fn("only a single 'requirements_lock' file can be used when using '--platform' pip argument, consider specifying it via 'requirements_lock' attribute")
             return None
 
-        files_by_platform = [
-            (lock_files[0], platforms_from_args),
-        ]
+        if not lock_files:
+            files_by_platform = []
+        else:
+            files_by_platform = [
+                (lock_files[0], platforms_from_args),
+            ]
         if logger:
             logger.debug(lambda: "Files by platform with the platform set in the args: {}".format(files_by_platform))
     else:

--- a/tests/pypi/hub_builder/hub_builder_tests.bzl
+++ b/tests/pypi/hub_builder/hub_builder_tests.bzl
@@ -79,6 +79,7 @@ def hub_builder(
             },
             netrc = None,
             auth_patterns = None,
+            toml_decode = json.decode,
         ),
         whl_overrides = whl_overrides,
         minor_mapping = minor_mapping or {"3.15": "3.15.19"},
@@ -150,6 +151,30 @@ def _test_simple(env):
     pypi.extra_aliases().contains_exactly({})
 
 _tests.append(_test_simple)
+
+def _test_uv_lock_only(env):
+    builder = hub_builder(env)
+    builder.pip_parse(
+        _mock_mctx(
+            os_name = "osx",
+            arch_name = "aarch64",
+            mock_files = {
+                "uv.lock": """{"package":[{"name":"simple","source":{"registry":"https://pypi.org/simple"},"version":"0.0.1","wheels":[{"hash":"sha256:deadbeef","url":"https://files.pythonhosted.org/packages/simple-0.0.1-py3-none-any.whl"}]}]}""",
+            },
+        ),
+        _parse(
+            hub_name = "pypi",
+            python_version = "3.15",
+            requirements_lock = None,
+            uv_lock = "uv.lock",
+        ),
+    )
+    pypi = builder.build()
+
+    pypi.exposed_packages().contains_exactly(["simple"])
+    pypi.group_map().contains_exactly({})
+
+_tests.append(_test_uv_lock_only)
 
 def _test_simple_multiple_requirements(env):
     sub_tests = {

--- a/tests/pypi/requirements_files_by_platform/requirements_files_by_platform_tests.bzl
+++ b/tests/pypi/requirements_files_by_platform/requirements_files_by_platform_tests.bzl
@@ -43,7 +43,7 @@ def _test_fail_no_requirements(env):
         fail_fn = errors.append,
     )
     env.expect.that_str(errors[0]).equals("""\
-A 'requirements_lock' attribute must be specified, a platform-specific lockfiles via 'requirements_by_platform' or an os-specific lockfiles must be specified via 'requirements_*' attributes""")
+A 'requirements_lock' or 'uv_lock' attribute must be specified, a platform-specific lockfiles via 'requirements_by_platform' or an os-specific lockfiles must be specified via 'requirements_*' attributes""")
 
 _tests.append(_test_fail_no_requirements)
 
@@ -318,6 +318,25 @@ def _test_host_only_os_with_fallback(env):
     })
 
 _tests.append(_test_host_only_os_with_fallback)
+
+def _test_uv_lock_only(env):
+    """Verify that using only uv_lock without requirements_lock succeeds."""
+    got = requirements_files_by_platform(
+        uv_lock = "uv.lock",
+    )
+    env.expect.that_dict(got).contains_exactly({})
+
+_tests.append(_test_uv_lock_only)
+
+def _test_uv_lock_with_platform_arg(env):
+    """Verify that using uv_lock with --platform argument succeeds."""
+    got = requirements_files_by_platform(
+        uv_lock = "uv.lock",
+        extra_pip_args = ["--platform", "linux_x86_64"],
+    )
+    env.expect.that_dict(got).contains_exactly({})
+
+_tests.append(_test_uv_lock_with_platform_arg)
 
 def requirements_files_by_platform_test_suite(name):
     """Create the test suite.


### PR DESCRIPTION
Currently, calling `pip.parse(uv_lock = ...)` without setting
`requirements_lock` causes repository generation to fail during platform
lockfile validation because mandatory requirement files are enforced. This
prevents using `uv_lock` as a standalone lockfile in `pip.parse`.

To fix, accept `uv_lock` in platform requirement validation and exempt callers
from mandatory requirement file checks when a `uv_lock` is present.

Related #1975
Related #2787 