### PR TITLE
chore: cherry-pick 2.3.2 changelog prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,21 @@ Unreleased changes are tracked as individual files in the [news/](./news)
 directory, or view the [latest generated
 changelog](https://rules-python.readthedocs.io/en/latest/changelog.html).
 
+{#v2-3-2}
+## [2.3.2] - 2026-08-22
+
+[2.3.2]: https://github.com/bazel-contrib/rules_python/releases/tag/2.3.2
+
+{#v2-3-2-fixed}
+### Fixed
+* (pypi) Fixed analysis failures in {obj}`pip.parse` for source-less wheels with
+  dependencies. ([#4053](https://github.com/bazel-contrib/rules_python/issues/4053))
+* (pypi) Fixed the handling of optional args for the {obj}`pip_archive` and {obj}`whl_archive`
+  repository rules within the {obj}`whl_library`. From now on we are dropping unsupported args.
+* (pypi) Fixed {obj}`pip.parse` repository names for Git sources in `uv.lock`
+  files by excluding URL query and fragment components
+  ([#4084](https://github.com/bazel-contrib/rules_python/issues/4084)).
+
 {#v2-3-1}
 ## [2.3.1] - 2026-08-14
 

--- a/news/4054.fixed.md
+++ b/news/4054.fixed.md
@@ -1,3 +1,0 @@
-(pypi) Fixed analysis failures in {obj}`pip.parse` for source-less wheels with
-dependencies.
-([#4053](https://github.com/bazel-contrib/rules_python/issues/4053))

--- a/news/4077.fixed.md
+++ b/news/4077.fixed.md
@@ -1,2 +1,0 @@
-(pypi) Fixed the handling of optional args for the {obj}`pip_archive` and {obj}`whl_archive`
-repository rules within the {obj}`whl_library`. From now on we are dropping unsupported args.

--- a/news/4084.fixed.md
+++ b/news/4084.fixed.md
@@ -1,3 +1,0 @@
-(pypi) Fixed {obj}`pip.parse` repository names for Git sources in `uv.lock`
-files by excluding URL query and fragment components
-([#4084](https://github.com/bazel-contrib/rules_python/issues/4084)).

--- a/python/private/py_library.bzl
+++ b/python/private/py_library.bzl
@@ -330,7 +330,7 @@ def create_py_library_rule_builder():
     srcs_attr.set_allow_files(True)
     srcs_attr.set_doc(srcs_attr.doc() + """
 
-:::{versionchanged} VERSION_NEXT_FEATURE
+:::{versionchanged} 2.3.2
 As an exception, empty targets in `srcs` that provide {obj}`PyInfo` are
 allowed. Ordinary library dependencies should remain in `deps`.
 :::


### PR DESCRIPTION
Summary:
- doc: changelog entries for 2.3.2
- chore: fix version numbers

Work towards #4088
