### PR TITLE
feat(python): add py_extension to features loadable_symbols

### DIFF
--- a/python/features.bzl
+++ b/python/features.bzl
@@ -26,6 +26,10 @@ def _features_typedef():
     A map of public API targets available in rules_python for feature detection
     purposes.
 
+    :::{seealso}
+    * {obj}`features.loadable_symbols`
+    :::
+
     :::{versionadded} 1.9.0
     :::
     ::::
@@ -53,6 +57,10 @@ def _features_typedef():
     :type: dict[str, list[str]]
 
     A map of bzl paths to the list of public symbols they export.
+
+    :::{seealso}
+    * {obj}`features.targets`
+    :::
 
     :::{versionadded} 2.2.0
     :::
@@ -128,6 +136,10 @@ _TARGETS = {
 }
 
 _LOADABLE_SYMBOLS = {
+    "//python/cc:py_extension.bzl": [
+        # keep sorted
+        "py_extension",
+    ],
     "//python:py_info.bzl": [
         # keep sorted
         "PyInfo",


### PR DESCRIPTION
Add py_extension to features.loadable_symbols.

This allows callers to use feature detection and optionally load it,
if desired.