### PR TITLE
agents: add concurrent multi-subagent pre-review audit to create-pr skill

### DIFF
--- a/.agents/rules/docs.md
+++ b/.agents/rules/docs.md
@@ -1,0 +1,15 @@
+---
+trigger: glob
+description: Documentation formatting, Sphinx MyST style rules, and documentation build correctness
+globs: "*.md"
+---
+
+# Documentation Rules
+
+* Act as an expert in tech writing, Sphinx, MyST, and markdown.
+* Wrap lines at 80 columns.
+* Use hyphens (`-`) in file names instead of underscores (`_`).
+* In Sphinx MyST markup, outer directives must have more colons than inner directives.
+* When adding `{versionadded}` or `{versionchanged}` sections, add them at the end of the documentation text.
+* For unreleased features or attributes, use `VERSION_NEXT_FEATURE` in `{versionadded}` / `{versionchanged}` directives.
+* **Documentation Build Correctness**: Ensure new `.bzl` files or user-facing APIs are properly registered in documentation build targets (e.g. `//docs:docs` or relevant Starlark API reference generation configs).

--- a/.agents/rules/docs.md
+++ b/.agents/rules/docs.md
@@ -1,7 +1,7 @@
 ---
 trigger: glob
 description: Documentation formatting, Sphinx MyST style rules, and documentation build correctness
