### PR TITLE
chore(release): invoke create release branch from prepare complete and support /create-release-branch

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_tracking_template.md
+++ b/.github/ISSUE_TEMPLATE/release_tracking_template.md
@@ -24,6 +24,7 @@ To manually control the release flow, see the [RELEASING.md: Manual Editing](htt
 Comment commands:
 - `/prepare`: Determines version, creates tracking issue and preparation PR.
 - `/prepare-complete [PR]`: Marks preparation task as complete.
+- `/create-release-branch`: Cuts and pushes the release branch.
 - `/create-rc`: Tags and publishes a new release candidate (RC).
 - `/process-backports`: Cherry-picks pending backports.
 - `/add-backports <PRs>`: Adds PRs to the backports and processes backports.

--- a/.github/workflows/on_comment.yaml
+++ b/.github/workflows/on_comment.yaml
@@ -57,6 +57,9 @@ jobs:
                 if [ -n "$pr_arg" ]; then
                   echo "pr_number=$pr_arg" >> "$GITHUB_OUTPUT"
                 fi
+              # Handle /create-release-branch comment
+              elif echo "$COMMENT_BODY" | grep -qE '^[[:space:]]*/create-release-branch([[:space:]]|$)'; then
+                echo "command=create-release-branch" >> "$GITHUB_OUTPUT"
               # Handle /prepare comment
               elif echo "$COMMENT_BODY" | grep -qE '^[[:space:]]*/prepare([[:space:]]|$)'; then
                 echo "command=prepare" >> "$GITHUB_OUTPUT"
@@ -132,6 +135,14 @@ jobs:
     uses: ./.github/workflows/release_complete_prepare.yaml
     with:
       pr: ${{ needs.parse_comment.outputs.pr_number }}
+      issue: ${{ needs.parse_comment.outputs.issue_number }}
+    secrets: inherit
+
+  call_create_release_branch:
+    needs: parse_comment
+    if: needs.parse_comment.outputs.command == 'create-release-branch'
+    uses: ./.github/workflows/release_create_release_branch.yaml
+    with:
       issue: ${{ needs.parse_comment.outputs.issue_number }}
     secrets: inherit
 

--- a/.github/workflows/release_complete_prepare.yaml
+++ b/.github/workflows/release_complete_prepare.yaml
@@ -37,6 +37,8 @@ jobs:
       (github.event.pull_request.merged == true &&
        contains(github.event.pull_request.labels.*.name, 'release-prepared'))
     runs-on: ubuntu-latest
+    outputs:
+      issue: ${{ steps.complete_prepare.outputs.issue }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -49,6 +51,7 @@ jobs:
           bazelisk-version: 1.20.0
 
       - name: Mark Prepare Release Complete
+        id: complete_prepare
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ inputs.pr || github.event.pull_request.number }}
@@ -66,3 +69,10 @@ jobs:
           # Run the complete-prepare subcommand in the release tool to cleanly update checklist metadata
           bazel run //tools/private/release -- \
             complete-prepare "${ARGS[@]}"
+
+  call_create_release_branch:
+    needs: complete_prepare
+    uses: ./.github/workflows/release_create_release_branch.yaml
+    with:
+      issue: ${{ needs.complete_prepare.outputs.issue }}
+    secrets: inherit

--- a/.github/workflows/release_create_release_branch.yaml
+++ b/.github/workflows/release_create_release_branch.yaml
@@ -1,8 +1,18 @@
 name: "Release: Create Release Branch"
 
 on:
-  issues:
-    types: [edited]
+  workflow_dispatch:
+    inputs:
+      issue:
+        description: 'The Release Tracking Issue Number (e.g., 142)'
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      issue:
+        description: 'The Release Tracking Issue Number (e.g., 142)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -10,8 +20,6 @@ permissions:
 
 jobs:
   cut_branch:
-    # Run only if the issue has the type: release label
-    if: "contains(github.event.issue.labels.*.name, 'type: release')"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -30,11 +38,11 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Attempt Branch Creation
-        run: |
-          bazel run //tools/private/release -- \
-            create-release-branch --issue ${{ github.event.issue.number }} --remote origin
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bazel run //tools/private/release -- \
+            create-release-branch --issue "${{ inputs.issue }}" --remote origin
 
   # A no-op job that always runs to prevent "no jobs ran" failures
   # when the main job is skipped.
@@ -43,4 +51,5 @@ jobs:
     steps:
       - name: Echo Success
         run: echo "Success"
+
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -259,6 +259,8 @@ The checklist items use metadata suffix: `| key=value key2=value2`.
 *   **Retry Prepare Release**: Reset the task to `- [ ] Prepare Release | status=awaiting-preparation`.
 *   **Complete Prepare Release**: Comment `/prepare-complete` on the tracking
     issue (or on the preparation PR) to mark the preparation task as done.
+*   **Create Release Branch**: Comment `/create-release-branch` on the tracking
+    issue to cut and push the release branch.
 *   **Force Task Done**: Check the box `- [x]` and add appropriate metadata (e.g. `status=done`).
 
 ## Secrets

--- a/tests/tools/private/release/complete_prepare_test.py
+++ b/tests/tools/private/release/complete_prepare_test.py
@@ -35,6 +35,35 @@ def test_complete_prepare_with_pr_success(mock_gh):
     )
 
 
