### PR TITLE
build(ci): remove legacy mypy type checking workflow and comments

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,17 +17,6 @@ permissions:
   contents: read
 
 jobs:
-  mypy:
-    runs-on: ubuntu-latest
-    steps:
-      # Checkout the code
-      - uses: actions/checkout@v7
-      - uses: jpetrucciani/mypy-check@master
-        with:
-          path: 'python/runfiles'
-      - uses: jpetrucciani/mypy-check@master
-        with:
-          path: 'tests/runfiles'
   ruff:
     runs-on: ubuntu-latest
     steps:

--- a/python/runfiles/runfiles.py
+++ b/python/runfiles/runfiles.py
@@ -162,7 +162,7 @@ class Path(pathlib.Path):
     using the associated `Runfiles` instance when converted to a string.
     """
 
-    # Mypy isn't smart enough to realize `self` in the methods
+    # Static type checkers may not realize `self` in the methods
     # refers to our Path class instead of pathlib.Path
     _runfiles: Runfiles | None
     _source_repo: str | None
@@ -231,8 +231,8 @@ class Path(pathlib.Path):
     # override
     def _make_child(self, args: tuple[str, ...]) -> Self:
         # _make_child is an internal CPython method in Python < 3.12 omitted from
-        # typeshed stubs. We ignore [misc] for mypy and [missing-attribute] for pyrefly.
-        obj = cast("Path", super()._make_child(args))  # type: ignore[misc]  # pyrefly: ignore[missing-attribute]
+        # typeshed stubs. We ignore [missing-attribute] for pyrefly.
+        obj = cast("Path", super()._make_child(args))  # pyrefly: ignore[missing-attribute]
         obj._runfiles = self._runfiles
         obj._source_repo = self._source_repo
         return cast(Self, obj)
@@ -378,13 +378,13 @@ class Path(pathlib.Path):
         path_posix = super().__str__().replace("\\", "/")
         if not path_posix or path_posix == ".":
             # pylint: disable=protected-access
-            return self._runfiles._python_runfiles_root  # type: ignore[attr-defined]  # pyrefly: ignore[missing-attribute]
+            return self._runfiles._python_runfiles_root  # pyrefly: ignore[missing-attribute]
         resolved = self._runfiles.Rlocation(path_posix, source_repo=self._source_repo)
         if resolved is not None:
             return resolved
 
         # pylint: disable=protected-access
-        return posixpath.join(self._runfiles._python_runfiles_root, path_posix)  # type: ignore[attr-defined]  # pyrefly: ignore[missing-attribute]
+        return posixpath.join(self._runfiles._python_runfiles_root, path_posix)  # pyrefly: ignore[missing-attribute]
 
     def __fspath__(self) -> str:
         return str(self)

--- a/tests/runfiles/runfiles_test.py
+++ b/tests/runfiles/runfiles_test.py
@@ -30,10 +30,10 @@ class RunfilesTest(unittest.TestCase):
 
     def testRlocationArgumentValidation(self) -> None:
         r = runfiles.Create({"RUNFILES_DIR": "whatever"})
-        assert r is not None  # mypy doesn't understand the unittest api.
-        self.assertRaises(ValueError, lambda: r.Rlocation(None))  # type: ignore[arg-type]  # pyrefly: ignore[bad-argument-type]
+        assert r is not None  # type assert
+        self.assertRaises(ValueError, lambda: r.Rlocation(None))  # pyrefly: ignore[bad-argument-type]
         self.assertRaises(ValueError, lambda: r.Rlocation(""))
-        self.assertRaises(TypeError, lambda: r.Rlocation(1))  # type: ignore[arg-type]  # pyrefly: ignore[bad-argument-type]
+        self.assertRaises(TypeError, lambda: r.Rlocation(1))  # pyrefly: ignore[bad-argument-type]
         self.assertRaisesRegex(
             ValueError, "is not normalized", lambda: r.Rlocation("../foo")
         )
@@ -69,7 +69,7 @@ class RunfilesTest(unittest.TestCase):
 
     def testRlocationWithData(self) -> None:
         r = runfiles.Create()
-        assert r is not None  # mypy doesn't understand the unittest api.
+        assert r is not None  # type assert
         settings_path = r.Rlocation(
             "rules_python/tests/support/current_build_settings.json"
         )
@@ -86,7 +86,7 @@ class RunfilesTest(unittest.TestCase):
                     "TEST_SRCDIR": "always ignored",
                 }
             )
-            assert r is not None  # mypy doesn't understand the unittest api.
+            assert r is not None  # type assert
             self.assertEqual(r.Rlocation("a/b"), "c/d")
             self.assertIsNone(r.Rlocation("foo"))
 
@@ -98,7 +98,7 @@ class RunfilesTest(unittest.TestCase):
                     "TEST_SRCDIR": "always ignored",
                 }
             )
-            assert r is not None  # mypy doesn't understand the unittest api.
+            assert r is not None  # type assert
             self.assertDictEqual(
                 r.EnvVars(),
                 {
@@ -115,7 +115,7 @@ class RunfilesTest(unittest.TestCase):
                     "TEST_SRCDIR": "always ignored",
                 }
             )
-            assert r is not None  # mypy doesn't understand the unittest api.
+            assert r is not None  # type assert
             self.assertDictEqual(
                 r.EnvVars(),
                 {
@@ -136,7 +136,7 @@ class RunfilesTest(unittest.TestCase):
                     "TEST_SRCDIR": "always ignored",
                 }
             )
-            assert r is not None  # mypy doesn't understand the unittest api.
+            assert r is not None  # type assert
             self.assertDictEqual(
                 r.EnvVars(),
                 {
@@ -153,7 +153,7 @@ class RunfilesTest(unittest.TestCase):
                 "TEST_SRCDIR": "always ignored",
             }
         )
-        assert r is not None  # mypy doesn't understand the unittest api.
+        assert r is not None  # type assert
         self.assertEqual(r.Rlocation("a/b"), "runfiles/dir/a/b")
         self.assertEqual(r.Rlocation("foo"), "runfiles/dir/foo")
 
@@ -164,7 +164,7 @@ class RunfilesTest(unittest.TestCase):
                 "TEST_SRCDIR": "always ignored",
             }
         )
-        assert r is not None  # mypy doesn't understand the unittest api.
+        assert r is not None  # type assert
         self.assertDictEqual(
             r.EnvVars(),
             {
@@ -763,7 +763,7 @@ class RunfilesTest(unittest.TestCase):
         else:
             expected = "rules_python"
         r = runfiles.Create()
-        assert r is not None  # mypy doesn't understand the unittest api.
+        assert r is not None  # type assert
         self.assertEqual(r.CurrentRepository(), expected)
 
     @staticmethod


### PR DESCRIPTION
Static type checking across the repository has been consolidated under
Pyrefly. The standalone GitHub Actions mypy workflow and mypy-specific
type ignore comments and suppressions are no longer necessary.

Remove the legacy mypy CI job from GitHub Actions workflows, clean up
mypy-specific type suppressions and comments in runfiles library code
and tests, and standardize type narrowing assertions.