-globs: "*.md"
+globs: docs/*.md
 ---
 
 # Documentation Rules

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -9,9 +9,14 @@ to handle PR creation or description drafting.
 
 ### Instructions
 
-1. Launch a subagent using `invoke_subagent` with `TypeName: "self"` (or
+1. **Pre-Review Audit Subagent**: Before drafting or creating a PR, launch a
+   subagent to run the `pre-review-audit` skill on local changes (`git diff`).
+   Verify all checks pass (e.g., `VERSION_NEXT_FEATURE` directives, no Bazel
+   copyright headers, line wrapping, Starlark formatting). Fix any issues
+   found before proceeding.
+2. Launch a subagent using `invoke_subagent` with `TypeName: "self"` (or
    `agentapi new-conversation`).
-2. Provide a prompt to the subagent directing it to:
+3. Provide a prompt to the subagent directing it to:
    - Include `@/.agents/rules/pr.md` and read `CONTRIBUTING.md` (specifically
      the sections on **Commit messages and PR descriptions** and
      **Documenting changes**) before drafting.
@@ -19,6 +24,9 @@ to handle PR creation or description drafting.
      - **PR Title**: Follow conventional commit style and title formatting.
        For agent rules, skills, and system updates, use `agents:` prefix.
      - **PR Body**: Include rationale, high-level summary, and structure.
+       **CRITICAL**: Strictly wrap all PR body text at 72 columns max
+       (GitHub uses the PR description as the commit message upon merge,
+       which reflows text at 72 columns).
      - **Formatting**: Follow repository style guidelines and structure.
    - Create a Markdown artifact (`pr_info.md`) containing the PR title, body,
      and link/metadata so the user can review and comment on it.
@@ -29,12 +37,12 @@ to handle PR creation or description drafting.
    - **Targeting Upstream Repo**: When executing `gh pr create`, always target
      the upstream repository by passing `--repo bazel-contrib/rules_python` and
      `--head <fork_owner>:<branch_name>`.
-3. **Return Status**: Direct the subagent to communicate the PR number or draft
+4. **Return Status**: Direct the subagent to communicate the PR number or draft
    status back using `send_message` (or `agentapi send-message`) with the
    parent conversation ID, or include it in its final completion response.
-4. **Publish Artifact**: Upon receiving the subagent completion message, the
+5. **Publish Artifact**: Upon receiving the subagent completion message, the
    main agent must publish `pr_info.md` to display the artifact directly in
    the primary user UI.
-5. **Interactive Actions**: To present custom action choices to the user
+6. **Interactive Actions**: To present custom action choices to the user
    (e.g., "Create PR", "Create Draft PR"), the main agent can use the
    `ask_question` tool with custom options.

--- a/.agents/skills/pre-review-audit/SKILL.md
+++ b/.agents/skills/pre-review-audit/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: pre-review-audit
+description: High-level pre-review audit of local changes when preparing to send a PR for review
+trigger: model_decision
+---
+
+When preparing to send a Pull Request for review, invoke **separate, concurrent sub-agents** (`invoke_subagent`), where each sub-agent focuses exclusively on its assigned checklist category.
+
+**CRITICAL**: Do NOT use a single sub-agent to validate multiple or all dimensions at once. Each sub-agent must be launched with its own distinct prompt file from `.agents/skills/pre-review-audit/`:
+
+### Audit Checklist & Sub-Agent Prompts
+
+1. **Starlark / Bazel Sub-Agent** (`Role: "Starlark Code Auditor"`):
+   - Prompt file: `.agents/skills/pre-review-audit/review-starlark-prompt.md`
+   - Focus: Audits Starlark / Bazel changes (`*.bzl`, `BUILD`, `*.bazel` files) in `git diff` against `.agents/rules/bzl.md` and Starlark rules in `AGENTS.md`.
+
+2. **Python Code Sub-Agent** (`Role: "Python Code Auditor"`):
+   - Prompt file: `.agents/skills/pre-review-audit/review-python-prompt.md`
+   - Focus: Audits Python source and test changes in `git diff` against `.agents/rules/python.md` and Python and pytest conventions in `AGENTS.md`.
+
+3. **Documentation Sub-Agent** (`Role: "Documentation Auditor"`):
+   - Prompt file: `.agents/skills/pre-review-audit/review-docs-prompt.md`
+   - Focus: Audits documentation (`.md`) changes and docs build targets against `.agents/rules/docs.md` and `AGENTS.md`.
+
+4. **Contribution Guidelines Sub-Agent** (`Role: "Contributing Auditor"`):
+   - Prompt file: `.agents/skills/pre-review-audit/review-contributing-prompt.md`
+   - Focus: Audits changes, requirements updates, and directives against `CONTRIBUTING.md`.
+
+5. **Project Conventions Sub-Agent** (`Role: "Project Conventions Auditor"`):
+   - Prompt file: `.agents/skills/pre-review-audit/review-agents-prompt.md`
+   - Focus: Audits overall workspace compliance against `AGENTS.md`.
+
+6. **Pull Request Standards Sub-Agent** (`Role: "PR Standards Auditor"`):
+   - Prompt file: `.agents/skills/pre-review-audit/review-pr-standards-prompt.md`
+   - Focus: Audits PR titles and descriptions against Conventional Commits formatting and PR update rules in `CONTRIBUTING.md`.
+
+### Action Instructions
+- Launch all sub-agents concurrently using `invoke_subagent`.
+- Collect the reports from each sub-agent and summarize any violations clearly with suggested fixes for the user.
+- If all domain audits pass, confirm that the PR is ready for review.

--- a/.agents/skills/pre-review-audit/review-agents-prompt.md
+++ b/.agents/skills/pre-review-audit/review-agents-prompt.md
@@ -1,0 +1,10 @@
+You are a specialized Project Conventions (`AGENTS.md`) Auditor sub-agent.
+Your sole task is to audit all local changes (`git diff`) and workspace state against `AGENTS.md`:
+
+1. Read `AGENTS.md` in full and respect all instructions within it without exception.
+2. Verify NO Bazel copyright headers (`# Copyright ... The Bazel Authors`) were added to new or existing files, unless explicitly instructed by the user.
+3. Verify that tests were executed using `bazel test --config=fast-tests` and non-test build targets did not use `--config=fast-tests`.
+4. Ensure public config settings in `python/config_settings/BUILD.bazel` were not modified unless explicitly instructed.
+5. Check that all repo rules and macro conventions described in `AGENTS.md` are respected.
+
+Report any violations found clearly with actionable suggested fixes, or report that the changes pass project conventions audit.

--- a/.agents/skills/pre-review-audit/review-agents-prompt.md
+++ b/.agents/skills/pre-review-audit/review-agents-prompt.md
@@ -1,7 +1,7 @@
 You are a specialized Project Conventions (`AGENTS.md`) Auditor sub-agent.
 Your sole task is to audit all local changes (`git diff`) and workspace state against `AGENTS.md`:
 
-1. Read `AGENTS.md` in full and respect all instructions within it without exception.
+1. Read and strictly enforce `AGENTS.md` and all `.agents/rules/*.md` files without exception.
 2. Verify NO Bazel copyright headers (`# Copyright ... The Bazel Authors`) were added to new or existing files, unless explicitly instructed by the user.
 3. Verify that tests were executed using `bazel test --config=fast-tests` and non-test build targets did not use `--config=fast-tests`.
 4. Ensure public config settings in `python/config_settings/BUILD.bazel` were not modified unless explicitly instructed.

--- a/.agents/skills/pre-review-audit/review-contributing-prompt.md
+++ b/.agents/skills/pre-review-audit/review-contributing-prompt.md
@@ -1,0 +1,9 @@
+You are a specialized Contribution Guidelines Auditor sub-agent.
+Your sole task is to audit all local changes (`git diff`), commit messages, and PR metadata against `CONTRIBUTING.md`:
+
+1. Read `CONTRIBUTING.md` in full and respect all instructions within it.
+2. Verify that `{versionadded}` and `{versionchanged}` directives use `VERSION_NEXT_FEATURE` for unreleased features.
+3. If locked/resolved requirements files (`requirements.txt`, `pyproject.toml`, `requirements.in`) were modified, verify that the associated `requirements.update` target was executed to keep locked requirement files in sync.
+4. Ensure style and conventions described in `CONTRIBUTING.md` are respected across the changes.
+
+Report any violations found clearly with actionable suggested fixes, or report that the changes pass contribution audit.

--- a/.agents/skills/pre-review-audit/review-contributing-prompt.md
+++ b/.agents/skills/pre-review-audit/review-contributing-prompt.md
@@ -1,7 +1,7 @@
 You are a specialized Contribution Guidelines Auditor sub-agent.
 Your sole task is to audit all local changes (`git diff`), commit messages, and PR metadata against `CONTRIBUTING.md`:
 
-1. Read `CONTRIBUTING.md` in full and respect all instructions within it.
+1. Read and strictly enforce `CONTRIBUTING.md`, all `.agents/rules/*.md` files, and `AGENTS.md`.
 2. Verify that `{versionadded}` and `{versionchanged}` directives use `VERSION_NEXT_FEATURE` for unreleased features.
 3. If locked/resolved requirements files (`requirements.txt`, `pyproject.toml`, `requirements.in`) were modified, verify that the associated `requirements.update` target was executed to keep locked requirement files in sync.
 4. Ensure style and conventions described in `CONTRIBUTING.md` are respected across the changes.

--- a/.agents/skills/pre-review-audit/review-docs-prompt.md
+++ b/.agents/skills/pre-review-audit/review-docs-prompt.md
@@ -1,7 +1,7 @@
 You are a specialized Documentation & Sphinx/MyST Auditor sub-agent.
 Your sole task is to audit all documentation (`.md`) changes and new `.bzl` APIs in `git diff` against the project's documentation rules:
 
-1. Read and strictly enforce `.agents/rules/docs.md` and documentation guidelines in `AGENTS.md`.
+1. Read and strictly enforce `.agents/rules/docs.md`, `AGENTS.md`, and `CONTRIBUTING.md`.
 2. Check that lines wrap at 80 columns.
 3. Ensure markdown filenames use hyphens (`-`) rather than underscores (`_`).
 4. Verify Sphinx MyST colon indentation hierarchy (outer directives must have more colons than inner directives).

--- a/.agents/skills/pre-review-audit/review-docs-prompt.md
+++ b/.agents/skills/pre-review-audit/review-docs-prompt.md
@@ -1,0 +1,12 @@
+You are a specialized Documentation & Sphinx/MyST Auditor sub-agent.
+Your sole task is to audit all documentation (`.md`) changes and new `.bzl` APIs in `git diff` against the project's documentation rules:
+
+1. Read and strictly enforce `.agents/rules/docs.md` and documentation guidelines in `AGENTS.md`.
+2. Check that lines wrap at 80 columns.
+3. Ensure markdown filenames use hyphens (`-`) rather than underscores (`_`).
+4. Verify Sphinx MyST colon indentation hierarchy (outer directives must have more colons than inner directives).
+5. Verify `{versionadded}` and `{versionchanged}` sections are placed at the end of the documentation text.
+6. For unreleased features or attributes, ensure `{versionadded}` / `{versionchanged}` directives use `VERSION_NEXT_FEATURE` (not hardcoded version numbers).
+7. Check documentation build correctness: ensure new `.bzl` files or public APIs are included in `//docs:docs` or relevant docs build targets.
+
+Report any violations found clearly with actionable suggested fixes, or report that the documentation changes pass audit.

--- a/.agents/skills/pre-review-audit/review-pr-standards-prompt.md
+++ b/.agents/skills/pre-review-audit/review-pr-standards-prompt.md
@@ -1,8 +1,9 @@
 You are a specialized PR Standards Auditor sub-agent.
-Your sole task is to audit PR titles and PR descriptions against `CONTRIBUTING.md` PR standards:
+Your sole task is to audit PR titles and PR descriptions against `CONTRIBUTING.md` and project rules:
 
-1. Check PR title formatting: must follow Conventional Commits format (e.g. `feat(cc): ...`, `docs(python): ...`). For agent rules/skills, use `agents:` prefix.
-2. Ensure PR descriptions explain *why* a change is made and provide a high-level overview of *how*, following advice in `CONTRIBUTING.md`.
-3. If a PR has already been created, enforce PR update rules: do NOT amend or rebase existing commits (create new commits and merges instead, to preserve code review comment threads).
+1. Read and strictly enforce `.agents/rules/pr.md`, `.agents/rules/news.md`, `AGENTS.md`, and `CONTRIBUTING.md`.
+2. Check PR title formatting: must follow Conventional Commits format (e.g. `feat(cc): ...`, `docs(python): ...`). For agent rules/skills, use `agents:` prefix.
+3. Ensure PR descriptions explain *why* a change is made and provide a high-level overview of *how*, following advice in `CONTRIBUTING.md`.
+4. If a PR has already been created, enforce PR update rules: do NOT amend or rebase existing commits (create new commits and merges instead, to preserve code review comment threads).
 
 Report any violations found clearly with actionable suggested fixes, or report that the PR standards pass audit.

--- a/.agents/skills/pre-review-audit/review-pr-standards-prompt.md
+++ b/.agents/skills/pre-review-audit/review-pr-standards-prompt.md
@@ -1,0 +1,8 @@
+You are a specialized PR Standards Auditor sub-agent.
+Your sole task is to audit PR titles and PR descriptions against `CONTRIBUTING.md` PR standards:
+
+1. Check PR title formatting: must follow Conventional Commits format (e.g. `feat(cc): ...`, `docs(python): ...`). For agent rules/skills, use `agents:` prefix.
+2. Ensure PR descriptions explain *why* a change is made and provide a high-level overview of *how*, following advice in `CONTRIBUTING.md`.
+3. If a PR has already been created, enforce PR update rules: do NOT amend or rebase existing commits (create new commits and merges instead, to preserve code review comment threads).
+
+Report any violations found clearly with actionable suggested fixes, or report that the PR standards pass audit.

--- a/.agents/skills/pre-review-audit/review-python-prompt.md
+++ b/.agents/skills/pre-review-audit/review-python-prompt.md
@@ -1,7 +1,7 @@
 You are a specialized Python & pytest Auditor sub-agent.
-Your sole task is to audit all Python source (`.py`) and test changes in `git diff` against the project's Python conventions in `.agents/rules/python.md` and `AGENTS.md`:
+Your sole task is to audit all Python source (`.py`) and test changes in `git diff` against the project's Python conventions:
 
-1. Read and strictly enforce `.agents/rules/python.md` and the Python guidelines in `AGENTS.md`.
+1. Read and strictly enforce `.agents/rules/python.md`, `AGENTS.md`, and `CONTRIBUTING.md`.
 2. Check Python pytest conventions: when registering pytest fixtures from helper modules in test files, use `pytest_plugins = ["<module_path>"]`.
 3. Name fixture functions with a `fixture_` prefix (e.g. `def fixture_foo():`) and pass the public fixture name using `@pytest.fixture(name="foo")`.
 4. Verify that tests were executed using Bazel (`bazel test --config=fast-tests`) and passed.

--- a/.agents/skills/pre-review-audit/review-python-prompt.md
+++ b/.agents/skills/pre-review-audit/review-python-prompt.md
@@ -1,0 +1,9 @@
+You are a specialized Python & pytest Auditor sub-agent.
+Your sole task is to audit all Python source (`.py`) and test changes in `git diff` against the project's Python conventions in `.agents/rules/python.md` and `AGENTS.md`:
+
+1. Read and strictly enforce `.agents/rules/python.md` and the Python guidelines in `AGENTS.md`.
+2. Check Python pytest conventions: when registering pytest fixtures from helper modules in test files, use `pytest_plugins = ["<module_path>"]`.
+3. Name fixture functions with a `fixture_` prefix (e.g. `def fixture_foo():`) and pass the public fixture name using `@pytest.fixture(name="foo")`.
+4. Verify that tests were executed using Bazel (`bazel test --config=fast-tests`) and passed.
+
+Report any violations found clearly with actionable suggested fixes, or report that the Python changes pass audit.

--- a/.agents/skills/pre-review-audit/review-starlark-prompt.md
+++ b/.agents/skills/pre-review-audit/review-starlark-prompt.md
@@ -1,0 +1,11 @@
+You are a specialized Starlark & Bazel Code Auditor sub-agent.
+Your sole task is to audit all Starlark (`.bzl`, `BUILD`, `WORKSPACE`, `MODULE.bazel`) changes in `git diff` against the project's Starlark coding rules and conventions:
+
+1. Read and strictly enforce `.agents/rules/bzl.md` and the Starlark style guidelines in `AGENTS.md`.
+2. Verify iterative algorithms are used (no recursion, no `while` loops).
+3. Ensure every `.bzl` file outside `tests/` has a corresponding `bzl_library` target in its `BUILD` file with proper dependencies.
+4. Ensure loads from `/private/` in test files have `# buildifier: disable=bzl-visibility`.
+5. Check multi-line rule/macro doc arguments: use triple-quoted strings (`"""`), and do NOT use trailing backslashes (`\`) on opening triple-quotes.
+6. Verify analysis tests use `rules_testing`, not `bazel_skylib`.
+
+Report any violations found clearly with actionable suggested fixes, or report that the Starlark changes pass audit.

--- a/.agents/skills/pre-review-audit/review-starlark-prompt.md
+++ b/.agents/skills/pre-review-audit/review-starlark-prompt.md
@@ -1,7 +1,7 @@
 You are a specialized Starlark & Bazel Code Auditor sub-agent.
-Your sole task is to audit all Starlark (`.bzl`, `BUILD`, `WORKSPACE`, `MODULE.bazel`) changes in `git diff` against the project's Starlark coding rules and conventions:
+Your sole task is to audit all Starlark (`.bzl`, `BUILD`, `*.bazel`) changes in `git diff` against the project's Starlark coding rules and conventions:
 
-1. Read and strictly enforce `.agents/rules/bzl.md` and the Starlark style guidelines in `AGENTS.md`.
+1. Read and strictly enforce `.agents/rules/starlark.md`, `.agents/rules/bzl.md`, `AGENTS.md`, and `CONTRIBUTING.md`.
 2. Verify iterative algorithms are used (no recursion, no `while` loops).
 3. Ensure every `.bzl` file outside `tests/` has a corresponding `bzl_library` target in its `BUILD` file with proper dependencies.
 4. Ensure loads from `/private/` in test files have `# buildifier: disable=bzl-visibility`.


### PR DESCRIPTION
To catch oversights early and prevent low-quality pull requests from
reaching reviewers, the PR creation process needs an automated quality
gate. Without pre-review validation, common formatting, documentation,
and testing errors can easily escape detection and cause unnecessary
review iterations.

This change integrates an automated, concurrent multi-subagent
pre-review quality audit directly into the PR creation workflow:

* Adds `.agents/rules/docs.md` and updates `.agents/rules/python.md` to
  define explicit domain standards for documentation and Python code.
* Introduces `.agents/skills/pre-review-audit/SKILL.md` along with 6
  specialized domain audit prompt files to inspect diffs across
  distinct technical areas concurrently.
* Updates `.agents/skills/create-pr/SKILL.md` so that `create-pr`
  automatically spawns concurrent subagents to execute the pre-review
  audit before a PR is opened, strictly wrapping PR body text at 72
  columns max.