### PR TITLE
agents(monitor-ci-results): ignore superseded retried Buildkite jobs in CI monitor

### DIFF
--- a/.agents/skills/monitor-ci-results/scripts/monitor_remote_ci.py
+++ b/.agents/skills/monitor-ci-results/scripts/monitor_remote_ci.py
@@ -27,7 +27,7 @@ def get_pr_checks(pr_number):
     if not check_cli("gh"):
         print("❌ 'gh' CLI not installed.", file=sys.stderr)
         return []
-    cmd = ["gh", "pr", "checks", str(pr_number), "--json", "name,link,state"]
+    cmd = ["gh", "pr", "checks", str(pr_number), "--json", "name,link,state,bucket"]
     try:
         res = subprocess.run(cmd, capture_output=True, text=True)
         out = res.stdout
@@ -157,6 +157,8 @@ def main():
                 other = 0
 
                 for job in jobs:
+                    if job.get("retried_in_job_uuid") or job.get("retried_at"):
+                        continue
                     jstate = job.get("state", "unknown")
                     exit_status = job.get("exit_status")
                     is_soft_failed = job.get("soft_failed") is True
@@ -194,6 +196,8 @@ def main():
                 )
 
                 for job in jobs:
+                    if job.get("retried_in_job_uuid") or job.get("retried_at"):
+                        continue
                     jname = job.get("name", "unknown_job")
                     jstate = job.get("state", "unknown")
                     jid = job.get("id", "")


### PR DESCRIPTION
When a Buildkite job fails and is subsequently retried, both the original failed job and the retried green job remain in `data/jobs.json`. This betrayal by superseded failed jobs causes false-positive failure reporting on builds that are actually green.

To fix this, update the job aggregation logic in the CI monitor:

* Skip jobs in `data/jobs.json` where `retried_in_job_uuid` or `retried_at` is set so that only active, non-superseded jobs are evaluated.
* Add `bucket` to the `--json` output fields in `gh pr checks` to provide additional check state metadata.