### PR TITLE
agents: emphasize trailing ampersand in CI monitor skill invocation

### DIFF
--- a/.agents/skills/monitor-ci-results/SKILL.md
+++ b/.agents/skills/monitor-ci-results/SKILL.md
@@ -18,3 +18,4 @@ When any CI job completes with errors or returns a non-zero exit code:
 ```bash
 ./scripts/monitor_remote_ci.py 3812 "0be435bd-96aa-4e1b-9c6f-727b31e80fa0" &
 ```
+*Note: Always include the trailing `&` when launching the monitoring script via tool calls to ensure it runs as a detached background task without blocking foreground execution.*


### PR DESCRIPTION
When launching `monitor_remote_ci.py` via agent tool calls without a trailing `&`, the script remains attached as a child process wrapper and blocks foreground execution.

To fix, update `SKILL.md` with an explicit note emphasizing that tool invocations must always include the trailing `&` to ensure the monitoring script runs as a detached background task.