### PR TITLE
tests: use runfiles.CreateOrRaise in release_test_helper

### DIFF
--- a/tests/tools/private/release/release_test_helper.py
+++ b/tests/tools/private/release/release_test_helper.py
@@ -23,7 +23,7 @@ class ReleaseToolEnv:
 
 
 def _find_real_template_path() -> Path:
-    r = runfiles.Create()
+    r = runfiles.CreateOrRaise()
     path = r.Rlocation(
         "rules_python/.github/ISSUE_TEMPLATE/release_tracking_template.md"
     )


### PR DESCRIPTION
Using runfiles.Create() returns an optional Runfiles object, which
can lead to typing issues and runtime attribute errors if runfiles
cannot be created or located.

Switch to runfiles.CreateOrRaise() in _find_real_template_path to
ensure a non-None Runfiles instance is returned and fail fast if
runfiles are unavailable.