### PR TITLE
build(agents): handle blocked Buildkite jobs in CI monitoring and update create-pr skill

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -26,3 +26,9 @@ to handle PR creation or description drafting.
 3. **Return Status**: Direct the subagent to communicate the PR number or draft
    status back using `send_message` (or `agentapi send-message`) with the
    parent conversation ID, or include it in its final completion response.
+4. **Publish Artifact**: Upon receiving the subagent completion message, the
+   main agent must publish `pr_info.md` to display the artifact directly in
+   the primary user UI.
+5. **Interactive Actions**: To present custom action choices to the user
+   (e.g., "Create PR", "Create Draft PR"), the main agent can use the
+   `ask_question` tool with custom options.

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -4,7 +4,7 @@ description: Create a pull request by delegating to a subagent
 ---
 
 When creating a Pull Request for local changes or a branch, invoke a subagent
-to handle PR creation.
+to handle PR creation or description drafting.
 
 ### Instructions
 
@@ -19,7 +19,10 @@ to handle PR creation.
      - **Formatting**: Follow repository style guidelines and structure.
    - Create a Markdown artifact (`pr_info.md`) containing the PR title, body,
      and link/metadata so the user can review and comment on it.
-   - Run `gh pr create` with the formatted title and body.
-3. **Return PR Number**: Direct the subagent to communicate the created PR
-   number back using `send_message` (or `agentapi send-message`) with the
+   - **Propose vs. Create**: If the user requested to propose or draft a PR
+     description, **do not** run `gh pr create`—just create the `pr_info.md`
+     artifact for the user to review. Otherwise, execute `gh pr create` with
+     the formatted title and body.
+3. **Return Status**: Direct the subagent to communicate the PR number or draft
+   status back using `send_message` (or `agentapi send-message`) with the
    parent conversation ID, or include it in its final completion response.

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: create-pr
+description: Create a pull request by delegating to a subagent
+---
+
+When creating a Pull Request for local changes or a branch, invoke a subagent
+to handle PR creation.
+
+### Instructions
+
+1. Launch a subagent using `invoke_subagent` with `TypeName: "self"` (or
+   `agentapi new-conversation`).
+2. Provide a prompt to the subagent directing it to:
+   - Read `CONTRIBUTING.md` (specifically the sections on **Commit messages
+     and PR descriptions** and **Documenting changes**) before drafting.
+   - Strictly adhere to `CONTRIBUTING.md` rules for:
+     - **PR Title**: Follow conventional commit style and title formatting.
+     - **PR Body**: Include rationale, high-level summary, and structure.
+     - **Formatting**: Follow repository style guidelines and structure.
+   - Create a Markdown artifact (`pr_info.md`) containing the PR title, body,
+     and link/metadata so the user can review and comment on it.
+   - Run `gh pr create` with the formatted title and body.
+3. **Return PR Number**: Direct the subagent to communicate the created PR
+   number back using `send_message` (or `agentapi send-message`) with the
+   parent conversation ID, or include it in its final completion response.

--- a/.agents/skills/monitor-ci-results/SKILL.md
+++ b/.agents/skills/monitor-ci-results/SKILL.md
@@ -1,21 +1,31 @@
 ---
 name: monitor-ci-results
-description: Monitor remote CI results for a PR and autonomously trigger log analysis upon failures
+description: Monitor CI for PRs and notify of status
 ---
 
-When the user requests to monitor remote CI results or watch a pull request, invoke `scripts/monitor_remote_ci.py <pr_number> <your_conversation_id>`.
+When the user requests to monitor remote CI results or watch a pull request,
+invoke `scripts/monitor_remote_ci.py <pr_number> <your_conversation_id>`.
 
-This long-running monitoring service runs in the background and continuously polls both GitHub PR checks and Buildkite workflow executions.
+This long-running monitoring service runs in the background and continuously
+polls both GitHub PR checks and Buildkite workflow executions.
 
-### ✨ Autonomous Failure Orchestration
-When any CI job completes with errors or returns a non-zero exit code:
-1. It automatically downloads the raw CI log file to `ci_logs/`.
-2. It launches an independent background analyzer script (`analyze_ci_failure.py`).
-3. It authors a beautifully structured Markdown suggested plan for how to fix the failure.
-4. It natively dispatches a high-priority notification message back to your active agent conversation (containing the downloaded log path and fix plan) using `agentapi send-message`!
+### ✨ Autonomous Failure and Blocked Job Orchestration
+1. **Blocked Jobs**: When a Buildkite job or GitHub check is in a blocked
+   state waiting for user confirmation, it dispatches a notification via
+   `agentapi send-message` so the user is alerted to confirm running the job.
+2. **Failure Analysis**: When any CI job completes with errors or returns a
+   non-zero exit code:
+   - It automatically downloads the raw CI log file to `ci_logs/`.
+   - It launches an independent background analyzer script
+     (`analyze_ci_failure.py`).
+   - It authors a structured Markdown plan to fix the failure.
+   - It natively dispatches a high-priority notification back to your active
+     agent conversation using `agentapi send-message`!
 
 ### Example Invocation
 ```bash
 ./scripts/monitor_remote_ci.py 3812 "0be435bd-96aa-4e1b-9c6f-727b31e80fa0" &
 ```
-*Note: Always include the trailing `&` when launching the monitoring script via tool calls to ensure it runs as a detached background task without blocking foreground execution.*
+*Note: Always include the trailing `&` when launching the monitoring script via
+tool calls to ensure it runs as a detached background task without blocking
+foreground execution.*

