### PR TITLE
agents: document Windows extended path rules and test organization

### DIFF
--- a/.agents/rules/testing.md
+++ b/.agents/rules/testing.md
@@ -29,3 +29,11 @@
 ## Documentation Flake Handling
 * When building `//docs:docs` fails with exit code 2, treat it as a known
   Sphinx/Bazel flake and retry the build.
+
+## Test Organization
+* **Domain Placement**: Place tests by the feature tested (e.g.,
+  `tests/bootstrap_impls/`), not by the fixture helper used (e.g.,
+  `py_extension`).
+* **Platform Constraints**: Restrict OS-specific targets with
+  `target_compatible_with` (e.g., `["@platforms//os:windows"]`) to skip on
+  incompatible platforms.

--- a/.agents/rules/windows.md
+++ b/.agents/rules/windows.md
@@ -30,3 +30,12 @@
   `foo.cp311-win_amd64.pyd`).
 * SOABI on Windows includes both the ABI prefix and platform tag (e.g.,
   `cp311-win_amd64`).
+
+## Extended Paths (`\\?\`)
+* **Test Path Lengths**: Keep source directories short so MSVC `cl.exe` params
+  files stay under 260 chars (`MAX_PATH`, avoids `D8022`). Rely on runfiles
+  expansion (`.exe.runfiles/_main/...`) to exceed `MAX_PATH` at runtime.
+* **No `..` Segments**: Win32 ignores `..` on `\\?\` paths. Always call
+  `os.path.normpath(...)` before accessing files (e.g., wheel `RECORD` paths).
+* **Comparing Executables**: Subprocesses may drop `\\?\` or `\\?\UNC\` prefixes.
+  Strip prefixes and compare via `os.path.normcase(os.path.normpath(...))`.

--- a/.agents/rules/windows.md
+++ b/.agents/rules/windows.md
@@ -37,5 +37,6 @@
   expansion (`.exe.runfiles/_main/...`) to exceed `MAX_PATH` at runtime.
 * **No `..` Segments**: Win32 ignores `..` on `\\?\` paths. Always call
   `os.path.normpath(...)` before accessing files (e.g., wheel `RECORD` paths).
-* **Comparing Executables**: Subprocesses may drop `\\?\` or `\\?\UNC\` prefixes.
-  Strip prefixes and compare via `os.path.normcase(os.path.normpath(...))`.
+* **Comparing Executables**: Subprocesses may drop `\\?\` or `\\?\UNC\`
+  prefixes. Strip prefixes and compare via
+  `os.path.normcase(os.path.normpath(...))`.


### PR DESCRIPTION
During Windows test and bootstrap development, long path resolution
and platform constraints can introduce subtle failures, such as Win32
APIs ignoring relative traversal on extended-length paths or MSVC
compiler limitations when source directories exceed standard limits.

To prevent these pitfalls in future agent-assisted workflows, this
change codifies guidelines for handling Windows extended-length paths
and establishes conventions for test suite organization and platform
constraints. Specifically, it documents strategies for keeping source
directories concise, normalizing paths prior to file access or
comparisons, organizing tests by feature domain, and applying
appropriate platform compatibility restrictions.