+def test_complete_prepare_writes_github_output(release_tool_env, mock_gh):
+    args = argparse.Namespace(pr=456, issue=None)
+    mock_gh.prs[456] = {
+        "state": "MERGED",
+        "body": "Prepare release for v2.0.0\n\nWork towards #123",
+        "mergeCommit": {"oid": "abcdef1234567890"},
+    }
+    issue_body = """
+## Checklist
+- [ ] Prepare Release | status=pending pr=#456
+- [ ] Create Release branch
+- [ ] Tag Final
+"""
+    mock_gh.issues[123] = {
+        "title": "Release 2.0.0",
+        "body": issue_body,
+        "labels": ["type: release"],
+        "number": 123,
+        "url": "https://github.com/bazel-contrib/rules_python/issues/123",
+    }
+
+    result = CompletePrepare(args, mock_gh).run()
+    assert result == 0
+    assert release_tool_env.github_output_file.exists()
+    assert (
+        release_tool_env.github_output_file.read_text(encoding="utf-8") == "issue=123\n"
+    )
+
+
 def test_complete_prepare_with_issue_success(mock_gh):
     args = argparse.Namespace(pr=None, issue=123)
     mock_gh.prs[456] = {

--- a/tests/tools/private/release/release_test_helper.py
+++ b/tests/tools/private/release/release_test_helper.py
@@ -13,9 +13,11 @@ class ReleaseToolEnv:
 
     Attributes:
         git_root: The root path of the temporary Git repository workspace.
+        github_output_file: Path to the mocked GITHUB_OUTPUT file.
     """
 
     git_root: Path
+    github_output_file: Path
 
 
 DEFAULT_RELEASE_TEMPLATE_CONTENT = (
@@ -55,4 +57,6 @@ def fixture_release_tool_env(tmp_path, monkeypatch):
     template_dir.mkdir(parents=True, exist_ok=True)
     template_file = template_dir / "release_tracking_template.md"
     template_file.write_text(DEFAULT_RELEASE_TEMPLATE_CONTENT, encoding="utf-8")
-    yield ReleaseToolEnv(git_root=tmp_path)
+    github_output_file = tmp_path / "github_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output_file))
+    yield ReleaseToolEnv(git_root=tmp_path, github_output_file=github_output_file)

--- a/tools/private/release/complete_prepare.py
+++ b/tools/private/release/complete_prepare.py
@@ -7,6 +7,7 @@ from tools.private.release.release_issue import (
     parse_checklist_state,
     update_task_in_body,
 )
+from tools.private.release.utils import set_github_output
 
 
 class CompletePrepare:
@@ -80,6 +81,9 @@ class CompletePrepare:
         )
         self.gh.update_issue_body(issue_number, updated_body)
         print("Prepare Release task marked complete successfully!")
+
+        set_github_output("issue", str(issue_number))
+
         return 0
 
     @classmethod

--- a/tools/private/release/create_rc.py
+++ b/tools/private/release/create_rc.py
@@ -1,5 +1,6 @@
 """Subcommand to tag and push the next release candidate."""
 
+import os
 import traceback
 from argparse import Namespace
 
@@ -16,6 +17,7 @@ from tools.private.release.release_issue import (
 from tools.private.release.utils import (
     REPO_URL,
     get_latest_rc_tag,
+    set_github_output,
 )
 
 
@@ -142,11 +144,7 @@ class CreateRc:
         self.git.tag(next_rc, target_ref)
         self.git.push(args.remote, next_rc)
 
-        import os
-
-        if "GITHUB_OUTPUT" in os.environ:
-            with open(os.environ["GITHUB_OUTPUT"], "a") as f:
-                f.write(f"tag_name={next_rc}\n")
+        set_github_output("tag_name", next_rc)
 
         # Check off the appropriate "Tag RC{N}" task in the checklist
         print(f"Checking off Tag RC{next_rc_num} task...")

--- a/tools/private/release/promote.py
+++ b/tools/private/release/promote.py
@@ -15,6 +15,7 @@ from tools.private.release.utils import (
     determine_next_version,
     get_latest_rc_tag,
     semver_type,
+    set_github_output,
 )
 
 
@@ -170,9 +171,7 @@ class Promote:
         self.git.tag(version, commit_sha)
         self.git.push(args.remote, version)
 
-        if github_output := os.environ.get("GITHUB_OUTPUT"):
-            with open(github_output, "a", encoding="utf-8") as f:
-                f.write(f"version={version}\n")
+        set_github_output("version", version)
 
         print(f"Updating tracking issue #{issue_num} checklist...")
         self.gh.update_issue_body(issue_num, updated_body)

--- a/tools/private/release/utils.py
+++ b/tools/private/release/utils.py
@@ -184,3 +184,10 @@ def parse_pr_list(value: str) -> list[str]:
         return []
     # Split by space and/or comma
     return [p for p in re.split(r"[\s,]+", value.strip()) if p]
+
+
+def set_github_output(name: str, value: str) -> None:
+    """Sets a GitHub Actions output parameter if GITHUB_OUTPUT is set."""
+    if github_output := os.environ.get("GITHUB_OUTPUT"):
+        with open(github_output, "a", encoding="utf-8") as f:
+            f.write(f"{name}={value}\n")


### PR DESCRIPTION
Triggering the create release branch workflow on issue edits fired
unnecessarily on unrelated edits and failed to trigger when other
GitHub Actions modified the issue due to token recursion limits.
Maintainers also lacked a direct comment command to manually cut the
release branch from a release tracking issue if needed.

Invoke the create release branch workflow automatically upon
completion of the prepare workflow, support manual and reusable
workflow dispatch with a tracking issue input, add
`/create-release-branch` comment command support, and introduce a
shared helper for writing GitHub Actions step outputs across release
tools.