### PR TITLE
agents: update review-code skill to initialize and update artifact on responses

### DIFF
--- a/.agents/skills/review-code/SKILL.md
+++ b/.agents/skills/review-code/SKILL.md
@@ -53,13 +53,17 @@ file from `.agents/skills/review-code/`:
      formatting and PR update rules in `CONTRIBUTING.md`.
 
 ### Action Instructions
+- Immediately create a user-facing review artifact named
+  `code-review-results.md` in the conversation artifact directory so progress
+  is visible right away.
 - Launch all sub-agents concurrently using `invoke_subagent`.
-- Collect the reports from each sub-agent.
-- Create a user-facing review artifact named `code-review-results.md` in the
-  conversation artifact directory. The artifact must include:
+- Update `code-review-results.md` as sub-agent responses come in.
+- The artifact must include:
   - Overall summary and verdict across audit categories.
   - Detailed analysis and findings from each sub-agent.
   - Actionable findings and fix suggestions with specific code snippets, diffs,
     and clickable file links for any violations found.
-- In the response, provide a concise summary with the overall verdict and a
-  clickable markdown link to `code-review-results.md`.
+- Once all sub-agents finish, finalize `code-review-results.md` and provide a
+  concise summary with the overall verdict and a clickable markdown link to
+  `code-review-results.md` in the response.
+


### PR DESCRIPTION
Previously, the code review skill waited until all auditing subagents
finished before creating and populating the review artifact. For
large reviews or multi-agent audits, this caused significant delays
where users could not inspect findings or observe progress.

To improve responsiveness, the review-code skill now initializes the
`code-review-results.md` artifact immediately before launching
subagents and updates the artifact as individual subagent responses
arrive.