### PR TITLE
agents(review-code): export review results artifact and factor report format

### DIFF
--- a/.agents/skills/review-code/SKILL.md
+++ b/.agents/skills/review-code/SKILL.md
@@ -54,6 +54,12 @@ file from `.agents/skills/review-code/`:
 
 ### Action Instructions
 - Launch all sub-agents concurrently using `invoke_subagent`.
-- Collect the reports from each sub-agent and report all violations and
-  suggested improvements clearly with suggested fixes for the user.
-- If all domain audits pass, confirm that the PR is ready for review.
+- Collect the reports from each sub-agent.
+- Create a user-facing review artifact named `code-review-results.md` in the
+  conversation artifact directory. The artifact must include:
+  - Overall summary and verdict across audit categories.
+  - Detailed analysis and findings from each sub-agent.
+  - Actionable findings and fix suggestions with specific code snippets, diffs,
+    and clickable file links for any violations found.
+- In the response, provide a concise summary with the overall verdict and a
+  clickable markdown link to `code-review-results.md`.

--- a/.agents/skills/review-code/review-agents-prompt.md
+++ b/.agents/skills/review-code/review-agents-prompt.md
@@ -14,5 +14,4 @@ against `AGENTS.md`:
 5. Check that all repo rules and macro conventions described in `AGENTS.md`
    are respected.
 
-Report any violations found clearly with actionable suggested fixes, or report
-that the changes pass project conventions audit.
+@.agents/skills/review-code/review-report-format.md

--- a/.agents/skills/review-code/review-contributing-prompt.md
+++ b/.agents/skills/review-code/review-contributing-prompt.md
@@ -33,5 +33,4 @@ and PR metadata against `CONTRIBUTING.md` and project rules:
 5. Ensure style and conventions described in `CONTRIBUTING.md` are respected
    across all changes.
 
-Report any violations found clearly with actionable suggested fixes, or report
-that the changes pass contribution audit.
+@.agents/skills/review-code/review-report-format.md

--- a/.agents/skills/review-code/review-docs-prompt.md
+++ b/.agents/skills/review-code/review-docs-prompt.md
@@ -20,5 +20,4 @@ in `git diff` against the project's documentation rules:
    `.agents/rules/news.md` and `CONTRIBUTING.md` (proper `<id>.<category>.md`
    name, no leading bullets, subsystem prefix, `{obj}` refs, issue links).
 
-Report any violations found clearly with actionable suggested fixes, or report
-that the documentation changes pass audit.
+@.agents/skills/review-code/review-report-format.md

--- a/.agents/skills/review-code/review-pr-standards-prompt.md
+++ b/.agents/skills/review-code/review-pr-standards-prompt.md
@@ -13,5 +13,4 @@ Your sole task is to audit PR titles and PR descriptions against
    rebase existing commits (create new commits and merges instead, to preserve
    code review comment threads).
 
-Report any violations found clearly with actionable suggested fixes, or report
-that the PR standards pass audit.
+@.agents/skills/review-code/review-report-format.md

--- a/.agents/skills/review-code/review-python-prompt.md
+++ b/.agents/skills/review-code/review-python-prompt.md
@@ -11,5 +11,4 @@ Your sole task is to audit all Python source (`.py`) and test changes in
 4. Verify that tests were executed using Bazel
    (`bazel test --config=fast-tests`) and passed.
 
-Report any violations found clearly with actionable suggested fixes, or report
-that the Python changes pass audit.
+@.agents/skills/review-code/review-report-format.md

--- a/.agents/skills/review-code/review-report-format.md
+++ b/.agents/skills/review-code/review-report-format.md
@@ -1,0 +1,6 @@
+Provide a structured report containing:
+- Status: PASS, WARNING, ACTION_REQUIRED, USER_DECISION_REQUIRED, or
+  NOT_APPLICABLE
+- Detailed analysis and findings for each item checked
+- Actionable findings and fix suggestions with specific code snippets, diffs,
+  and clickable file links for any violations found

--- a/.agents/skills/review-code/review-starlark-prompt.md
+++ b/.agents/skills/review-code/review-starlark-prompt.md
@@ -13,5 +13,4 @@ in `git diff` against the project's Starlark coding rules and conventions:
    (`"""`), and do NOT use trailing backslashes (`\`) on opening triple-quotes.
 6. Verify analysis tests use `rules_testing`, not `bazel_skylib`.
 
-Report any violations found clearly with actionable suggested fixes, or report
-that the Starlark changes pass audit.
+@.agents/skills/review-code/review-report-format.md


### PR DESCRIPTION
The review-code skill orchestrator previously lacked instructions to
synthesize subagent findings into a single user-facing markdown
artifact, making it difficult to inspect audit reports in a structured
manner. Furthermore, reporting format and status guidelines were
duplicated across individual auditor prompts.

Update the review-code orchestrator to generate a unified
`code-review-results.md` artifact containing overall summaries and
per-category findings. Extract shared reporting format rules into a
reusable markdown fragment referenced by all reviewer prompts.