### PR TITLE
agents(monitor-ci-results): autonomous flake retries via subagent and forbid file lists in PRs

### DIFF
--- a/.agents/skills/monitor-ci-results/SKILL.md
+++ b/.agents/skills/monitor-ci-results/SKILL.md
@@ -12,8 +12,10 @@ or when monitoring CI after PR updates:
 > launch duplicate monitoring jobs for the same PR.
 
 1. **Check Existing Process**: Check if a monitor script is already running for
-   the PR (e.g., `pgrep -f "monitor_remote_ci.py <pr_number>"`). If one is
-   already running, do not start another instance.
+   **this specific PR** using `pgrep -f "monitor_remote_ci.py <pr_number>"`. Do
+   NOT use a generic grep without `<pr_number>`, as other active agent
+   conversations may be monitoring different PRs concurrently. If one is
+   already running for this PR, do not start another instance.
 2. **Launch Monitoring Script**: If no monitor process is active for
    `<pr_number>`, launch the script in the background:
 ```bash
@@ -35,3 +37,12 @@ or when monitoring CI after PR updates:
    the monitoring script, immediately launch a separate subagent using the
    `invoke_subagent` tool with the role "CI Failure Analyzer" to run the
    `analyze-ci-failure` skill on the reported failure.
+5. **Autonomous Flake Retry**: If the CI Failure Analyzer subagent confirms
+   that the failure is a transient infrastructure or network flake (e.g. disk
+   I/O error, 504 gateway, sandbox initialization failure), **immediately and
+   autonomously** launch a separate subagent using `invoke_subagent` with the
+   role "CI Job Retrier" and the prompt template in
+   `.agents/skills/monitor-ci-results/retry-job-prompt.md` to run the
+   `buildkite-retry-job` skill for `<pr_number>`. Do not execute the script
+   directly; use the subagent and skill orchestration instead. Continue
+   monitoring without pausing to ask the user.

--- a/.agents/skills/monitor-ci-results/retry-job-prompt.md
+++ b/.agents/skills/monitor-ci-results/retry-job-prompt.md
@@ -1,0 +1,3 @@
+Use the `buildkite-retry-job` skill to retry the failed Buildkite job(s) for PR {pr_number}.
+Follow the instructions in `.agents/skills/buildkite-retry-job/SKILL.md` to retry the failing jobs using the skill.
+Once the retry request completes, report back to the parent conversation.


### PR DESCRIPTION
agents(monitor-ci-results): autonomous flake retries via subagent and forbid file lists in PRs

Scopes process checks (`pgrep -f "monitor_remote_ci.py <pr_number>"`) specifically to
the target PR number to prevent cross-PR monitoring conflicts when multiple agent
conversations run concurrently. Automates recovery from transient infrastructure
or network flakes without requiring manual human intervention.

Updates `monitor-ci-results` workflow steps to require PR-scoped process lookups
and introduces an autonomous retry step that spawns a dedicated retrier subagent
via a prompt template (`retry-job-prompt.md`) to execute the `buildkite-retry-job`
skill.