### PR TITLE
agents: document dev python version bump and merge queue fields

### DIFF
--- a/.agents/skills/merge-pr/SKILL.md
+++ b/.agents/skills/merge-pr/SKILL.md
@@ -23,5 +23,11 @@ When the user asks to merge a pull request (e.g., "merge PR <number>", "merge th
      `gh api repos/:owner/:repo/branches --jq '.[].name | select(test("gh-readonly-queue/.*/pr-<pr_number>-"))'`
      and monitor commit statuses/Buildkite builds running on that temporary
      branch.
-4. **Queue Shepherding**: Periodically check `gh pr view <pr_number> --json state,autoMergeRequest`. While `state` is `"OPEN"`, ensure auto-merge is enabled / queued by running `gh pr merge <pr_number> --auto --squash`. If `autoMergeRequest` is null (e.g., ejected from the merge queue due to a CI flake in the temporary queue branch), re-enqueue it for merge by running `gh pr merge <pr_number> --auto --squash` once checks are retried or green.
+4. **Queue Shepherding**: Periodically check `gh pr view <pr_number> --json
+   state,autoMergeRequest,mergeStateStatus,mergeable`. While `state` is
+   `"OPEN"`, ensure auto-merge is enabled / queued by running `gh pr merge
+   <pr_number> --auto --squash`. If `autoMergeRequest` is null (e.g., ejected
+   from the merge queue due to a CI flake in the temporary queue branch),
+   re-enqueue it for merge by running `gh pr merge <pr_number> --auto --squash`
+   once checks are retried or green.
 5. **Completion Notification**: Once `state` becomes `"MERGED"`, send a high-priority message back to the parent conversation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,6 +211,14 @@ When modifying locked/resolved requirements files:
     the requirements.txt file. That will update the locked/resolved
     requirements.txt file.
 
+When updating the minimum Python version for dev/docs tooling (e.g. following
+Dependabot alerts):
+  * Update `python_version` in both `lock(name = "requirements", ...)` and
+    `lock(name = "uv_lock", ...)` within `dev/BUILD.bazel`.
+  * Regenerate lockfiles by running:
+    `bazel run //dev:requirements.update && bazel run //dev:uv_lock.update`
+  * Verify docs build via `bazel build //docs:docs`.
+
 ## rules_python idiosyncrasies
 
 When building `//docs:docs`, ignore an error about exit code 2; this is a flake,


### PR DESCRIPTION
Updating dev tooling Python versions requires updating multiple lock
configurations and regenerating lockfiles, but this process was not
documented in agent instructions. In addition, the merge-pr skill
needed to query additional GitHub PR state fields to reliably inspect
merge queue status and mergeability.

Add developer guidance for bumping dev tooling Python versions and
running lockfile update commands, and expand the gh pr view fields
queried during merge queue shepherding.