### PR TITLE
test: improve error reporting and artifact generation for lockfile test

### DIFF
--- a/tests/integration/BUILD.bazel
+++ b/tests/integration/BUILD.bazel
@@ -42,6 +42,7 @@ default_test_runner(
 rules_python_integration_test(
     name = "bzlmod_lockfile_test",
     bazel_versions = ["9.1.0"],
+    py_main = "bzlmod_lockfile_test.py",
 )
 
 test_suite(

--- a/tests/integration/bzlmod_lockfile_test.py
+++ b/tests/integration/bzlmod_lockfile_test.py
@@ -1,0 +1,59 @@
+import difflib
+import os
+import pathlib
+import unittest
+
+from tests.integration import runner
+
+
+class BzlmodLockfileTest(runner.TestCase):
+    def test_bzlmod_lockfile(self):
+        lockfile_path = self.repo_root / "MODULE.bazel.lock"
+        self.assertTrue(
+            lockfile_path.exists(),
+            f"Expected lockfile at {lockfile_path}",
+        )
+        original_lockfile = lockfile_path.read_text()
+
+        res = self.run_bazel("test", "//...", check=False)
+        if res.exit_code == 0:
+            return
+
+        # Generate updated lockfile to compare diff and export artifact
+        self.run_bazel("mod", "deps", "--lockfile_mode=update", check=False)
+        updated_lockfile = lockfile_path.read_text() if lockfile_path.exists() else ""
+
+        undeclared_outputs_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR")
+        if undeclared_outputs_dir:
+            out_dir = pathlib.Path(undeclared_outputs_dir)
+            (out_dir / "MODULE.bazel.lock").write_text(updated_lockfile)
+
+        if original_lockfile != updated_lockfile:
+            diff_lines = list(
+                difflib.unified_diff(
+                    original_lockfile.splitlines(keepends=True),
+                    updated_lockfile.splitlines(keepends=True),
+                    fromfile="MODULE.bazel.lock (checked-in)",
+                    tofile="MODULE.bazel.lock (expected/updated)",
+                )
+            )
+            diff_str = "".join(diff_lines)
+
+            if undeclared_outputs_dir:
+                (out_dir / "MODULE.bazel.lock.diff").write_text(diff_str)
+
+            msg = (
+                f"MODULE.bazel.lock is out of date.\n\n"
+                f"--- DIFF ---\n{diff_str}\n"
+                f"--- END DIFF ---\n\n"
+                f"To update the lockfile, run:\n"
+                f"  bazel mod deps --lockfile_mode=update\n"
+                f"inside tests/integration/bzlmod_lockfile, or copy the updated MODULE.bazel.lock artifact.\n"
+            )
+            self.fail(msg)
+        else:
+            self.fail(f"bazel test //... failed:\n{res.describe()}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integration/runner.py
+++ b/tests/integration/runner.py
@@ -80,10 +80,13 @@ class TestCase(unittest.TestCase):
         # Put the global tmp not under the test tmp to better match how a real
         # execution has entirely different directories for these.
         self.tmp_dir = outer_test_tmpdir / "bit_tmp"
+        self.test_tmp_dir.mkdir(parents=True, exist_ok=True)
+        self.tmp_dir.mkdir(parents=True, exist_ok=True)
         self.bazel_env = {
             "PATH": os.environ["PATH"],
             "TEST_TMPDIR": str(self.test_tmp_dir),
             "TMP": str(self.tmp_dir),
+            "TEMP": str(self.tmp_dir),
             # For some reason, this is necessary for Bazel 6.4 to work.
             # If not present, it can't find some bash helpers in @bazel_tools
             "RUNFILES_DIR": os.environ["TEST_SRCDIR"],


### PR DESCRIPTION
When `bzlmod_lockfile_test` fails due to an out-of-date `MODULE.bazel.lock`
file (e.g. under `--lockfile_mode=error`), Bazel previously output a generic
failure message without indicating what diff changed or providing an updated
lockfile artifact. This made debugging CI lockfile failures tedious and manual.

To improve the developer experience:
* On test failure, automatically run `bazel mod deps --lockfile_mode=update`
  to compute the expected lockfile changes.
* Output a unified diff between the checked-in and expected `MODULE.bazel.lock`
  directly in the test failure logs along with actionable update commands.
* Export the updated `MODULE.bazel.lock` and `MODULE.bazel.lock.diff` to
  `TEST_UNDECLARED_OUTPUTS_DIR` as build artifacts, allowing them to be downloaded directly in the Buildkite UI.
