### PR TITLE
tests(runfiles): migrate runfiles tests to pytest_test

### DIFF
--- a/tests/runfiles/BUILD.bazel
+++ b/tests/runfiles/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@rules_python//python:py_test.bzl", "py_test")
 load("@rules_python//python/private:bzlmod_enabled.bzl", "BZLMOD_ENABLED")  # buildifier: disable=bzl-visibility
 load("//tests/support/pytest_test:pytest_test.bzl", "pytest_test")
 
@@ -14,7 +15,7 @@ pytest_test(
     deps = ["//python/runfiles"],
 )
 
-pytest_test(
+py_test(
     name = "runfiles_min_python_test",
     srcs = ["runfiles_test.py"],
     data = [
@@ -23,6 +24,7 @@ pytest_test(
     env = {
         "BZLMOD_ENABLED": "1" if BZLMOD_ENABLED else "0",
     },
+    main = "runfiles_test.py",
     python_version = "3.10",
     deps = ["//python/runfiles"],
 )
@@ -33,9 +35,10 @@ pytest_test(
     deps = ["//python/runfiles"],
 )
 
-pytest_test(
+py_test(
     name = "pathlib_min_python_test",
     srcs = ["pathlib_test.py"],
+    main = "pathlib_test.py",
     python_version = "3.10",
     deps = ["//python/runfiles"],
 )

--- a/tests/runfiles/BUILD.bazel
+++ b/tests/runfiles/BUILD.bazel
@@ -1,8 +1,8 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("@rules_python//python:py_test.bzl", "py_test")
 load("@rules_python//python/private:bzlmod_enabled.bzl", "BZLMOD_ENABLED")  # buildifier: disable=bzl-visibility
+load("//tests/support/pytest_test:pytest_test.bzl", "pytest_test")
 
-py_test(
+pytest_test(
     name = "runfiles_test",
     srcs = ["runfiles_test.py"],
     data = [
@@ -14,7 +14,7 @@ py_test(
     deps = ["//python/runfiles"],
 )
 
-py_test(
+pytest_test(
     name = "runfiles_min_python_test",
     srcs = ["runfiles_test.py"],
     data = [
@@ -23,21 +23,19 @@ py_test(
     env = {
         "BZLMOD_ENABLED": "1" if BZLMOD_ENABLED else "0",
     },
-    main = "runfiles_test.py",
     python_version = "3.10",
     deps = ["//python/runfiles"],
 )
 
-py_test(
+pytest_test(
     name = "pathlib_test",
     srcs = ["pathlib_test.py"],
     deps = ["//python/runfiles"],
 )
 
-py_test(
+pytest_test(
     name = "pathlib_min_python_test",
     srcs = ["pathlib_test.py"],
-    main = "pathlib_test.py",
     python_version = "3.10",
     deps = ["//python/runfiles"],
 )


### PR DESCRIPTION
Migrate the primary runfiles test targets to pytest_test to standardize
test execution and runner behavior across the test suite.

The main runfiles_test and pathlib_test targets are updated to use
pytest_test. However, the corresponding _min_python_test targets remain
standard py_test targets using standard library unittest. In WORKSPACE
mode, dev_pip dependencies only resolve for Python 3.11, so pytest is
unavailable when testing against Python 3.10; retaining py_test ensures
minimum Python version verification continues to work.