### PR TITLE
feat(coverage): fallback to pure Python wheel

### DIFF
--- a/news/3950.fixed.md
+++ b/news/3950.fixed.md
@@ -1,3 +1,3 @@
-(coverage) The warning about a missing bundled `coverage.py` wheel is only
-emitted once per affected and used toolchain when coverage is being collected
+(coverage) The warning about a missing bundled `coverage.py` wheel is no longer
+emitted as we are now falling back to a pure python wheel
 ([#3950](https://github.com/bazel-contrib/rules_python/issues/3950)).

--- a/python/private/coverage_deps.bzl
+++ b/python/private/coverage_deps.bzl
@@ -20,6 +20,10 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("//python/private:version_label.bzl", "version_label")
 
 # START: maintained by 'bazel run //tools/private/update_deps:update_coverage_deps <version>'
+_default = (
+    "https://files.pythonhosted.org/packages/ec/16/114df1c291c22cac3b0c127a73e0af5c12ed7bbb6558d310429a0ae24023/coverage-7.10.7-py3-none-any.whl",
+    "f7941f6f2fe6dd6807a1208737b8a0cbcf1cc6d7b07d24998ad2d63590868260",
+)
 _coverage_deps = {
     "cp310": {
         "aarch64-apple-darwin": (
@@ -184,15 +188,10 @@ def coverage_dep(name, python_version, platform, visibility):
         return None
 
     abi = "cp" + version_label(python_version)
-    url, sha256 = _coverage_deps.get(abi, {}).get(platform, (None, ""))
+    url, sha256 = _coverage_deps.get(abi, {}).get(platform, _default)
 
-    if url == None:
-        # Toolchains are registered for every platform in PLATFORMS, most of
-        # which a given build never resolves, so warning here is noise. The
-        # empty-lcov outcome is reported by py_runtime instead, which is
-        # analyzed only for the runtime actually selected. See
-        # https://github.com/bazel-contrib/rules_python/issues/3950.
-        return None
+    # NOTE @aignas 2026-07-27: if the default is matched, then the same file may be extracted
+    # multiple times. The wheel is small enough to not matter in most cases.
 
     maybe(
         http_archive,

--- a/tests/coverage_deps/coverage_deps_test.bzl
+++ b/tests/coverage_deps/coverage_deps_test.bzl
@@ -19,20 +19,6 @@ load("//python/private:coverage_deps.bzl", "coverage_dep")  # buildifier: disabl
 
 _tests = []
 
-def _test_unsupported_python_version_returns_none(env):
-    # cp37 is not in the bundled wheel set, so there is no coverage tool to
-    # attach to the runtime. Reporting that is py_runtime's job -- registration
-    # covers every platform in PLATFORMS, most of which are never selected.
-    result = coverage_dep(
-        name = "unused_for_test",
-        python_version = "3.7",
-        platform = "aarch64-apple-darwin",
-        visibility = ["//visibility:public"],
-    )
-    env.expect.that_bool(result == None).equals(True)
-
-_tests.append(_test_unsupported_python_version_returns_none)
-
 def _test_windows_platform_returns_none(env):
     # Windows is intentionally unsupported: the upstream coverage wrapper is
     # written in shell.

--- a/tools/private/update_deps/update_coverage_deps.py
+++ b/tools/private/update_deps/update_coverage_deps.py
@@ -115,12 +115,12 @@ def _map(
     platform: str,
     **kwargs: Any,
 ):
-    if platform not in _supported_platforms:
+    if platform and platform not in _supported_platforms:
         return None
 
     return Dep(
         name=name,
-        platform=_supported_platforms[platform],
+        platform=_supported_platforms[platform] if platform else "",
         python=python_version,
         url=url,
         sha256=digests["sha256"],
@@ -170,11 +170,16 @@ def main():
         data = json.loads(response.read().decode("utf-8"))
 
     urls = []
+    default_url = None
     for u in data["urls"]:
         if u["yanked"]:
             continue
 
         if not u["filename"].endswith(".whl"):
+            continue
+
+        if u["filename"].endswith("py3-none-any.whl"):
+            default_url = _map(name=args.name, platform="", **u)
             continue
 
         if u["python_version"] not in args.py:
@@ -196,7 +201,13 @@ def main():
     # Update the coverage_deps, which are used to register deps
     update_file(
         path=args.update_file,
-        snippet=f"_coverage_deps = {repr(Deps(urls))}\n",
+        snippet="\n".join(
+            [
+                f"_default = {repr(default_url)}",
+                f"_coverage_deps = {repr(Deps(urls))}",
+                "",
+            ]
+        ),
         start_marker="# START: maintained by 'bazel run //tools/private/update_deps:update_coverage_deps <version>'",
         end_marker="# END: maintained by 'bazel run //tools/private/update_deps:update_coverage_deps <version>'",
         dry_run=args.dry_run,


### PR DESCRIPTION
This is an alternative way to solve the warning issue that was reported
in the ticket. This means that `rules_python` from now on actually can
register `coverage` for any UNIXy toolchain no matter the toolchain
build.

Fixes #3950
