### PR TITLE
agents: add VERSION_NEXT_PATCH docs rule and Strunk & White PR guidelines

### DIFF
--- a/.agents/rules/docs.md
+++ b/.agents/rules/docs.md
@@ -11,5 +11,8 @@ globs: docs/*.md
 * Use hyphens (`-`) in file names instead of underscores (`_`).
 * In Sphinx MyST markup, outer directives must have more colons than inner directives.
 * When adding `{versionadded}` or `{versionchanged}` sections, add them at the end of the documentation text.
-* For unreleased features or attributes, use `VERSION_NEXT_FEATURE` in `{versionadded}` / `{versionchanged}` directives.
+* For unreleased features or attributes, use `VERSION_NEXT_FEATURE` in
+  `{versionadded}` / `{versionchanged}` directives. For bug fixes or patch-level
+  behavioral adjustments, use `VERSION_NEXT_PATCH` in `{versionchanged}`
+  directives.
 * **Documentation Build Correctness**: Ensure new `.bzl` files or user-facing APIs are properly registered in documentation build targets (e.g. `//docs:docs` or relevant Starlark API reference generation configs).

--- a/.agents/rules/pr.md
+++ b/.agents/rules/pr.md
@@ -38,3 +38,5 @@ Before drafting any pull request description, strictly adhere to the rules in
   individual file modifications in PR descriptions or commit messages.
 * High-level overview only: state *why* the change is made and *how* at a
   conceptual level. Link related issues (e.g. `Work towards #<issue>`).
+* **Conciseness & Style (Strunk & White)**: Omit needless words. Use clear,
+  active, and direct phrasing for *why* and *how*.

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -19,7 +19,7 @@ to a subagent. NEVER create or draft PRs directly in the main conversation.
    - **PR Title**: Conventional commits format (`agents:` prefix for agent
      rules/skills).
    - **PR Body**: Explain *why* and conceptual *how*. Wrap strictly at 72
-     columns max. Omit TAG/CONV.
+     columns max. Use concise, active phrasing (Strunk & White).
    - **Artifact Requirements**: Create `pr_info.md` with:
      - **User-facing**: Published directly in the user interface.
      - **Interactive feedback enabled**: Allows selecting lines and leaving


### PR DESCRIPTION
Agent guidelines lacked explicit instructions for versioning bug fixes
in documentation and allowed verbose, passive pull request descriptions.

Document using `VERSION_NEXT_PATCH` for bug fixes and patch-level
behavioral adjustments in `{versionchanged}` directives. Direct agents
to apply Strunk & White conciseness and active phrasing when authoring
PR descriptions.