### PR TITLE
fix(zipapp): guard against null runtime files

### DIFF
--- a/news/py_zipapp_runtime_files.fixed.md
+++ b/news/py_zipapp_runtime_files.fixed.md
@@ -1,0 +1,2 @@
+(zipapp) Fixed handling of {obj}`PyRuntimeInfo` with `files = None` so creating
+zipapp archives does not error.

--- a/python/private/zipapp/py_zipapp_rule.bzl
+++ b/python/private/zipapp/py_zipapp_rule.bzl
@@ -133,7 +133,8 @@ def _create_zip(ctx, py_runtime, py_executable, stage2_bootstrap):
 
     runfiles = builders.RunfilesBuilder()
 
-    runfiles.add(py_runtime.files)
+    if py_runtime.files != None:
+        runfiles.add(py_runtime.files)
     if py_executable.venv_python_exe:
         runfiles.add(py_executable.venv_python_exe)
 


### PR DESCRIPTION
When building a zipapp archive with a Python runtime whose \`files\`
attribute is \`None\` (such as a system interpreter), adding
\`py_runtime.files\` to the runfiles builder raises an error.

Only add \`py_runtime.files\` to the runfiles builder when it is not
\`None\`.