### PR TITLE
agents: add constraint synchronization rule for dependency bumps

### DIFF
--- a/.agents/rules/lockfiles.md
+++ b/.agents/rules/lockfiles.md
@@ -1,7 +1,12 @@
 ---
 trigger: glob
 description: Rules for updating uv.lock and requirements.txt files
-globs: "*requirements*.txt,*requirements*.in,uv.lock,pyproject.toml"
+globs:
+  - "*requirements*.txt"
+  - "*requirements*.in"
+  - "uv.lock"
+  - "pyproject.toml"
+  - "*constraints*.txt"
 ---
 
 # Lockfile & Dependency Rules
@@ -25,3 +30,5 @@ When dependencies bump, manually synchronize:
   entries in `examples/bzlmod/patches/*.patch`.
 * **Test Assertions**: Update hardcoded versions and `dist-info` file lists in
   tests (`pip_whl_mods_test.py`, `pip_parse/test.py`, `pip_parse_test.py`).
+* **Constraints**: Update conflicting pins in `*constraints*.txt` and rerun
+  affected `.update` targets.


### PR DESCRIPTION
When dependencies are bumped, hardcoded version pins in constraint
files can conflict with newly resolved requirements and cause lockfile
update targets to fail.

To prevent these conflicts, expand the lockfile and dependency agent
rules to trigger on constraint files and instruct agents to update any
conflicting constraint pins and rerun affected update targets during
dependency updates.