### PR TITLE
agents(rules): document git push -u guardrail and delegating function docstrings

### DIFF
--- a/.agents/rules/python.md
+++ b/.agents/rules/python.md
@@ -13,3 +13,8 @@
 * **External Objects**: When defining a `TypedDict` for an external object,
   link to its definition in the docstring.
 
+## Delegating Functions
+* Module-level functions delegating to class methods should have a docstring
+  referring to the class method (e.g. `"""Refer to \`Class.method\`."""`).
+
+

--- a/.agents/rules/workspace.md
+++ b/.agents/rules/workspace.md
@@ -16,3 +16,5 @@ basis:
   ```bash
   .agents/scripts/setup_triangle_branch.sh <branch>
   ```
+* Never use `git push -u` or `--set-upstream` (it breaks upstream tracking).
+


### PR DESCRIPTION
Using `git push -u` or `--set-upstream` disrupts triangle branch
tracking by repointing the local tracking branch away from upstream.
Additionally, delegating helper functions need consistent docstring
references to their underlying implementations.

Update workspace and Python agent rules to prohibit setting upstream
on push and establish a docstring reference convention for delegating
functions.