### PR TITLE
agents: clarify commit and PR type conventions in pr.md

### DIFF
--- a/.agents/rules/pr.md
+++ b/.agents/rules/pr.md
@@ -14,6 +14,10 @@ Before drafting any pull request description, strictly adhere to the rules in
 * Always include `@CONTRIBUTING.md` in rule definitions so that PR formatting
   rules are injected into context whenever PR workflows run.
 
+## Commit & PR Types
+* `fix:` / `feat:`: User-visible changes ONLY.
+* `tests:`: Test-only changes and test-helper fixes (never `fix:` or `fix(tests):`).
+
 ## PR Commit Workflow Invariant
 * Once a Pull Request is created, always make new commits or merge commits.
 * **NEVER** amend or rebase commits on an active PR branch to avoid breaking


### PR DESCRIPTION
Add explicit guidance in pr.md defining commit and pull request type
prefixes. Clarify that `fix:` and `feat:` are reserved exclusively for
user-visible changes, while `tests:` must be used for test-only changes
and test-helper fixes.