### PR TITLE
build(dev): remove unused requirements update aliases

### DIFF
--- a/dev/BUILD.bazel
+++ b/dev/BUILD.bazel
@@ -58,21 +58,3 @@ multirun(
     tags = ["manual"],
     visibility = ["//:__subpackages__"],
 )
-
-alias(
-    name = "requirements_all.update",
-    actual = ":all_requirements.update",
-    tags = ["manual"],
-    visibility = ["//:__subpackages__"],
-)
-
-# NOTE: The requirements for the pip dependencies may sometimes break the build
-# process due to how `pip-compile` works (i.e. it sometimes needs to build
-# wheels to resolve the `pyproject.toml` file.  Hence we do not lump the
-# target with the other targets above.
-alias(
-    name = "whl_library_requirements.update",
-    actual = "//tools/private/update_deps:update_pip_deps",
-    tags = ["manual"],
-    visibility = ["//:__subpackages__"],
-)

--- a/docs/devguide.md
+++ b/docs/devguide.md
@@ -95,7 +95,7 @@ integration test.
 
 1. Modify the `./python/private/pypi/requirements.txt` file and run:
    ```
-   bazel run //dev:whl_library_requirements.update
+   bazel run //tools/private/update_deps:update_pip_deps
    ```
 1. Run the following target to update `twine` dependencies:
    ```


### PR DESCRIPTION
Remove requirements_all.update and whl_library_requirements.update
aliases from //dev. Reference update_pip_deps directly in devguide.

Work towards #4128