### PR TITLE
agents: add merge queue CI monitoring and lockfile sync rules

### DIFF
--- a/.agents/rules/testing.md
+++ b/.agents/rules/testing.md
@@ -13,6 +13,11 @@
 * Changes to transitive module extension dependencies or `.bzl` files loaded by
   extensions update Bazel 9 lockfile hashes, requiring `bazel mod deps
   --lockfile_mode=update` in integration test workspaces.
+* When requirements files (e.g., in `//tools/publish` or root pip parses) are
+  modified or bumped by Dependabot, update the integration lockfile by running
+  `bazel mod deps --lockfile_mode=update` in `tests/integration/bzlmod_lockfile`
+  and verify with
+  `bazel test //tests/integration:bzlmod_lockfile_test_bazel_9.1.0`.
 
 ## Documentation Flake Handling
 * When building `//docs:docs` fails with exit code 2, treat it as a known

--- a/.agents/skills/merge-pr/SKILL.md
+++ b/.agents/skills/merge-pr/SKILL.md
@@ -13,7 +13,15 @@ When the user asks to merge a pull request (e.g., "merge PR <number>", "merge th
      merge. Never invoke `--admin` autonomously.
 2. **Invoke a Background Shepherd**: Launch a background subagent with the role `Merge PR Shepherd` to continuously watch the PR until it merges.
 3. **Leverage Existing CI Skills**: 
-   - Have the subagent use the **`monitor-ci-results`** skill to watch for CI check failures and generate analysis reports.
-   - Have the subagent use the **`buildkite-retry-job`** skill (`retry_buildkite_jobs.py <pr_number>`) to automatically retry any transient network flakes (e.g., HTTP 504 gateway timeouts, downloader errors).
+   - Have the subagent use the **`monitor-ci-results`** skill to watch for CI
+     check failures and generate analysis reports.
+   - Have the subagent use the **`buildkite-retry-job`** skill
+     (`retry_buildkite_jobs.py <pr_number>`) to automatically retry any
+     transient network flakes (e.g., HTTP 504 gateway timeouts, downloader
+     errors).
+   - When the PR is queued, actively discover the merge queue branch via
+     `gh api repos/:owner/:repo/branches --jq '.[].name | select(test("gh-readonly-queue/.*/pr-<pr_number>-"))'`
+     and monitor commit statuses/Buildkite builds running on that temporary
+     branch.
 4. **Queue Shepherding**: Periodically check `gh pr view <pr_number> --json state,autoMergeRequest`. While `state` is `"OPEN"`, ensure auto-merge is enabled / queued by running `gh pr merge <pr_number> --auto --squash`. If `autoMergeRequest` is null (e.g., ejected from the merge queue due to a CI flake in the temporary queue branch), re-enqueue it for merge by running `gh pr merge <pr_number> --auto --squash` once checks are retried or green.
 5. **Completion Notification**: Once `state` becomes `"MERGED"`, send a high-priority message back to the parent conversation.


### PR DESCRIPTION
CI monitoring previously missed runs executed on GitHub merge queue
temporary branches (`gh-readonly-queue/...`), and integration lockfiles
became out of sync when requirements were bumped.

Update merge shepherd guidance to discover and monitor merge queue
branch statuses, and add testing rules to synchronize Bazel lockfiles
in integration test workspaces whenever dependencies or requirements
files change.