### PR TITLE
agents: specify docs and build(release) commit types

### DIFF
--- a/.agents/rules/pr.md
+++ b/.agents/rules/pr.md
@@ -16,9 +16,10 @@ Before drafting any pull request description, strictly adhere to the rules in
 
 ## Commit & PR Types
 * `fix:` / `feat:`: User-visible changes ONLY.
-* `build:` / `build(release):`: Internal release tooling, developer workflows,
-  and build scripts (prefer `build(release):` over `chore:` or `tools:`, since
-  `tools:` could be ambiguous with production tools).
+* `build:` / `build(release):`: Internal release tooling
+  (`tools/private/release/`), developer workflows, and build scripts. Always
+  prefer `build(release):` over `chore:` or `chore(release):`.
+* `docs:`: Documentation and issue templates (`.github/ISSUE_TEMPLATE/`).
 * `ci:`: `.bazelci` and Buildkite CI configurations.
 * `workflow:` / `workflows:`: GitHub Actions workflow configurations
   (`.github/workflows/`).


### PR DESCRIPTION
Ambiguity in commit type selection can cause issue templates or release scripts to be mislabeled under generic types like chore.

Updates the agent pull request rules to specify that issue template changes use docs: and release tooling uses build(release):.