### PR TITLE
agents: explain force-merging while requiring user consent

### DIFF
--- a/.agents/rules/pr.md
+++ b/.agents/rules/pr.md
@@ -1,6 +1,6 @@
 ---
 trigger: model_decision
-description: Apply when drafting pull request descriptions.
+description: rules to apply to pull request descriptions
 ---
 
 @CONTRIBUTING.md
@@ -18,3 +18,7 @@ Before drafting any pull request description, strictly adhere to the rules in
 * Once a Pull Request is created, always make new commits or merge commits.
 * **NEVER** amend or rebase commits on an active PR branch to avoid breaking
   code review threads.
+* **NEVER** include a list of per-file edits or changelog bullet points of
+  individual file modifications in PR descriptions or commit messages.
+* High-level overview only: state *why* the change is made and *how* at a
+  conceptual level. Link related issues (e.g. `Work towards #<issue>`).

--- a/.agents/skills/merge-pr/SKILL.md
+++ b/.agents/skills/merge-pr/SKILL.md
@@ -6,6 +6,11 @@ description: Merge a pull request into main, monitoring the merge queue, retryin
 When the user asks to merge a pull request (e.g., "merge PR <number>", "merge this PR", or monitor its merge):
 
 1. **Enqueue for Merge**: Run `gh pr merge <pr_number> --auto --squash` to enable auto-merge or add the pull request to the merge queue.
+   - **Force / Admin Merge**: **CRITICAL**: Passing `--admin` to bypass the
+     merge queue or required checks requires explicit user permission or
+     consent. Only pass `--admin` (e.g., `gh pr merge <pr_number> --admin
+     --squash`) if the user has explicitly requested or approved a force/admin
+     merge. Never invoke `--admin` autonomously.
 2. **Invoke a Background Shepherd**: Launch a background subagent with the role `Merge PR Shepherd` to continuously watch the PR until it merges.
 3. **Leverage Existing CI Skills**: 
    - Have the subagent use the **`monitor-ci-results`** skill to watch for CI check failures and generate analysis reports.


### PR DESCRIPTION
The merge-pr skill tells agents how to force merge pull requests using
gh pr merge --admin, but also explicitly requires that agents obtain
user consent before bypassing merge queues or required checks.