### PR TITLE
agents: update news and PR conventions

### DIFF
--- a/.agents/rules/news.md
+++ b/.agents/rules/news.md
@@ -12,9 +12,13 @@ Before drafting any news entry, adhere strictly to the rules in
 `CONTRIBUTING.md` above.
 
 ## Sphinx MyST Cross-Reference Syntax (`{obj}`)
-* Use `{obj}\`<symbol>\`` in news entries for rules, macros, targets, providers,
-  attributes, args, and any other cross-referencable Starlark or Python
-  objects.
+* Use `{obj}\`<symbol>\`` only for cross-referencable Starlark or Python API
+  symbols (rules, macros, targets, providers, attributes, args).
+* Never use `{obj}` on metadata files (e.g. `RECORD`), file paths, or tools.
+
+## Content
+* State user-visible behavior and outcomes (what now works, what changed).
+* Omit internal implementation and refactoring details.
 
 ## GitHub Issue Link Formatting
 * Append GitHub issue cross-references at the end of news entries in markdown

--- a/.agents/rules/pr.md
+++ b/.agents/rules/pr.md
@@ -43,3 +43,5 @@ Before drafting any pull request description, strictly adhere to the rules in
   conceptual level. Link related issues (e.g. `Work towards #<issue>`).
 * **Conciseness & Style (Strunk & White)**: Omit needless words. Use clear,
   active, and direct phrasing for *why* and *how*.
+* **Preserve Existing Descriptions**: Preserve the author's wording unless
+  instructed to change it. Wrap bodies at 72 columns.


### PR DESCRIPTION
Update agent rules based on recent review feedback.

- Refine `.agents/rules/news.md` to mandate focusing on user-visible
  outcomes and restrict `{obj}` to documented API symbols.
- Update `.agents/rules/pr.md` to preserve author wording and wrap PR
  description bodies at 72 columns.