### PR TITLE
agents: remove _bzl suffix requirement for bzl_library targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,25 +120,23 @@ The `repository_ctx` API docs are at: https://bazel.build/rules/lib/builtins/rep
 
 * A `bzl_library` target should be defined for every `.bzl` file outside
   of the `tests/` directory.
-* They should have a single `srcs` file and be named after the file with `_bzl`
-  appended.
+* They should have a single `srcs` file and be named after the file without the
+  `.bzl` extension.
 * Their deps should be based on the `load()` statements in the source file
-  and refer to the `bzl_library` target containing the loaded file.
-  * For files in rules_python: replace `.bzl` with `_bzl`.
-    e.g. given `load("//foo:bar.bzl", ...)`, the target is `//foo:bar_bzl`.
-  * For files outside rules_python: remove the `.bzl` suffix. e.g. given
-    `load("@foo//foo:bar.bzl", ...)`, the target is `@foo//foo:bar`.
+  and refer to the `bzl_library` target containing the loaded file (remove the
+  `.bzl` suffix; e.g. `load("//foo:bar.bzl", ...)` becomes `//foo:bar`, and
+  `load("@foo//foo:bar.bzl", ...)` becomes `@foo//foo:bar`).
 
 Example:
 
 ```
 bzl_library(
-    name = "alpha_bzl",
+    name = "alpha",
     srcs = ["alpha.bzl"],
-    deps = [":beta_bzl"],
+    deps = [":beta"],
 )
 bzl_library(
-    name = "beta_bzl",
+    name = "beta",
     srcs = ["beta.bzl"]
 )
 ```


### PR DESCRIPTION
Guidance previously instructed agents to append `_bzl` to bzl_library
targets within rules_python, diverging from external target naming
conventions and creating unnecessary naming discrepancies.

Update bzl_library guidance and examples in AGENTS.md to consistently
drop the `.bzl` extension rather than appending `_bzl`.