### PR TITLE
docs(pypi): add versionadded 2.2.0 directive to uv_lock attribute

### DIFF
--- a/python/private/pypi/extension.bzl
+++ b/python/private/pypi/extension.bzl
@@ -991,9 +991,12 @@ a string `"{os}_{arch}"` as the value here. You could also use `"{os}_{arch}_fre
 """,
         ),
         "uv_lock": attr.label(
-            doc = """\
+            doc = """
 (label, optional): A label pointing to the uv.lock file. If provided,
 the uv.lock file will be used as the primary source for package metadata.
+
+:::{versionadded} 2.2.0
+:::
 """,
         ),
         "whl_modifications": attr.label_keyed_string_dict(


### PR DESCRIPTION
The uv_lock argument for pip.parse was introduced in version 2.2.0, but its attribute documentation did not indicate when it was added.

To fix this, add the :::{versionadded} 2.2.0::: directive to the uv_lock attribute docstring in python/private/pypi/extension.bzl.