### PR TITLE
agents(rules): update github_actions_workflows rule with python script and testing conventions

### DIFF
--- a/.agents/rules/github_actions_workflows.md
+++ b/.agents/rules/github_actions_workflows.md
@@ -10,3 +10,14 @@ globs: [".github/workflows/*.yml", ".github/workflows/*.yaml", ".github/*.yaml"]
 * Preserve `suppress-no-jobs-ran-error` fallback jobs in conditional workflows.
 * Pass inputs (e.g. `${{ inputs.issue }}`) directly to commands without
   redundant shell parameter stripping or conversions.
+* Print console messages using GitHub workflow command syntax (e.g.,
+  `::error::`, `::warning::`, `::notice::`, `::group::`).
+
+## Workflow Python Scripts & Testing
+* **Test Location**: Place workflow tests under `tests/workflows/`.
+* **Imports over `sys.path`**: Never alter `sys.path`. Define a `py_library`
+  with `imports = ["../../.github/workflows"]` in `tests/workflows/BUILD.bazel`.
+* **Functional Design & Fixtures**: Keep scripts functional with one public
+  entry point (e.g. `process_comment()`) and private helpers (`_` prefix). Write
+  outputs directly when matching actions. Test end-to-end via autouse fixtures
+  for GHA env files and API mocks.


### PR DESCRIPTION
Workflow automation scripts and tests across GitHub Actions lacked
clear, standardized rules for console logging, test placement, Bazel
import targets, and test fixture design. Without shared guidelines,
scripts risked inconsistent log formatting, sys.path manipulations, and
ad-hoc test structures.

Update .agents/rules/github_actions_workflows.md to require GitHub
workflow command syntax for console logging, define tests under
tests/workflows/, prefer py_library imports over sys.path alterations,
and follow functional script design with autouse fixtures for mocks.