### PR TITLE
chore(release): indent multi-line bullet points in changelog

### DIFF
--- a/tests/tools/private/release/changelog_news_test.py
+++ b/tests/tools/private/release/changelog_news_test.py
@@ -495,3 +495,61 @@ def test_update_changelog_insertion_point_too_small(tmp_path):
             changelog_path=changelog_path,
             news_dir=news_dir,
         )
+
+
+def test_format_entry():
+    # Multi-line without leading bullet
+    raw = "(foo) bla bla\nblabl bla\nblabla"
+    expected = "* (foo) bla bla\n  blabl bla\n  blabla"
+    assert changelog_news._format_entry(raw) == expected
+
+    # Multi-line with leading bullet
+    raw_with_bullet = "* (foo) bla bla\nblabl bla\nblabla"
+    assert changelog_news._format_entry(raw_with_bullet) == expected
+
+    # Multi-line already indented
+    raw_indented = "* (foo) bla bla\n  blabl bla\n  blabla"
+    assert changelog_news._format_entry(raw_indented) == expected
+
+    # Empty string
+    assert changelog_news._format_entry("") == ""
+
+
+def test_update_changelog_multiline_indentation(tmp_path):
+    # Arrange
+    changelog = """# Changelog
+
+{#unreleased}
+## Unreleased
+
+[unreleased]: https://github.com/bazel-contrib/rules_python/releases/tag/unreleased
+
+{#v2-0-0}
+## [2.0.0] - 2026-04-09
+
+[2.0.0]: https://github.com/bazel-contrib/rules_python/releases/tag/2.0.0
+"""
+    changelog_path = tmp_path / "CHANGELOG.md"
+    changelog_path.write_text(changelog)
+
+    news_dir = tmp_path / "news"
+    news_dir.mkdir()
+    (news_dir / "1.fixed.md").write_text("(foo) bla bla\nblabl bla\nblabla")
+    (news_dir / "2.added.md").write_text("* (bar) feature one\nsecond line of feature")
+
+    # Act
+    changelog_news.update_changelog(
+        "2.1.0",
+        "2026-06-17",
+        changelog_path=changelog_path,
+        news_dir=news_dir,
+    )
+
+    # Assert
+    new_content = changelog_path.read_text()
+
+    expected_fixed = "### Fixed\n* (foo) bla bla\n  blabl bla\n  blabla"
+    expected_added = "### Added\n* (bar) feature one\n  second line of feature"
+
+    assert expected_fixed in new_content
+    assert expected_added in new_content

--- a/tools/private/release/changelog_news.py
+++ b/tools/private/release/changelog_news.py
@@ -34,6 +34,35 @@ def _get_news_files(news_dir):
     return [p for p in news_path.iterdir() if is_news_file(p)]
 
 
+def _format_entry(content):
+    """Formats news entry content as a markdown bullet list item.
+
+    Continuation lines are indented with two spaces.
+    """
+    lines = content.strip().splitlines()
+    if not lines:
+        return ""
+
+    formatted_lines = []
+    first_line = lines[0]
+    if not (first_line.startswith("* ") or first_line.startswith("- ")):
+        formatted_lines.append(f"* {first_line}")
+    else:
+        formatted_lines.append(first_line)
+
+    for line in lines[1:]:
+        if not line:
+            formatted_lines.append("")
+        elif line.startswith("* ") or line.startswith("- "):
+            formatted_lines.append(line)
+        elif line.startswith("  "):
+            formatted_lines.append(line)
+        else:
+            formatted_lines.append(f"  {line}")
+
+    return "\n".join(formatted_lines)
+
+
 def _parse_new_files(news_files):
     """Parses news files and groups them by category."""
     entries = {}
@@ -48,13 +77,13 @@ def _parse_new_files(news_files):
         if not content:
             continue
 
-        # Format as list item if not already
-        if not (content.startswith("* ") or content.startswith("- ")):
-            content = f"* {content}"
+        formatted_content = _format_entry(content)
+        if not formatted_content:
+            continue
 
         if category not in entries:
             entries[category] = []
-        entries[category].append(content)
+        entries[category].append(formatted_content)
 
     return entries
 


### PR DESCRIPTION
When assembling changelog entries from news files during release
preparation, multi-line descriptions had continuation lines unindented.
In Markdown, unindented continuation lines break list item hierarchy
and cause improper formatting.

Format news entries so continuation lines are indented with two spaces,
preserving proper list item structure in the generated changelog.