### PR TITLE
agents(rules): update python rules with typing and runfiles conventions

### DIFF
--- a/.agents/rules/python.md
+++ b/.agents/rules/python.md
@@ -18,10 +18,22 @@
   (e.g. `[missing-import]`) over `tags = ["no-pyrefly"]`.
 * **No blanket ignores**: NEVER use bare `# type: ignore` or literal
   `# type: ignore[...]`. Use error-specific ignores instead.
+* **Ignore comments**: When adding `# pyrefly: ignore[...]` or type
+  suppressions, add an explanatory comment indicating why it is suppressed.
 * **Type assertions**: When adding assertions for type narrowing, add an
   end-of-line comment: `assert foo is not None  # type assert`.
 * **Consent for `Any`**: Require user consent before changing type annotations
   to `Any`.
+* **Union syntax (`X | None`)**: Use `X | None` instead of `typing.Optional[X]`.
+  Add `from __future__ import annotations` if necessary.
+* **Collections generics**: Use `collections.abc` (e.g., `Sequence`, `Iterable`,
+  `Iterator`, `Callable`, `Mapping`) and builtin generics (`list`, `dict`,
+  `tuple`, `set`) instead of `typing.XXX` collection types.
+
+## Runfiles
+* **Fail-fast creation**: Prefer `runfiles.CreateOrRaise()` over
+  `runfiles.Create()` followed by manual `assert` when initializing runfiles in
+  tests and runtime scripts.
 
 ## Delegating Functions
 * Module-level functions delegating to class methods should have a docstring


### PR DESCRIPTION
Update the Python agent rules to standardize type annotation practices
and simplify runfiles initialization across Python files.

Clarify best practices by requiring explanatory comments for type
suppressions, adopting modern union syntax (`X | None`), and preferring
generic collections from `collections.abc` and builtins over legacy
`typing` equivalents. Additionally, instruct agents to prefer fail-fast
`runfiles.CreateOrRaise()` when setting up Bazel runfiles.