### PR TITLE
chore(release): add release-prepared label to prepare PRs

### DIFF
--- a/tests/tools/private/release/prepare_test.py
+++ b/tests/tools/private/release/prepare_test.py
@@ -1,5 +1,6 @@
 import argparse
 
+from tools.private.release.gh import RELEASE_PREPARED_LABEL
 from tools.private.release.prepare import Prepare
 
 pytest_plugins = ["tests.tools.private.release.release_test_helper"]
@@ -27,6 +28,7 @@ def test_prepare_success_existing_issue(mocker, release_tool_env, mock_git, mock
     assert 1002 in mock_gh.prs
     assert mock_gh.prs[1002]["title"] == "Prepare release v2.0.0"
     assert mock_gh.prs[1002]["body"] == "Work towards #1001"
+    assert mock_gh.prs[1002]["labels"] == [RELEASE_PREPARED_LABEL]
     mock_git.add_modified_and_deleted.assert_called_once()
 
 
@@ -49,6 +51,7 @@ def test_prepare_success_create_issue(mocker, release_tool_env, mock_git, mock_g
     assert 1002 in mock_gh.prs
     assert mock_gh.prs[1002]["title"] == "Prepare release v2.0.0"
     assert mock_gh.prs[1002]["body"] == "Work towards #1001"
+    assert mock_gh.prs[1002]["labels"] == [RELEASE_PREPARED_LABEL]
     mock_git.add_modified_and_deleted.assert_called_once()
 
 
@@ -154,6 +157,7 @@ def test_prepare_create_pr_when_none_associated(
     )
     updated_body = mock_gh.get_issue_body(1001)
     assert "pr=#1002" in updated_body
+    assert mock_gh.prs[1002]["labels"] == [RELEASE_PREPARED_LABEL]
 
 
 def test_prepare_reuse_existing_pr(mocker, release_tool_env, mock_git, mock_gh):

--- a/tools/private/release/gh.py
+++ b/tools/private/release/gh.py
@@ -13,6 +13,7 @@ from tools.private.release.shell import run_cmd
 # GitHub label types
 RELEASE_LABEL = "type: release"
 BACKPORT_LABEL = "type: backport-pr"
+RELEASE_PREPARED_LABEL = "release-prepared"
 
 # GitHub reaction types
 # See: https://docs.github.com/en/rest/reactions/reactions?apiVersion=2022-11-28#about-reactions

--- a/tools/private/release/prepare.py
+++ b/tools/private/release/prepare.py
@@ -6,6 +6,7 @@ import pathlib
 
 from tools.private.release import changelog_news
 from tools.private.release.gh import (
+    RELEASE_PREPARED_LABEL,
     GitHub,
     MultipleTrackingIssuesError,
     NoTrackingIssueError,
@@ -177,6 +178,7 @@ class Prepare:
                     title=f"Prepare release v{version}",
                     body=f"Work towards #{issue_num}",
                     base="main",
+                    labels=[RELEASE_PREPARED_LABEL],
                 )
                 pr_num = pr_url.split("/")[-1]
                 print(f"Created Pull Request: {pr_url} (PR #{pr_num})")


### PR DESCRIPTION
Release preparation pull requests created by the release prepare tool
did not have the `release-prepared` label applied upon creation. This
prevented downstream automation and CI workflows that filter or
trigger on this label from detecting newly prepared release PRs.

To address this, define the `release-prepared` label constant in GitHub
helpers, attach the label when creating prepare PRs, and update test
assertions to verify label assignment.