### PR TITLE
agents: add external PR push guidance, refactor commit type, and fix news frontmatter

### DIFF
--- a/.agents/rules/news.md
+++ b/.agents/rules/news.md
@@ -1,14 +1,15 @@
 ---
-trigger: news/*.md
+trigger: glob
 description: Apply when drafting news entries.
+globs: "news/*.md"
 ---
 
 @CONTRIBUTING.md
 
 # News Entry Conventions
 
-Before drafting any news entry, strictly adhere to the rules in `CONTRIBUTING.md`
-above.
+Before drafting any news entry, adhere strictly to the rules in
+`CONTRIBUTING.md` above.
 
 ## Sphinx MyST Cross-Reference Syntax (`{obj}`)
 * Use `{obj}\`<symbol>\`` in news entries for rules, macros, targets, providers,
@@ -17,4 +18,9 @@ above.
 
 ## GitHub Issue Link Formatting
 * Append GitHub issue cross-references at the end of news entries in markdown
-  link format: `([#3283](https://github.com/bazel-contrib/rules_python/issues/3283))`.
+  link format:
+  `([#3283](https://github.com/bazel-contrib/rules_python/issues/3283))`.
+
+## Unreleased and Internal Changes
+* Do not add news entries for internal refactoring or fixes to unreleased code.
+  News entries are only for released, user-visible behavior.

--- a/.agents/rules/pr.md
+++ b/.agents/rules/pr.md
@@ -27,6 +27,8 @@ Before drafting any pull request description, strictly adhere to the rules in
   `fix(tests):`).
 * `agents:` / `agents(<scope>):`: Agent rules, skills, and prompts
   (`.agents/`).
+* `refactor:`: Internal refactoring and fixes for unreleased changes. Never use
+  `fix:` or `feat:` unless modifying released, user-visible behavior.
 
 ## PR Commit Workflow Invariant
 * Once a Pull Request is created, always make new commits or merge commits.

--- a/.agents/rules/workspace.md
+++ b/.agents/rules/workspace.md
@@ -17,4 +17,7 @@ basis:
   .agents/scripts/setup_triangle_branch.sh <branch>
   ```
 * Never use `git push -u` or `--set-upstream` (it breaks upstream tracking).
+* When pushing to a checked-out PR branch from an external fork, push
+  explicitly to that remote (`git push <remote> HEAD:<branch>`). Do not rely on
+  a bare `git push`.
 


### PR DESCRIPTION
Improve agent guidance and rule syntax consistency when working with
external PR branches, internal refactoring changes, and news file glob
matching.

- Add explicit push instructions for checked-out external PR branches to
  prevent accidental pushes to upstream or default remotes.
- Document the `refactor:` commit and PR type for unreleased changes and
  internal refactorings to keep commit logs accurate.
- Correct the news rule frontmatter syntax to use glob triggering and
  clarify that news entries should be omitted for unreleased code.