### PR TITLE
refactor(config_settings): remove unused private distribution target

### DIFF
--- a/python/config_settings/BUILD.bazel
+++ b/python/config_settings/BUILD.bazel
@@ -26,9 +26,7 @@ load(":config_settings.bzl", "construct_config_settings")
 
 filegroup(
     name = "distribution",
-    srcs = glob(["**"]) + [
-        "//python/config_settings/private:distribution",
-    ],
+    srcs = glob(["**"]),
     visibility = ["//python:__pkg__"],
 )
 

--- a/python/config_settings/private/BUILD.bazel
+++ b/python/config_settings/private/BUILD.bazel
@@ -1,5 +1,0 @@
-filegroup(
-    name = "distribution",
-    srcs = glob(["**"]),
-    visibility = ["//python/config_settings:__pkg__"],
-)


### PR DESCRIPTION
The `python/config_settings/private` package contains no source files,
leaving its `:distribution` target empty and obsolete. Including it
in `//python/config_settings:distribution` adds redundant build graph
structure.

Delete the unused private `BUILD.bazel` file and remove the dependency
from `//python/config_settings:distribution`.