### PR TITLE
fix(sphinxdocs): include stderr in Sphinx worker response output

### DIFF
--- a/sphinxdocs/sphinxdocs/private/sphinx_build.py
+++ b/sphinxdocs/sphinxdocs/private/sphinx_build.py
@@ -267,9 +267,19 @@ class Worker:
         # implicily bring along what the symlinks point to.
         shutil.copytree(worker_outdir, bazel_outdir, dirs_exist_ok=True)
 
+        # Include both stdout and stderr in the response output so that Sphinx
+        # warnings or diagnostic messages written to stderr are reported to the
+        # Bazel console even when the build succeeds.
+        stdout_output = stdout.getvalue()
+        stderr_output = stderr.getvalue()
+        if stderr_output:
+            output = f"--- STDOUT ---\n{stdout_output}\n--- STDERR ---\n{stderr_output}"
+        else:
+            output = stdout_output
+
         response = {
             "requestId": request.get("requestId", 0),
-            "output": stdout.getvalue(),
+            "output": output,
             "exitCode": 0,
         }
         return response


### PR DESCRIPTION
When running Sphinx in persistent worker mode, warnings and error
messages emitted to stderr during build execution were not included
in the worker response output sent back to Bazel. This made it
difficult to diagnose build warnings or diagnostic messages printed to
stderr when the worker succeeded with exit code 0.

To fix this, include both stdout and stderr in the worker response's
output dictionary with clear `--- STDOUT ---` and `--- STDERR ---`
separators when stderr is present, and document why stderr is included.

Work towards #3977.