### PR TITLE
agents: prevent duplicate CI monitoring processes in monitor-ci-results skill

### DIFF
--- a/.agents/skills/monitor-ci-results/SKILL.md
+++ b/.agents/skills/monitor-ci-results/SKILL.md
@@ -5,7 +5,17 @@ description: Monitor remote CI results for a PR and autonomously launch
 ---
 
 When the user requests to monitor remote CI results or watch a pull request,
-launch the monitoring script in the background:
+or when monitoring CI after PR updates:
+
+> **Note**: `monitor_remote_ci.py` is a single long-running continuous task.
+> It continuously watches all current and future CI runs for the PR. Do NOT
+> launch duplicate monitoring jobs for the same PR.
+
+1. **Check Existing Process**: Check if a monitor script is already running for
+   the PR (e.g., `pgrep -f "monitor_remote_ci.py <pr_number>"`). If one is
+   already running, do not start another instance.
+2. **Launch Monitoring Script**: If no monitor process is active for
+   `<pr_number>`, launch the script in the background:
 ```bash
 ./.agents/skills/monitor-ci-results/scripts/monitor_remote_ci.py \
   <pr_number> "<your_conversation_id>" &
@@ -13,10 +23,11 @@ launch the monitoring script in the background:
 
 ### ✨ Autonomous Subagent Orchestration
 1. **Background Polling**: `monitor_remote_ci.py` continuously polls both
-   GitHub PR checks and Buildkite workflow executions in the background.
-2. **Blocked Jobs**: When a Buildkite job or GitHub check is in a blocked
-   state waiting for user confirmation, it dispatches a notification via
-   `agentapi send-message` so the user is alerted to confirm running the job.
+   GitHub PR checks and Buildkite workflow executions in the background across
+   new commits and CI re-runs.
+2. **Blocked Jobs**: When a Buildkite job or GitHub check is in a blocked state
+   waiting for user confirmation, it dispatches a notification via `agentapi
+   send-message` so the user is alerted to confirm running the job.
 3. **Failure Reporting**: When any GitHub check or Buildkite job completes
    with errors, `monitor_remote_ci.py` dispatches a high-priority notification
    message reporting the failed check back to your conversation.

--- a/.agents/skills/monitor-ci-results/scripts/monitor_remote_ci.py
+++ b/.agents/skills/monitor-ci-results/scripts/monitor_remote_ci.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import fcntl
 import json
 import os
 import subprocess
@@ -79,9 +80,49 @@ def main():
     )
     args = parser.parse_args()
 
-    skill_dir = os.path.abspath(os.path.dirname(__file__))
+    skill_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    scratch_dir = os.path.join(skill_dir, "scratch")
+    os.makedirs(scratch_dir, exist_ok=True)
 
-    state_file = os.path.join(skill_dir, f"monitored_state_pr_{args.pr}.json")
+    # Acquire lock for PR to avoid duplicate monitoring processes
+    lock_file_path = os.path.join(scratch_dir, f".monitored_pr_{args.pr}.lock")
+    lock_file = open(lock_file_path, "a+")
+    running_agent_conv_id = os.environ.get("ANTIGRAVITY_CONVERSATION_ID", "")
+    try:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        lock_file.seek(0)
+        lock_file.truncate(0)
+        lock_data = {
+            "pid": os.getpid(),
+            "agent_conv_id": running_agent_conv_id,
+            "notify_conv_id": args.conv_id,
+        }
+        lock_file.write(json.dumps(lock_data) + "\n")
+        lock_file.flush()
+    except (BlockingIOError, OSError):
+        existing_agent_conv = ""
+        try:
+            lock_file.seek(0)
+            content = lock_file.read().strip()
+            if content:
+                data = json.loads(content)
+                existing_agent_conv = data.get("agent_conv_id", "") or data.get(
+                    "conv_id", ""
+                )
+        except Exception:
+            pass
+
+        subagent_str = (
+            f" under agent/subagent conversation '{existing_agent_conv}'"
+            if existing_agent_conv
+            else ""
+        )
+        print(
+            f"ℹ️ Continuous remote CI monitoring for PR #{args.pr} is already running in another process{subagent_str}. Exiting."
+        )
+        sys.exit(0)
+
+    state_file = os.path.join(scratch_dir, f"monitored_state_pr_{args.pr}.json")
     monitored = {}
     if os.path.exists(state_file):
         try:


### PR DESCRIPTION
Previously, launching multiple CI monitoring workflows or updating PRs could spawn duplicate `monitor_remote_ci.py` background processes for the same pull request, causing redundant polling and notification noise.

To prevent duplication:
* Implement non-blocking file locking (`fcntl.flock`) in `monitor_remote_ci.py` using a lockfile in the skill's `scratch/` directory (`.monitored_pr_<pr>.lock`).
* Automatically exit gracefully with an informative message if another process is already monitoring the target PR.
* Update `SKILL.md` guidance to instruct agents to check for existing monitoring processes before launching new ones.
* Relocate monitoring state files to the skill `scratch/` directory to keep the skill directory clean.