### PR TITLE
agents: add workflow type convention and python exception rules

### DIFF
--- a/.agents/rules/pr.md
+++ b/.agents/rules/pr.md
@@ -16,7 +16,10 @@ Before drafting any pull request description, strictly adhere to the rules in
 
 ## Commit & PR Types
 * `fix:` / `feat:`: User-visible changes ONLY.
-* `tests:`: Test-only changes and test-helper fixes (never `fix:` or `fix(tests):`).
+* `workflow:` / `workflows:`: Internal workflow automation, release tooling, and
+  CI scripts (e.g., `workflow(release): ...`).
+* `tests:`: Test-only changes and test-helper fixes (never `fix:` or
+  `fix(tests):`).
 
 ## PR Commit Workflow Invariant
 * Once a Pull Request is created, always make new commits or merge commits.

--- a/.agents/rules/python.md
+++ b/.agents/rules/python.md
@@ -9,6 +9,14 @@
 * Use direct attribute access (e.g. `args.foo`) on `argparse.Namespace` with
   well-defined shapes. Avoid defensive `getattr()`.
 
+## Exception Handling
+* Inherit custom exceptions from `Exception`, not `RuntimeError`.
+
+## Subprocess
+* Demarcate captured stdout/stderr in exceptions with 20 `=` characters:
+  `==================== STDOUT BEGIN ====================` /
+  `==================== STDOUT END ====================` (same for STDERR).
+
 ## TypedDict
 * **External Objects**: When defining a `TypedDict` for an external object,
   link to its definition in the docstring.
@@ -16,8 +24,9 @@
 ## Type Checking & Annotations
 * **`importlib.metadata` `PackagePath`**: `f.locate()` is typed as `PathLike`.
   Wrap with `pathlib.Path(f.locate())` to call `.exists()`, `.is_file()`, etc.
-* **In-file disables vs target skipping**: Prefer `# pyrefly: ignore[<error-code>]`
-  (e.g. `[missing-import]`) over `tags = ["no-pyrefly"]`.
+* **In-file disables vs target skipping**: Prefer
+  `# pyrefly: ignore[<error-code>]` (e.g. `[missing-import]`) over
+  `tags = ["no-pyrefly"]`.
 * **No blanket ignores**: NEVER use bare `# type: ignore` or literal
   `# type: ignore[...]`. Use error-specific ignores instead.
 * **Ignore comments**: When adding `# pyrefly: ignore[...]` or type


### PR DESCRIPTION
Add workflow:/workflows: PR and commit type convention to pr.md
for release automation and CI tooling.

Add Exception base class and subprocess error boundary demarcation rules
to python.md.