### PR TITLE
fix(gazelle)!: use per-version stdlib lists for Python 3.13 and 3.14

### DIFF
--- a/gazelle/MODULE.bazel
+++ b/gazelle/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
-bazel_dep(name = "rules_python", version = "0.18.0")
+bazel_dep(name = "rules_python", version = "1.5.0")
 bazel_dep(name = "rules_go", version = "0.59.0", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "gazelle", version = "0.47.0", repo_name = "bazel_gazelle")
 bazel_dep(name = "rules_cc", version = "0.0.16")

--- a/gazelle/deps.bzl
+++ b/gazelle/deps.bzl
@@ -26,9 +26,9 @@ def python_stdlib_list_deps():
     http_archive(
         name = "python_stdlib_list",
         build_file_content = """exports_files(glob(["stdlib_list/lists/*.txt"]))""",
-        sha256 = "aa21a4f219530e85ecc364f0bbff2df4e6097a8954c63652af060f4e64afa65d",
-        strip_prefix = "stdlib-list-0.11.0",
-        url = "https://github.com/pypi/stdlib-list/releases/download/v0.11.0/v0.11.0.tar.gz",
+        sha256 = "517824f27ee89e591d8ae7c1dd9ff34f672eae50ee886ea31bb8816d77535675",
+        strip_prefix = "stdlib_list-0.12.0",
+        url = "https://files.pythonhosted.org/packages/8c/25/f1540879c8815387980e56f973e54605bd924612399ace31487f7444171c/stdlib_list-0.12.0.tar.gz",
     )
 
 def gazelle_deps():

--- a/gazelle/examples/bzlmod_build_file_generation/MODULE.bazel
+++ b/gazelle/examples/bzlmod_build_file_generation/MODULE.bazel
@@ -13,7 +13,7 @@ module(
 # For typical setups you set the version.
 # See the releases page for available versions.
 # https://github.com/bazel-contrib/rules_python/releases
-bazel_dep(name = "rules_python", version = "1.4.0")
+bazel_dep(name = "rules_python", version = "1.5.0")
 
 # The following stanza defines the dependency rules_python_gazelle_plugin.
 # For typical setups you set the version.

--- a/gazelle/python/BUILD.bazel
+++ b/gazelle/python/BUILD.bazel
@@ -54,10 +54,12 @@ copy_file(
             "@rules_python//python/config_settings:is_python_3.10": "@python_stdlib_list//:stdlib_list/lists/3.10.txt",
             "@rules_python//python/config_settings:is_python_3.11": "@python_stdlib_list//:stdlib_list/lists/3.11.txt",
             "@rules_python//python/config_settings:is_python_3.12": "@python_stdlib_list//:stdlib_list/lists/3.12.txt",
+            "@rules_python//python/config_settings:is_python_3.13": "@python_stdlib_list//:stdlib_list/lists/3.13.txt",
+            "@rules_python//python/config_settings:is_python_3.14": "@python_stdlib_list//:stdlib_list/lists/3.14.txt",
             "@rules_python//python/config_settings:is_python_3.8": "@python_stdlib_list//:stdlib_list/lists/3.8.txt",
             "@rules_python//python/config_settings:is_python_3.9": "@python_stdlib_list//:stdlib_list/lists/3.9.txt",
-            # This is the same behaviour as previously
-            "//conditions:default": "@python_stdlib_list//:stdlib_list/lists/3.11.txt",
+            # Fall back to the latest stdlib list
+            "//conditions:default": "@python_stdlib_list//:stdlib_list/lists/3.14.txt",
         },
     ),
     out = "stdlib_list.txt",

--- a/news/3978.changed.md
+++ b/news/3978.changed.md
@@ -1,0 +1,3 @@
+(gazelle) **BREAKING** rules_python 1.5.0 or higher is now required. The Python
+extension selects its standard library list on `is_python_3.14`, which earlier
+versions do not define.

--- a/news/3978.fixed.md
+++ b/news/3978.fixed.md
@@ -1,0 +1,5 @@
+(gazelle) The Python extension now uses the correct standard library module list for
+`python_version` 3.13 and 3.14; previously both fell back to the 3.11 list, so modules
+added or removed since then (e.g. `compression.zstd`, `telnetlib`) were misclassified. The
+fallback list for unrecognized versions is now the newest available one rather than 3.11
+([#3978](https://github.com/bazel-contrib/rules_python/pull/3978)).


### PR DESCRIPTION
The gazelle Python extension picks its stdlib list by `python_version`. The select had no branch for `3.13` or `3.14`, so those configurations fell through to the `3.11` list and gazelle misses everything that changed since `3.11` (`3.14` added `compression.zstd`, `3.13` removed `telnetlib`).

Bump `python_stdlib_list` to `stdlib-list` `0.12.0`, the first release shipping `lists/3.14.txt`, and add the two matching branches. Point `//conditions:default` at the newest list, so configurations with no matching branch stop landing on one four releases behind.

Fetch the archive from the PyPI sdist rather than a GitHub release asset. Unlike `0.11.0`, `0.12.0` published no GitHub release assets. GitHub's auto-generated tag archives are not checksum-stable. PyPI never reuses an uploaded filename.

## BREAKING CHANGE: Gazelle plugin now requires rules_python 1.5.0

Bazel resolves every `select()` key at analysis time, so `is_python_3.14` must exist even for builds that never select it. `rules_python` generates that target from `MINOR_MAPPING`, which lists `3.14` starting in `1.5.0`. Older versions fail analysis, and that broke the `Gazelle: BCR` jobs on the first push.

Two pins constrain resolution, and both move to `1.5.0`: the plugin's own `bazel_dep` (was `0.18.0`) and `gazelle/examples/bzlmod_build_file_generation` (was `1.4.0`). The example's `other_module` keeps its placeholder pin, which the root module overrides.

## Testing

I added no automated coverage and would appreciate maintainer input on how, if at all, to test this. I didn't see an obvious way given the existing test infra.
