### PR TITLE
agents: document direct integration test execution in testing rules

### DIFF
--- a/.agents/rules/testing.md
+++ b/.agents/rules/testing.md
@@ -4,6 +4,13 @@
 * Always pass `--config=fast-tests` when running or building test targets to
   avoid running expensive, flaky integration tests.
 
+## Running Integration Tests Directly
+* Integration tests under `tests/integration/` are tagged
+  `["integration-test", "enormous"]` and are filtered out by
+  `--config=fast-tests`.
+* To run a specific integration test target directly, omit
+  `--config=fast-tests`: `bazel test //tests/integration:<target>`.
+
 ## CRITICAL: Never use `--config=fast-tests` on Non-Test Targets
 * `--config=fast-tests` sets `--build_tests_only=true`, which silently ignores
   non-test targets (such as `//docs:docs` or package libraries), resulting in 0


### PR DESCRIPTION
Integration tests under `tests/integration/` are filtered out by
the default `--config=fast-tests` configuration because they are
tagged with `integration-test` and `enormous`. When full integration
behavior needs to be verified, agents and developers must run them
directly without the fast-tests configuration flag.

Document how integration tests are tagged and outline the command to
invoke specific integration test targets directly without
`--config=fast-tests`.