### PR TITLE
feat(cc): populate abi and platform settings on local py_cc_toolchain

### DIFF
--- a/python/private/get_local_runtime_info.py
+++ b/python/private/get_local_runtime_info.py
@@ -16,6 +16,7 @@
 import glob
 import json
 import os
+import platform
 import sys
 import sysconfig
 from typing import Any
@@ -247,6 +248,7 @@ def _get_python_library_info(base_executable) -> dict[str, Any]:
         "abi_dynamic_libraries": _unique_basenames(abi_dynamic_libraries),
         "abi_interface_libraries": _unique_basenames(abi_interface_libraries),
         "abi_flags": abi_flags,
+        "abi_tag": config_vars.get("SOABI") or "",
         "shlib_suffix": ".dylib" if _IS_DARWIN else "",
         "additional_dlls": dlls,
         "defines": defines,
@@ -265,6 +267,8 @@ data = {
     "include": sysconfig.get_path("include"),
     "implementation_name": sys.implementation.name,
     "base_executable": _get_base_executable(),
+    "sys_platform": sys.platform,
+    "platform_machine": platform.machine(),
 }
 data.update(_get_python_library_info(_get_base_executable()))
 print(json.dumps(data))

--- a/python/private/local_runtime_repo.bzl
+++ b/python/private/local_runtime_repo.bzl
@@ -35,6 +35,7 @@ define_local_runtime_toolchain_impl(
     minor = "{minor}",
     micro = "{micro}",
     abi_flags = "{abi_flags}",
+    abi_tag = "{abi_tag}",
     os = "{os}",
     implementation_name = "{implementation_name}",
     interpreter_path = "{interpreter_path}",
@@ -44,6 +45,8 @@ define_local_runtime_toolchain_impl(
     abi3_interface_library = {abi3_interface_library},
     abi3_libraries = {abi3_libraries},
     additional_dlls = {additional_dlls},
+    sys_platform = "{sys_platform}",
+    platform_machine = "{platform_machine}",
 )
 """
 
@@ -53,6 +56,7 @@ def _expand_incompatible_template():
         minor = "0",
         micro = "0",
         abi_flags = "",
+        abi_tag = "",
         os = "@platforms//:incompatible",
         implementation_name = "incompatible",
         interpreter_path = "/incompatible",
@@ -62,6 +66,8 @@ def _expand_incompatible_template():
         abi3_interface_library = "None",
         abi3_libraries = "[]",
         additional_dlls = "[]",
+        sys_platform = "",
+        platform_machine = "",
     )
 
 def _norm_path(path):
@@ -210,6 +216,7 @@ def _local_runtime_repo_impl(rctx):
         minor = info["minor"],
         micro = info["micro"],
         abi_flags = info["abi_flags"],
+        abi_tag = info["abi_tag"],
         os = "@platforms//os:{}".format(repo_utils.get_platforms_os_name(rctx)),
         implementation_name = info["implementation_name"],
         interpreter_path = _norm_path(interpreter_path),
@@ -219,6 +226,8 @@ def _local_runtime_repo_impl(rctx):
         abi3_interface_library = repr(abi3_interface_library),
         abi3_libraries = repr(abi3_libraries),
         additional_dlls = repr(additional_dlls),
+        sys_platform = info["sys_platform"],
+        platform_machine = info["platform_machine"],
     )
     logger.debug(lambda: "BUILD.bazel\n{}".format(build_bazel))
 

--- a/python/private/local_runtime_repo_setup.bzl
+++ b/python/private/local_runtime_repo_setup.bzl
@@ -37,7 +37,10 @@ def define_local_runtime_toolchain_impl(
         defines,
         abi3_interface_library,
         abi3_libraries,
-        additional_dlls):
+        additional_dlls,
+        sys_platform = "",
+        platform_machine = "",
+        abi_tag = ""):
     """Defines a toolchain implementation for a local Python runtime.
 
     Generates public targets:
@@ -71,6 +74,9 @@ def define_local_runtime_toolchain_impl(
             e.g. ["lib/python3.dll"] or ["lib/python3.so"]
         additional_dlls: `list[str]` Path[s] to additional DLLs.
             e.g. ["lib/msvcrt123.dll"]
+        sys_platform: `str` The PEP 508 `sys_platform` marker, e.g. 'linux', 'darwin', 'win32'.
+        platform_machine: `str` The PEP 508 `platform_machine` marker, e.g. 'x86_64', 'aarch64'.
+        abi_tag: `str` The ABI tag for extension modules, e.g. 'cpython-311'.
     """
     major_minor = "{}.{}".format(major, minor)
     major_minor_micro = "{}.{}".format(major_minor, micro)
@@ -183,10 +189,14 @@ def define_local_runtime_toolchain_impl(
 
     py_cc_toolchain(
         name = "py_cc_toolchain",
+        abi_flags = abi_flags,
+        abi_tag = abi_tag,
         headers = ":python_headers",
         headers_abi3 = ":python_headers_abi3",
         libs = ":libpython",
+        platform_machine = platform_machine,
         python_version = major_minor_micro,
+        sys_platform = sys_platform,
         visibility = ["//visibility:public"],
     )
 


### PR DESCRIPTION
feat(cc): populate abi and platform settings on local py_cc_toolchain

The introduction of `py_extension` added `abi_flags`, `abi_tag`, `platform_machine`, and `sys_platform` to `py_cc_toolchain`. Local Python runtime toolchains did not populate these fields, causing `py_extension` builds to fail when using local toolchains.

Extract `sys_platform`, `platform_machine`, and `abi_tag` (from `sysconfig` `SOABI`) in `get_local_runtime_info.py`, pass them through `local_runtime_repo.bzl`, and set them on `py_cc_toolchain` in `local_runtime_repo_setup.bzl`.