### PR TITLE
agents: refine commit type definitions and interface docstring rules

### DIFF
--- a/.agents/rules/pr.md
+++ b/.agents/rules/pr.md
@@ -16,8 +16,12 @@ Before drafting any pull request description, strictly adhere to the rules in
 
 ## Commit & PR Types
 * `fix:` / `feat:`: User-visible changes ONLY.
-* `workflow:` / `workflows:`: Internal workflow automation, release tooling, and
-  CI scripts (e.g., `workflow(release): ...`).
+* `build:` / `build(release):`: Internal release tooling, developer workflows,
+  and build scripts (prefer `build(release):` over `chore:` or `tools:`, since
+  `tools:` could be ambiguous with production tools).
+* `ci:`: `.bazelci` and Buildkite CI configurations.
+* `workflow:` / `workflows:`: GitHub Actions workflow configurations
+  (`.github/workflows/`).
 * `tests:`: Test-only changes and test-helper fixes (never `fix:` or
   `fix(tests):`).
 

--- a/.agents/rules/python.md
+++ b/.agents/rules/python.md
@@ -9,6 +9,10 @@
 * Use direct attribute access (e.g. `args.foo`) on `argparse.Namespace` with
   well-defined shapes. Avoid defensive `getattr()`.
 
+## Interface & ABC Docstrings
+* In abstract base class / interface methods, always document `Args:`,
+  `Returns:`, and all custom exceptions raised under `Raises:`.
+
 ## Exception Handling
 * Inherit custom exceptions from `Exception`, not `RuntimeError`.
 


### PR DESCRIPTION
Agent rules previously grouped build, release tooling, CI, and GitHub
Actions under a generic `workflow:` category, creating ambiguity for
conventional commit types. Furthermore, agent rules lacked explicit
guidance on documenting interface methods in abstract base classes.

Clarify commit type conventions for release/build tools (`build:`),
CI configurations (`ci:`), and GitHub Actions workflows (`workflow:`).
Additionally, require docstrings on abstract base classes to explicitly
document Args, Returns, and custom exceptions under Raises.