### PR TITLE
docs(release): document sync-changelog command in template and guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_tracking_template.md
+++ b/.github/ISSUE_TEMPLATE/release_tracking_template.md
@@ -36,6 +36,7 @@ Comment commands:
 - `/create-release-branch`: Cuts and pushes the release branch.
 - `/create-rc`: Tags and publishes a new release candidate (RC).
 - `/process-backports`: Cherry-picks pending backports.
+- `/sync-changelog`: Processes sync changelog tasks.
 - `/backport <PRs>`: Adds PRs to the backports and processes backports.
 - `/promote`: Promotes the latest RC to final release.
  

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -193,6 +193,11 @@ If a backport fails to process (e.g., due to cherry-pick conflicts):
     cherry-pick the PR, resolve conflicts, push to remote, and manually check
     the box on the tracking issue checklist with `status=done` metadata.
 
+If changelog syncing fails (or if you need to retrigger syncing to `main`):
+*   Comment `/sync-changelog` on the release tracking issue.
+*   Or trigger the `release_sync_changelog.yaml` workflow manually with the
+    issue number.
+
 ## Automated patch releases to multiple versions
 
 If you need to backport a PR to multiple older active release branches (e.g.,
@@ -316,6 +321,8 @@ The checklist items use metadata suffix: `| key=value key2=value2`.
     issue (or on the preparation PR) to mark the preparation task as done.
 *   **Create Release Branch**: Comment `/create-release-branch` on the tracking
     issue to cut and push the release branch.
+*   **Retry Changelog Sync**: Comment `/sync-changelog` on the tracking issue to
+    retrigger creating the sync PR to `main` for backports.
 *   **Force Task Done**: Check the box `- [x]` and add appropriate metadata (e.g. `status=done`).
 
 ## Secrets


### PR DESCRIPTION
The /sync-changelog command was added to on_comment and the release
tool CLI, but was omitted from the release tracking issue template and
troubleshooting documentation.

Add /sync-changelog to the Available Commands section of the release
tracking issue template, and document how to retry changelog syncing in
RELEASING.md.