### PR TITLE
agents: add Windows shebang RECORD rewriting and PR metadata discrepancy rules

### DIFF
--- a/.agents/rules/pr.md
+++ b/.agents/rules/pr.md
@@ -34,6 +34,9 @@ Before drafting any pull request description, strictly adhere to the rules in
 * Once a Pull Request is created, always make new commits or merge commits.
 * **NEVER** amend or rebase commits on an active PR branch to avoid breaking
   code review threads.
+* **PR Metadata Discrepancies**: If a PR title or description diverges from
+  the branch's actual scope, notify the user of the discrepancy and ask for
+  confirmation before updating GitHub.
 * **NEVER** include a list of per-file edits or changelog bullet points of
   individual file modifications in PR descriptions or commit messages.
 * High-level overview only: state *why* the change is made and *how* at a

--- a/.agents/rules/windows.md
+++ b/.agents/rules/windows.md
@@ -40,3 +40,10 @@
 * **Comparing Executables**: Subprocesses may drop `\\?\` or `\\?\UNC\`
   prefixes. Strip prefixes and compare via
   `os.path.normcase(os.path.normpath(...))`.
+
+## Windows Wheel Script Rewriting & RECORD Generation
+* **Shebang Rewriting**: On Windows, scripts that use shebangs are rewritten into
+  wrapper scripts with `.bat` file extensions.
+* **RECORD File Paths**: In `RECORD` files, append `.bat` only to the
+  shebang-rewritten scripts. Leave all other script paths unchanged.
+


### PR DESCRIPTION
Document agent workflow rules for Windows wheel installation and PR
metadata management.

Agents need explicit guidance when rewriting Windows wheel scripts to
avoid misidentifying wrapper scripts in RECORD files, and must not
silently alter PR metadata without user confirmation.

Specify that Windows shebang scripts are rewritten as .bat wrapper
scripts and only those scripts receive .bat extensions in RECORD files.
Require agents to notify users and seek confirmation before updating
divergent PR metadata on GitHub.