### PR TITLE
agents: clarify fast-tests config flag usage for building

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,10 @@ Tests are under the `tests/` directory.
 
 When testing, add `--config=fast-tests`.
 
-When building, add `--config=fast-tests`.
+When building test targets, add `--config=fast-tests`. Do NOT use
+`--config=fast-tests` when building non-test targets (such as `//docs:docs`),
+because `--config=fast-tests` enables `--build_tests_only=true`, which causes
+non-test targets to be silently ignored (finding 0 targets).
 
 The `--config=fast-tests` flag avoids running expensive and slow tests can that
 freeze the host machine or cause flakiness.


### PR DESCRIPTION
Currently, AGENTS.md instructs agents to add --config=fast-tests when building. However, --config=fast-tests enables --build_tests_only=true, which silently ignores non-test targets like //docs:docs and reports 0 targets found.

To fix this, clarify that --config=fast-tests should only be used when building test targets, and must not be used when building non-test targets.