### PR TITLE
agents: document Windows machine normalization and SOABI support

### DIFF
--- a/.agents/rules/windows.md
+++ b/.agents/rules/windows.md
@@ -18,4 +18,13 @@
 ## Windows Platform Tag Derivation
 * Windows platform tags for Python C extensions evaluate to `win_amd64`
   (x86_64/amd64), `win_arm64` (aarch64/arm64), or `win32` (32-bit x86).
+* **`platform.machine()` Normalization**: On Windows, `platform.machine()` returns
+  uppercase (`"AMD64"`, `"ARM64"`). Always normalize with `.lower()` when
+  deriving PEP 508 markers or resolving platform tags.
 * **Citation**: [PEP 425 — Compatibility Tags for Built Distributions](https://peps.python.org/pep-0425/).
+
+## Windows CPython SOABI & ABI Infix Support
+* CPython on Windows natively supports loading ABI-tagged `.pyd` files
+  containing platform tags (e.g., `foo.cp314-win_amd64.pyd`, `foo.cp311-win_amd64.pyd`).
+* SOABI on Windows includes both the ABI prefix and platform tag (e.g.,
+  `cp311-win_amd64`).

--- a/.agents/rules/windows.md
+++ b/.agents/rules/windows.md
@@ -18,13 +18,15 @@
 ## Windows Platform Tag Derivation
 * Windows platform tags for Python C extensions evaluate to `win_amd64`
   (x86_64/amd64), `win_arm64` (aarch64/arm64), or `win32` (32-bit x86).
-* **`platform.machine()` Normalization**: On Windows, `platform.machine()` returns
-  uppercase (`"AMD64"`, `"ARM64"`). Always normalize with `.lower()` when
-  deriving PEP 508 markers or resolving platform tags.
+* **`platform.machine()` Normalization**: On Windows,
+  `platform.machine()` returns uppercase (`"AMD64"`, `"ARM64"`). Always
+  normalize with `.lower()` when deriving PEP 508 markers or resolving platform
+  tags.
 * **Citation**: [PEP 425 — Compatibility Tags for Built Distributions](https://peps.python.org/pep-0425/).
 
 ## Windows CPython SOABI & ABI Infix Support
 * CPython on Windows natively supports loading ABI-tagged `.pyd` files
-  containing platform tags (e.g., `foo.cp314-win_amd64.pyd`, `foo.cp311-win_amd64.pyd`).
+  containing platform tags (e.g., `foo.cp314-win_amd64.pyd`,
+  `foo.cp311-win_amd64.pyd`).
 * SOABI on Windows includes both the ABI prefix and platform tag (e.g.,
   `cp311-win_amd64`).


### PR DESCRIPTION
Agents resolving platform tags on Windows may encounter uppercase
strings from platform.machine(), leading to mismatch errors when
matching PEP 508 tags. Additionally, agents lacked guidance on Windows
CPython native support for SOABI ABI infix tags.

Document the requirement to normalize platform.machine() to lowercase
and clarify native SOABI platform tag support for Windows CPython.