--- a/.agents/skills/monitor-ci-results/scripts/monitor_remote_ci.py
+++ b/.agents/skills/monitor-ci-results/scripts/monitor_remote_ci.py
@@ -111,24 +111,32 @@ def main():
                 passed = 0
                 failed = 0
                 running = 0
+                blocked = 0
                 other = 0
 
                 for job in jobs:
                     jstate = job.get("state", "unknown")
                     exit_status = job.get("exit_status")
                     is_soft_failed = job.get("soft_failed") is True
+                    is_blocked = jstate in ["blocked", "blocked_failed"]
                     is_failed = (
-                        jstate in ["failed", "failing"]
-                        or (exit_status != 0 and exit_status is not None)
-                    ) and not is_soft_failed
+                        (
+                            jstate in ["failed", "failing"]
+                            or (exit_status != 0 and exit_status is not None)
+                        )
+                        and not is_soft_failed
+                        and not is_blocked
+                    )
                     is_passed = (
                         jstate in ["passed", "success"]
                         or (jstate == "finished" and exit_status == 0)
                         or is_soft_failed
-                    )
-                    is_running = jstate in ["running", "scheduled"]
+                    ) and not is_blocked
+                    is_running = jstate in ["running", "scheduled"] and not is_blocked
 
-                    if is_failed:
+                    if is_blocked:
+                        blocked += 1
+                    elif is_failed:
                         failed += 1
                     elif is_passed:
                         passed += 1
@@ -140,7 +148,7 @@ def main():
                 build_id = link.split("/")[-1].split("#")[0]
                 print(
                     f"Buildkite #{build_id}: {len(jobs)} total jobs "
-                    f"(Passed: {passed}, Failed: {failed}, Running: {running}, Other: {other})"
+                    f"(Passed: {passed}, Failed: {failed}, Running: {running}, Blocked: {blocked}, Other: {other})"
                 )
 
                 for job in jobs:
@@ -151,12 +159,42 @@ def main():
 
                     exit_status = job.get("exit_status")
                     is_soft_failed = job.get("soft_failed") is True
+                    is_blocked = jstate in ["blocked", "blocked_failed"]
                     is_failed = (
-                        jstate in ["failed", "failing"]
-                        or (exit_status != 0 and exit_status is not None)
-                    ) and not is_soft_failed
+                        (
+                            jstate in ["failed", "failing"]
+                            or (exit_status != 0 and exit_status is not None)
+                        )
+                        and not is_soft_failed
+                        and not is_blocked
+                    )
 
-                    if is_failed and jkey not in monitored:
+                    if is_blocked:
+                        jkey_blocked = f"bk_blocked_{jid}"
+                        if jkey_blocked not in monitored:
+                            print(
+                                f"⏸️ Notifying blocked state for Buildkite job '{jname}' (ID: {jid})..."
+                            )
+                            msg = (
+                                f"⚠️ Remote CI Buildkite Job '{jname}' is blocked!\n\n"
+                                f"Build ID: {build_id} | Job ID: {jid}\n"
+                                f"Log URL: {job.get('log_url', link)}\n\n"
+                                f"The user must confirm whether to run the CI jobs."
+                            )
+                            subprocess.run(
+                                [
+                                    "agentapi",
+                                    "send-message",
+                                    "--title=CI Job Blocked",
+                                    args.conv_id,
+                                    msg,
+                                ]
+                            )
+                            monitored[jkey_blocked] = time.time()
+                            with open(state_file, "w") as f:
+                                json.dump(monitored, f)
+
+                    elif is_failed and jkey not in monitored:
                         print(
                             f"🚨 Notifying failure for Buildkite job '{jname}' (ID: {jid})..."
                         )
@@ -178,6 +216,29 @@ def main():
                         monitored[jkey] = time.time()
                         with open(state_file, "w") as f:
                             json.dump(monitored, f)
+
+            elif (
+                state.upper() in ["ACTION_REQUIRED", "BLOCKED"]
+                and f"gh_blocked_{name}" not in monitored
+            ):
+                print(f"⏸️ Notifying blocked state for GitHub check '{name}'...")
+                msg = (
+                    f"⚠️ Remote CI GitHub Check '{name}' is blocked!\n\n"
+                    f"Link: {link}\n\n"
+                    f"The user must confirm whether to run the CI jobs."
+                )
+                subprocess.run(
+                    [
+                        "agentapi",
+                        "send-message",
+                        "--title=CI Check Blocked",
+                        args.conv_id,
+                        msg,
+                    ]
+                )
+                monitored[f"gh_blocked_{name}"] = time.time()
+                with open(state_file, "w") as f:
+                    json.dump(monitored, f)
 
             elif state in ["FAILURE", "failed"] and name not in monitored:
                 print(f"🚨 Notifying failure for GitHub check '{name}'...")


### PR DESCRIPTION
build(agents): handle blocked Buildkite jobs in CI monitoring and update create-pr skill

When remote Buildkite CI jobs enter a blocked state waiting for user
confirmation, the CI monitoring script did not explicitly track or notify
about blocked jobs, leading to unhandled paused builds. In addition, the
`create-pr` skill lacked instructions for handling proposal-only workflows
where subagents should draft PR information without executing `gh pr create`.

To address this:
* Updated `monitor_remote_ci.py` to identify `blocked` and `blocked_failed`
  job states, track blocked job counts separately, and send real-time
  notifications via `agentapi send-message` to alert users when a job is
  waiting for approval.
* Documented blocked job orchestration in `.agents/skills/monitor-ci-results/SKILL.md`.
* Updated `.agents/skills/create-pr/SKILL.md` to guide subagents on drafting PR
  proposals via `pr_info.md` artifacts when running in proposal mode rather
  than calling `gh pr create`.