### PR TITLE
agents: update create-pr and analyze-ci-failure skills

### DIFF
--- a/.agents/skills/analyze-ci-failure/SKILL.md
+++ b/.agents/skills/analyze-ci-failure/SKILL.md
@@ -15,7 +15,7 @@ check, invoke this skill by running:
 1. **Resolves Log**: Automatically resolves the Buildkite job download URL or
    fetches GitHub Actions logs via `gh` CLI.
 2. **Downloads & Ingests**: Fetches the full raw CI log file and saves it
-   locally.
+   locally to `.agents/skills/analyze-ci-failure/scratch/`.
 3. **Smart Error Extraction**: Scans log lines for critical failure signatures
    (`Traceback`, `ERROR:`, `FAILED:`, missing packages, compiler aborts, linter
    errors).

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -15,6 +15,7 @@ to handle PR creation or description drafting.
      and PR descriptions** and **Documenting changes**) before drafting.
    - Strictly adhere to `CONTRIBUTING.md` rules for:
      - **PR Title**: Follow conventional commit style and title formatting.
+       For agent rules, skills, and system updates, use `agents:` prefix.
      - **PR Body**: Include rationale, high-level summary, and structure.
      - **Formatting**: Follow repository style guidelines and structure.
    - Create a Markdown artifact (`pr_info.md`) containing the PR title, body,
@@ -23,6 +24,9 @@ to handle PR creation or description drafting.
      description, **do not** run `gh pr create`—just create the `pr_info.md`
      artifact for the user to review. Otherwise, execute `gh pr create` with
      the formatted title and body.
+   - **Targeting Upstream Repo**: When executing `gh pr create`, always target
+     the upstream repository by passing `--repo bazel-contrib/rules_python` and
+     `--head <fork_owner>:<branch_name>`.
 3. **Return Status**: Direct the subagent to communicate the PR number or draft
    status back using `send_message` (or `agentapi send-message`) with the
    parent conversation ID, or include it in its final completion response.


### PR DESCRIPTION
Update the create-pr skill to specify --repo bazel-contrib/rules_python and enforce using the agents: title prefix for agent-related pull requests. Also update analyze-ci-failure skill documentation to clarify the scratch directory path for downloaded logs.

* Updates create-pr SKILL.md with upstream repo targeting rules and title prefix guidelines.
* Updates analyze-ci-failure SKILL.md to clarify log download scratch directory path.