### PR TITLE
fix: preserve arguments with spaces

### DIFF
--- a/python/private/runtime_env_toolchain_interpreter.sh
+++ b/python/private/runtime_env_toolchain_interpreter.sh
@@ -77,7 +77,7 @@ if [ -e "$self_dir/pyvenv.cfg" ] || [ -e "$self_dir/../pyvenv.cfg" ]; then
   # binary, not the actual one invoked.
   # NOTE: exec -a would be simpler, but isn't posix-compatible, and dash shell
   # (Ubuntu/debian default) doesn't support it; see #3009.
-  exec sh -c "$PYTHON_BIN \$@" "$venv_bin" "$@"
+  exec sh -c 'exec "$@"' "$venv_bin" "$PYTHON_BIN" "$@"
 else
   exec "$PYTHON_BIN" "$@"
 fi

--- a/tests/runtime_env_toolchain/BUILD.bazel
+++ b/tests/runtime_env_toolchain/BUILD.bazel
@@ -44,6 +44,7 @@ py_reconfig_test(
 py_reconfig_test(
     name = "bootstrap_script_test",
     srcs = ["toolchain_runs_test.py"],
+    args = ["'argument with spaces'"],
     bootstrap_impl = "script",
     data = [
         "//tests/support:current_build_settings",

--- a/tests/runtime_env_toolchain/toolchain_runs_test.py
+++ b/tests/runtime_env_toolchain/toolchain_runs_test.py
@@ -26,6 +26,7 @@ class RunTest(unittest.TestCase):
             )
 
         if settings["bootstrap_impl"] == "script":
+            self.assertEqual(sys.argv[1:], ["argument with spaces"])
             # Verify we're running in a venv
             self.assertNotEqual(sys.prefix, sys.base_prefix)
             # .venv/ occurs for a build-time venv.
@@ -35,4 +36,4 @@ class RunTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main(argv=sys.argv[:1])


### PR DESCRIPTION
The runtime environment launcher collapsed interpreter arguments into one shell word. It now forwards each argument without reparsing it, preserving the original argument boundaries.

This includes a regression test for interpreter arguments containing spaces.

Related: https://github.com/bazelbuild/bazel/issues/30644