### PR TITLE
agents: add rule for PR descriptions and news entries

### DIFF
--- a/.agents/rules/pr_and_news.md
+++ b/.agents/rules/pr_and_news.md
@@ -1,0 +1,12 @@
+---
+trigger: model_decision
+description: Apply when drafting pull request descriptions or news entries.
+---
+
+# PR Descriptions and News Entries
+
+Before drafting any pull request description or news entry, you MUST read
+`CONTRIBUTING.md` (specifically the sections on **Commit messages and PR
+descriptions** and **Documenting changes**) and strictly adhere to its style,
+formatting, and structure rules. Do not generate PR descriptions or news
+entries without consulting `CONTRIBUTING.md` first.


### PR DESCRIPTION
Currently, AI agents may draft pull request descriptions or news entries without
consulting repository style guides, leading to format regressions such as
verbose diff lists or markdown section headers.

To prevent this, add an agent rule that mandates reading and adhering to
`CONTRIBUTING.md` before drafting pull request descriptions or news entries.