### PR TITLE
agents: document rf.root() path navigation and Runfiles.CreateOrRaise() in python rules

### DIFF
--- a/.agents/rules/python.md
+++ b/.agents/rules/python.md
@@ -47,8 +47,9 @@
 
 ## Runfiles
 * **Fail-fast creation**: Prefer `runfiles.CreateOrRaise()` over
-  `runfiles.Create()` followed by manual `assert` when initializing runfiles in
-  tests and runtime scripts.
+  `runfiles.Create()` + `assert`.
+* **Path navigation**: Prefer `rf.root() / "<repo>/<path>"` over `Rlocation()`;
+  use `.glob()` on `runfiles.Path` instead of multi-root fallback loops.
 
 ## Delegating Functions
 * Module-level functions delegating to class methods should have a docstring


### PR DESCRIPTION
When interacting with Bazel runfiles in Python tests and runtime helpers, using structured path navigation and globbing provides a cleaner, less error-prone interface than manual path manipulation or multi-root fallback loops.

Update .agents/rules/python.md to document the preference for `rf.root() / "<repo>/<path>"` over `Rlocation()` and using `.glob()` on `runfiles.Path`. Refine fail-fast creation guidance to prefer `runfiles.CreateOrRaise()` over `runfiles.Create()` with assertions.